### PR TITLE
fix: fix user management after server refactor

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -46,7 +46,7 @@
     "no-console": ["error", { "allow": ["warn", "error"] }],
     "no-param-reassign": [
       "error",
-      { "props": true, "ignorePropertyModificationsFor": ["sliceState"] }
+      { "props": true, "ignorePropertyModificationsFor": ["sliceState", "immerState"] }
     ],
     "prefer-object-spread": "off",
     "prefer-promise-reject-errors": "off",

--- a/src/components/Layout/TopNav.tsx
+++ b/src/components/Layout/TopNav.tsx
@@ -143,8 +143,8 @@ function TopNav() {
             <div className="flex items-center gap-x-2">
               <div className="flex items-center justify-center bg-highlight-1/75 hover:bg-highlight-1 w-8 h-8 text-xl rounded-full mr-1">
                 {
-                  currentUser.data?.Avatar.RelativeFilepath
-                    ? (<img src={`/api/v3/Image/User/Avatar/${currentUser.data?.Avatar.ID}?requestId=${currentUser.requestId}`} alt="avatar" className="w-8 h-8 rounded-full" />)
+                  currentUser.data?.Avatar
+                    ? (<img src={currentUser.data?.Avatar} alt="avatar" className="w-8 h-8 rounded-full" />)
                     : currentUser.data?.Username.charAt(0)
                 }
               </div>

--- a/src/core/middlewares/rtkQueryError.ts
+++ b/src/core/middlewares/rtkQueryError.ts
@@ -1,8 +1,14 @@
 import type { Middleware, MiddlewareAPI } from '@reduxjs/toolkit';
 import { isRejectedWithValue } from '@reduxjs/toolkit';
+import { forEach } from 'lodash';
 
 import toast from '@/components/Toast';
 import Events from '../events';
+
+type ProblemDetails = { title: string; status: number; type: string; errors: Record<string, string[]>; traceId: string; };
+
+const isErrorObject = (target: any): target is ProblemDetails =>
+  typeof target === 'object' && target !== null && typeof target.title === 'string' && typeof target.errors === 'object' && target.errors !== null;
 
 const rtkQueryErrorLogger: Middleware = (_api: MiddlewareAPI) => dispatch => (action) => {
   if (isRejectedWithValue(action)) {
@@ -11,7 +17,20 @@ const rtkQueryErrorLogger: Middleware = (_api: MiddlewareAPI) => dispatch => (ac
       if (window.location.pathname !== '/webui/login') dispatch({ type: Events.STORE_CLEAR_STATE });
       toast.error('Unauthorized!', '', { toastId: 'unauthorized' });
     } else if (action.payload.originalStatus !== 503 && action.meta.arg.endpointName !== 'getRandomMetadata') {
-      toast.error(action.payload?.data?.title ?? action.payload.error ?? `${action.payload.status} - ${action.error.message}`, `Debug Info: ${action.meta.arg.endpointName}`);
+      const { data } = action.payload;
+      const endpointName = action.meta.arg.endpointName as string;
+      const method = action.meta.baseQueryMeta.request.method as string;
+      const url = new URL(action.meta.baseQueryMeta.request.url as string);
+      const endpoint = `${method} ${url.pathname + url.search}`;
+      if (isErrorObject(data)) {
+        if (data.title === 'One or more validation errors occurred.') {
+          forEach(Object.entries(data.errors), ([key, messageList]) =>
+            forEach(messageList, message =>
+              toast.error(message, `Error for key "${key}" during \`${endpoint}\` (${endpointName})`)));
+        }
+      } else {
+        toast.error(action.payload.error ?? `${action.payload.status} - ${action.error.message}`, `Error occured during \`${endpoint}\` (${endpointName})`);
+      }
     }
   }
 

--- a/src/core/rtkQuery/splitV3Api/userApi.ts
+++ b/src/core/rtkQuery/splitV3Api/userApi.ts
@@ -58,6 +58,15 @@ const userApi = splitV3Api.injectEndpoints({
       invalidatesTags: ['Users'],
     }),
 
+    // Remove the user.
+    deleteUser: build.mutation<void, number>({
+      query: userId => ({
+        url: `User/${userId}`,
+        method: 'DELETE',
+      }),
+      invalidatesTags: ['Users'],
+    }),
+
     // Change the password for the current user or a user by id.
     postChangePassword: build.mutation<void, { Password: string; RevokeAPIKeys: boolean; ID?: number; }>({
       query: ({ ID, ...body }) => ({
@@ -83,6 +92,7 @@ export const {
   useGetUsersQuery,
   usePostUserMutation,
   usePutUserMutation,
+  useDeleteUserMutation,
   usePostChangePasswordMutation,
   useGetCurrentUserQuery,
 } = userApi;

--- a/src/core/rtkQuery/splitV3Api/userApi.ts
+++ b/src/core/rtkQuery/splitV3Api/userApi.ts
@@ -16,7 +16,7 @@ const simplifyCommunitySites = (sites: Array<string>) => {
 
 const userApi = splitV3Api.injectEndpoints({
   endpoints: build => ({
-    // List all Users. Admin only
+    // List all users.
     getUsers: build.query<Array<UserType>, void>({
       query: () => ({ url: 'User' }),
       transformResponse: (response: Array<ApiUserType>) => {
@@ -30,54 +30,44 @@ const userApi = splitV3Api.injectEndpoints({
       providesTags: ['Users'],
     }),
 
-    // Edit User. This replaces all values, except Plex and Password.
-    putUser: build.mutation<void, UserType>({
+    // Add a new user.
+    postUser: build.mutation<UserType, Omit<UserType, 'ID'>>({
       query: ({ CommunitySites, ...user }) => ({
         url: 'User',
-        method: 'PUT',
-        body: { ...user, CommunitySites: map(pickBy(CommunitySites, identity), (_, key) => key) },
+        method: 'POST',
+        body: { ...user, CommunitySites: CommunitySites ? map(pickBy(CommunitySites, identity), (_, key) => key) : null } as ApiUserType,
       }),
+      transformResponse: (user: ApiUserType) => {
+        const { CommunitySites, ...tempUser } = user;
+        return { ...tempUser, CommunitySites: simplifyCommunitySites(CommunitySites) };
+      },
       invalidatesTags: ['Users'],
     }),
 
-    // Change the password for a user
-    postChangePassword: build.mutation<void, { Password: string, RevokeAPIKeys: boolean, userId: number, admin: boolean }>({
-      query: ({ admin, userId, ...body }) => ({
-        url: `User/${admin ? userId.toString() : 'Current'}/ChangePassword`,
+    // Edit the current user or a user by id using a raw object to do a partial update.
+    putUser: build.mutation<UserType, UserType>({
+      query: ({ ID, CommunitySites, Password: __, ...user }) => ({
+        url: `User/${ID}`,
+        method: 'PUT',
+        body: { ...user, CommunitySites: CommunitySites ? map(pickBy(CommunitySites, identity), (_, key) => key) : null } as ApiUserType,
+      }),
+      transformResponse: (user: ApiUserType) => {
+        const { CommunitySites, ...tempUser } = user;
+        return { ...tempUser, CommunitySites: simplifyCommunitySites(CommunitySites) };
+      },
+      invalidatesTags: ['Users'],
+    }),
+
+    // Change the password for the current user or a user by id.
+    postChangePassword: build.mutation<void, { Password: string; RevokeAPIKeys: boolean; ID?: number; }>({
+      query: ({ ID, ...body }) => ({
+        url: `User/${ID || 'Current'}/ChangePassword`,
         body,
         method: 'POST',
       }),
     }),
 
-    // Change the user avatar for a user
-    postUserChangeAvatar: build.mutation<void, { avatar: File, userId: number }>({
-      query: ({ avatar, userId }) => {
-        const formData = new FormData();
-        formData.append('image', avatar);
-
-        return {
-          url: `User/${userId}/ChangeAvatar`,
-          method: 'POST',
-          body: formData,
-          prepareHeaders: (headers) => {
-            headers.set('Content-Type', 'multipart/form-data');
-            return headers;
-          },
-        };
-      },
-      invalidatesTags: ['Users'],
-    }),
-
-    // Remove the user avatar for a user
-    deleteUserAvatar: build.mutation<void, number>({
-      query: userId => ({
-        url: `User/${userId}/ChangeAvatar`,
-        method: 'DELETE',
-      }),
-      invalidatesTags: ['Users'],
-    }),
-
-    // Get the current Shoko.Server.API.v3.Models.Shoko.User
+    // Get the current user.
     getCurrentUser: build.query<UserType, void>({
       query: () => ({ url: 'User/Current' }),
       transformResponse: (response: ApiUserType) => {
@@ -91,9 +81,8 @@ const userApi = splitV3Api.injectEndpoints({
 
 export const {
   useGetUsersQuery,
+  usePostUserMutation,
   usePutUserMutation,
   usePostChangePasswordMutation,
-  usePostUserChangeAvatarMutation,
-  useDeleteUserAvatarMutation,
   useGetCurrentUserQuery,
 } = userApi;

--- a/src/core/types/api/user.ts
+++ b/src/core/types/api/user.ts
@@ -3,10 +3,8 @@ type BaseUserType = {
   Username: string;
   IsAdmin: boolean;
   RestrictedTags: Array<number>;
-  Avatar: {
-    RelativeFilepath: string;
-    ID: number;
-  };
+  Avatar: string;
+  Password?: string;
 };
 
 export type CommunitySitesType = {

--- a/src/pages/settings/tabs/UserManagementSettings.tsx
+++ b/src/pages/settings/tabs/UserManagementSettings.tsx
@@ -17,6 +17,7 @@ import type { UserType } from '@/core/types/api/user';
 import {
   useGetUsersQuery, usePutUserMutation,
   usePostChangePasswordMutation, useGetCurrentUserQuery,
+  useDeleteUserMutation,
 } from '@/core/rtkQuery/splitV3Api/userApi';
 import {
   useGetPlexAuthenticatedQuery,
@@ -53,6 +54,7 @@ function UserManagementSettings() {
   const usersQuery = useGetUsersQuery();
   const users = useMemo(() => usersQuery.data ?? [], [usersQuery]);
   const [editUser] = usePutUserMutation();
+  const [deleteUser] = useDeleteUserMutation();
   const [changePassword, changePasswordResult] = usePostChangePasswordMutation();
   const [selectedUser, setSelectedUser] = useImmer(initialUser);
   const [newPassword, setNewPassword] = useState('');
@@ -143,6 +145,15 @@ function UserManagementSettings() {
     setSelectedUser((immerState) => { immerState.Avatar = ''; });
   };
 
+  const deleteSelectedUser = (user: UserType) => {
+    if (currentUser.data?.ID === user.ID) {
+      toast.error('Woah there buddy!', 'You just tried to delete yourself from the matrix. That\'s not the way to go about doing it.');
+    } else {
+      deleteUser(user.ID)
+        .catch(error => console.error(error));
+    }
+  };
+
   const handlePlexLogin = () => {
     window.open(getPlexLoginUrlResult?.data, '_blank');
     setPlexPollingInterval(1000);
@@ -198,9 +209,11 @@ function UserManagementSettings() {
               <div>{user.Username}</div>
               <div className="flex gap-x-2">
                 <div onClick={() => setSelectedUser(user)}>
-                  <Icon path={mdiCircleEditOutline} size={1} className="text-highlight-1" />
+                  <Icon path={mdiCircleEditOutline} size={1} className="cursor-pointer text-highlight-1" />
                 </div>
-                <Icon path={mdiMinusCircleOutline} size={1} className="text-highlight-3" />
+                <div onClick={() => deleteSelectedUser(user)}>
+                  <Icon path={mdiMinusCircleOutline} size={1} className="cursor-pointer text-highlight-3" />
+                </div>
               </div>
             </div>
           ))}


### PR DESCRIPTION
- fix the user avatar logic that changed in the last refactor on the server.

- added the missing AniDB user toggle. I don't know why it was missing.

- made sure the user is only logged out if they're revoking the API keys for themselves, and not for other users.

- made the `delete user` action clickable.

- made sure the edit and delete user buttons use the `pointer` cursor

- improved validation error toast messages