### PR TITLE
fix: display "<missing file path>" when displaying the file location for a file without any locations.

### DIFF
--- a/src/components/Collection/Series/EpisodeFileInfo.tsx
+++ b/src/components/Collection/Series/EpisodeFileInfo.tsx
@@ -49,12 +49,12 @@ const EpisodeFileInfo = ({ file }) => {
           <div className="flex">
             <div className="min-w-[9.375rem] font-semibold">File Name</div>
             {/* TODO: Only show filename */}
-            {get(file, 'Locations.0.RelativePath', '')}
+            {get(file, 'Locations.0.RelativePath', '<missing file path>')}
           </div>
           <div className="flex">
             <div className="min-w-[9.375rem] font-semibold">Location</div>
             {/* TODO: Show path not relative path */}
-            {get(file, 'Locations.0.RelativePath', '')}
+            {get(file, 'Locations.0.RelativePath', '<missing file path>')}
           </div>
           <div className="flex">
             <div className="min-w-[9.375rem] font-semibold">Size</div>

--- a/src/components/Utilities/Unrecognized/ManuallyLinkedFilesRow.tsx
+++ b/src/components/Utilities/Unrecognized/ManuallyLinkedFilesRow.tsx
@@ -97,7 +97,7 @@ function ManuallyLinkedFilesRow(props: Props) {
         className: 'w-auto',
       },
     }),
-    columnHelper.accessor(row => row.Locations?.[0].RelativePath.split(/[/\\]/g).pop(), {
+    columnHelper.accessor(row => row.Locations?.[0].RelativePath.split(/[/\\]/g).pop() ?? '<missing file path>', {
       header: 'File',
       id: 'file',
       cell: info => info.getValue(),

--- a/src/pages/dashboard/panels/UnrecognizedFiles.tsx
+++ b/src/pages/dashboard/panels/UnrecognizedFiles.tsx
@@ -35,7 +35,7 @@ const FileItem = ({ file }: { file: FileType }) => {
     <div key={file.ID} className="flex items-center">
       <div className="flex flex-col grow">
         <span className="font-semibold">{moment(file.Created).format('yyyy-MM-DD')} / {moment(file.Created).format('hh:mm A')}</span>
-        <span className="break-all max-w-[95%]">{file.Locations[0].RelativePath.split(/[/\\]/g).pop()}</span>
+        <span className="break-all max-w-[95%]">{file.Locations[0]?.RelativePath.split(/[/\\]/g).pop() ?? '<missing file path>'}</span>
       </div>
       <div className="flex justify-between">
         {(avdumpList[file.ID] === undefined || avdumpList[file.ID].fetching) && (

--- a/src/pages/utilities/UnrecognizedUtility.tsx
+++ b/src/pages/utilities/UnrecognizedUtility.tsx
@@ -33,7 +33,7 @@ function UnrecognizedUtility() {
           className: 'w-52',
         },
       }),
-      columnHelper.accessor(row => get(row, 'Locations.0.RelativePath', ''), {
+      columnHelper.accessor(row => get(row, 'Locations.0.RelativePath', '<missing file path>'), {
         header: 'Filename',
         id: 'filename',
         cell: info => <div className="break-all">{info.getValue().split(/[/\\]/g).pop()}</div>,

--- a/src/pages/utilities/UnrecognizedUtilityTabs/LinkFilesTab.tsx
+++ b/src/pages/utilities/UnrecognizedUtilityTabs/LinkFilesTab.tsx
@@ -193,7 +193,7 @@ function LinkFilesTab() {
     const result: React.ReactNode[] = [];
     forEach(fileLinks, (link, idx) => {
       const file = find(selectedRows, ['ID', link.FileID]);
-      const path = file?.Locations?.[0].RelativePath ?? '';
+      const path = file?.Locations?.[0].RelativePath ?? '<missing file path>';
       const isSameFile = idx > 0 && fileLinks[idx - 1].FileID === link.FileID;
       result.push(
         <div title={path} className={cx(['flex items-center p-4 w-full border border-background-border rounded-md col-start-1 cursor-pointer transition-colors leading-5', idx % 2 === 0 ? 'bg-background-alt' : 'bg-background', selectedLink === idx && 'border-highlight-1'])} key={`${link.FileID}-${link.EpisodeID}-${idx}`} data-file-id={link.FileID} onClick={() => updateSelectedLink(idx)}>
@@ -225,7 +225,7 @@ function LinkFilesTab() {
     forEach(selectedRows, (file) => {
       manualLinkFileRows.push(
         <div className="p-4 w-full odd:bg-background even:bg-background-alt border border-background-border rounded-md leading-5" key={file.ID}>
-          {file.Locations?.[0].RelativePath ?? ''}
+          {file.Locations?.[0].RelativePath ?? '<missing file path>'}
         </div>,
       );
     });

--- a/src/pages/utilities/UnrecognizedUtilityTabs/UnrecognizedTab.tsx
+++ b/src/pages/utilities/UnrecognizedUtilityTabs/UnrecognizedTab.tsx
@@ -296,7 +296,7 @@ function UnrecognizedTab() {
 
   const ed2kLinks = () => {
     const fileList = selectedRows.length > 0 ? selectedRows : files.List;
-    return fileList.map(file => `ed2k://|file|${file.Locations[0]?.RelativePath}|${file.Size}|${file.Hashes.ED2K}|/`);
+    return fileList.map(file => `ed2k://|file|${file.Locations[0]?.RelativePath ?? '<missing file path>'}|${file.Size}|${file.Hashes.ED2K}|/`);
   };
 
   return (


### PR DESCRIPTION
this PR should should stop the crashing on the dashboard when we try to display the path for a file without any locations, also made the change to display the text everywhere for consistency's sake, and because it's useful no matter which page
we're on to know if the file does not have any locations.