### PR TITLE
Add lint rules

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -41,6 +41,10 @@
       "error",
       { "functions": false }
     ],
+    "@typescript-eslint/consistent-type-definitions": [
+      "error",
+      "type"
+    ],
     "arrow-parens": [
       "error",
       "as-needed",
@@ -113,6 +117,7 @@
     "react/prefer-stateless-function": "off",
     "react/prop-types": "off",
     "react/require-default-props": "off",
-    "sort-destructure-keys/sort-destructure-keys": 2
+    "sort-destructure-keys/sort-destructure-keys": 2,
+    "no-undef": "error"
   }
 }

--- a/src/components/DnDList/PortalAwareItem.tsx
+++ b/src/components/DnDList/PortalAwareItem.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import type { JSX } from 'react';
 import type { DraggableProvided, DraggableStateSnapshot } from 'react-beautiful-dnd';
 import ReactDOM from 'react-dom';
 

--- a/src/core/localStorage.ts
+++ b/src/core/localStorage.ts
@@ -1,3 +1,5 @@
+/* global globalThis */
+
 import { get, omit } from 'lodash';
 
 import { externalApi } from './rtkQuery/externalApi';

--- a/src/core/react-table.d.ts
+++ b/src/core/react-table.d.ts
@@ -1,6 +1,7 @@
 import '@tanstack/react-table';
 
 declare module '@tanstack/react-table' {
+  /* eslint-disable-next-line  @typescript-eslint/consistent-type-definitions */
   interface ColumnMeta {
     className?: string;
   }

--- a/src/core/router/AuthenticatedRoute.tsx
+++ b/src/core/router/AuthenticatedRoute.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { type JSX } from 'react';
 import { useSelector } from 'react-redux';
 import { Navigate } from 'react-router';
 

--- a/src/core/router/index.tsx
+++ b/src/core/router/index.tsx
@@ -1,3 +1,4 @@
+/* global globalThis */
 import React, { useEffect, useRef } from 'react';
 import { useSelector } from 'react-redux';
 import { Navigate, Route } from 'react-router';

--- a/src/core/store.ts
+++ b/src/core/store.ts
@@ -1,3 +1,4 @@
+/* global globalThis */
 import { configureStore } from '@reduxjs/toolkit';
 import { setupListeners } from '@reduxjs/toolkit/query/react';
 import { throttle } from 'lodash';

--- a/src/core/util.ts
+++ b/src/core/util.ts
@@ -53,9 +53,11 @@ export function omitDeepBy(value: any, iteratee: Function) {
 // tanstack table helpers
 
 declare module '@tanstack/table-core' {
+  /* eslint-disable-next-line  @typescript-eslint/consistent-type-definitions */
   interface FilterFns {
     fuzzy: FilterFn<unknown>;
   }
+  /* eslint-disable-next-line  @typescript-eslint/consistent-type-definitions */
   interface FilterMeta {
     itemRank: RankingInfo;
   }

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,11 +1,11 @@
 /// <reference types="vite/client" />
-
+/* eslint-disable-next-line  @typescript-eslint/consistent-type-definitions */
 interface ImportMetaEnv {
   readonly VITE_GITHASH: string;
   readonly VITE_APPVERSION: string;
   // more env variables...
 }
-
+/* eslint-disable-next-line  @typescript-eslint/consistent-type-definitions */
 interface ImportMeta {
   readonly env: ImportMetaEnv;
 }

--- a/src/pages/dashboard/components/EpisodeDetails.tsx
+++ b/src/pages/dashboard/components/EpisodeDetails.tsx
@@ -1,4 +1,5 @@
 import React, { useMemo } from 'react';
+import type { JSX } from 'react';
 import { mdiLayersTripleOutline } from '@mdi/js';
 import { Icon } from '@mdi/react';
 import moment from 'moment';

--- a/src/pages/dashboard/components/SeriesDetails.tsx
+++ b/src/pages/dashboard/components/SeriesDetails.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { type JSX } from 'react';
 
 import BackgroundImagePlaceholderDiv from '@/components/BackgroundImagePlaceholderDiv';
 import useMainPoster from '@/hooks/useMainPoster';

--- a/src/pages/settings/SettingsPage.tsx
+++ b/src/pages/settings/SettingsPage.tsx
@@ -1,3 +1,4 @@
+/* global globalThis */
 import React, { useEffect, useMemo, useState } from 'react';
 import { useDispatch } from 'react-redux';
 import { useMediaQuery } from 'react-responsive';


### PR DESCRIPTION
Since we use type for types add @typescript-eslint/consistent-type-definitions to force using type instead of interface

Add no-undef to prevent issues when renaming variables like in pull #628