### PR TITLE
fix: fix anidb description… again

### DIFF
--- a/src/components/Collection/AnidbDescription.tsx
+++ b/src/components/Collection/AnidbDescription.tsx
@@ -1,16 +1,25 @@
 import React, { useMemo } from 'react';
 
-const RemoveSummaryRegex = /^\n(Source|Note|Summary):.*/mg;
+// The question marks are there because people can't spell…
+const RemoveSummaryRegex = /\b(Sour?ce|Note|Summ?ary):([^\r\n]+|$)/mg;
+
+const MultiSpacesRegex = /\s{2,}/g;
+
 const CleanMiscLinesRegex = /^(\*|--|~) /sg;
+
 const CleanMultiEmptyLinesRegex = /\n{2,}/sg;
-const LinkRegex = /(?<url>http:\/\/anidb\.net\/(?<type>ch|cr|[feat])(?<id>\d+)) \[(?<text>[^\]]+)]/g;
+
+// eslint-disable-next-line operator-linebreak -- Because dprint and eslint can't agree otherwise. Feel free to fix it.
+const LinkRegex =
+  /(?<url>http:\/\/anidb\.net\/(?<type>ch|cr|[feat]|(?:character|creator|file|episode|anime|tag)\/)(?<id>\d+)) \[(?<text>[^\]]+)]/g;
 
 const AnidbDescription = ({ text }: { text: string }) => {
   const modifiedText = useMemo(() => {
     const cleanedText = text
       .replaceAll(CleanMiscLinesRegex, '')
       .replaceAll(RemoveSummaryRegex, '')
-      .replaceAll(CleanMultiEmptyLinesRegex, '\n');
+      .replaceAll(CleanMultiEmptyLinesRegex, '\n')
+      .replaceAll(MultiSpacesRegex, ' ');
 
     const lines = [] as React.ReactNode[];
     let prevPos = 0;
@@ -21,7 +30,7 @@ const AnidbDescription = ({ text }: { text: string }) => {
       lines.push(cleanedText.substring(prevPos, pos));
       prevPos = pos + link[0].length;
       lines.push(
-        link[4],
+        link.groups!.text,
       );
       link = LinkRegex.exec(cleanedText);
     }

--- a/src/pages/collection/series/SeriesTags.tsx
+++ b/src/pages/collection/series/SeriesTags.tsx
@@ -5,6 +5,7 @@ import { Icon } from '@mdi/react';
 import cx from 'classnames';
 import { map } from 'lodash';
 
+import AnidbDescription from '@/components/Collection/AnidbDescription';
 import Input from '@/components/Input/Input';
 import ShokoPanel from '@/components/Panels/ShokoPanel';
 import { useGetSeriesTagsQuery } from '@/core/rtkQuery/splitV3Api/seriesApi';
@@ -27,7 +28,9 @@ function SeriesTag(props: { item: TagType }) {
         &nbsp;
         <Icon path={isOpen ? mdiChevronUp : mdiChevronDown} size={1} />
       </div>
-      <div className={cx('leading-5', { 'line-clamp-2': !isOpen })}>{item.Description}</div>
+      <div className={cx('leading-5', { 'line-clamp-2': !isOpen })}>
+        <AnidbDescription text={item?.Description || 'No description set.'} />
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
- add missing link templates to regex, since we only accounted for short links, but people also insert long links,

- merge multi spaces into single space,

- remove summary credits,

- account for people's disability to spell correctly, and

- fix tag descriptions.