### PR TITLE
Misc. changes

### DIFF
--- a/src/components/Collection/Series/EditSeriesTabs/NameTab.tsx
+++ b/src/components/Collection/Series/EditSeriesTabs/NameTab.tsx
@@ -13,7 +13,9 @@ const NameTab = ({ seriesId }: Props) => {
   const [search, setSearch] = useState('');
   const [nameEditable, setNameEditable] = useState(false);
 
-  const seriesQuery = useGetSeriesQuery({ seriesId: seriesId.toString(), includeDataFrom: ['AniDB'] });
+  const seriesQuery = useGetSeriesQuery({ seriesId: seriesId.toString(), includeDataFrom: ['AniDB'] }, {
+    refetchOnMountOrArgChange: false,
+  });
 
   useEffect(() => {
     setName(seriesQuery.data?.Name ?? '');

--- a/src/components/Collection/Series/EpisodeDetails.tsx
+++ b/src/components/Collection/Series/EpisodeDetails.tsx
@@ -25,7 +25,8 @@ function EpisodeDetails({ episode }: { episode: EpisodeType }) {
         {episode.Size > 1 && (
           <div>
             <span className="text-panel-text-important">{episode.Size}</span>
-            &nbsp;Files
+            &nbsp;
+            {episode.Size === 1 ? 'File' : 'Files'}
           </div>
         )}
       </div>

--- a/src/components/Collection/Series/EpisodeDetails.tsx
+++ b/src/components/Collection/Series/EpisodeDetails.tsx
@@ -18,7 +18,8 @@ function EpisodeDetails({ episode }: { episode: EpisodeType }) {
     <div className="flex grow flex-col gap-y-4">
       <div className="flex justify-between font-semibold">
         <div className="opacity-65">
-          Episode&nbsp;
+          {episode.AniDB?.Type.replace('Normal', 'Episode').replace('ThemeSong', 'Credit') ?? 'Episode'}
+          &nbsp;
           {episode.AniDB?.EpisodeNumber}
         </div>
         {episode.Size > 1 && (

--- a/src/components/Collection/Series/EpisodeFiles.tsx
+++ b/src/components/Collection/Series/EpisodeFiles.tsx
@@ -4,6 +4,7 @@ import { Icon } from '@mdi/react';
 import { get, map } from 'lodash';
 
 import DeleteFilesModal from '@/components/Dialogs/DeleteFilesModal';
+import Button from '@/components/Input/Button';
 import toast from '@/components/Toast';
 import { useDeleteFileMutation, usePostFileRescanMutation } from '@/core/rtkQuery/splitV3Api/fileApi';
 
@@ -61,53 +62,59 @@ const EpisodeFiles = ({ episodeFiles }: Props) => {
 
         return (
           <div className="flex flex-col gap-y-8" key={selectedFile.ID}>
-            <div className="flex grow gap-x-3 rounded-md border border-panel-border bg-panel-background-alt px-4 py-3">
-              <div
-                className="flex cursor-pointer items-center gap-x-2"
-                onClick={async () => {
-                  await rescanFile(selectedFile.ID);
-                }}
-              >
-                <Icon className="text-panel-icon-action" path={mdiRefresh} size={1} />
-                Force Update File Info
-              </div>
-              <div className="flex items-center gap-x-2">
-                <Icon className="text-panel-icon-action" path={mdiEyeOutline} size={1} />
-                {selectedFile.IsVariation ? 'Unmark' : 'Mark'}
-                &nbsp;File as Variation
-              </div>
-              {selectedFile.AniDB && (
-                <a href={`https://anidb.net/file/${selectedFile.AniDB.ID}`} target="_blank" rel="noopener noreferrer">
-                  <div className="flex items-center gap-x-2 font-semibold text-panel-text-primary">
-                    <div className="metadata-link-icon AniDB" />
-                    {`${selectedFile.AniDB.ID} (AniDB)`}
-                    <Icon className="text-panel-icon-action" path={mdiOpenInNew} size={1} />
-                  </div>
-                </a>
-              )}
-              {ReleaseGroupID > 0 && (
-                <a href={`https://anidb.net/group/${ReleaseGroupID}`} target="_blank" rel="noopener noreferrer">
-                  <div className="flex items-center gap-x-2 font-semibold text-panel-text-primary">
-                    <div className="metadata-link-icon AniDB" />
-                    {ReleaseGroupName === null ? 'Unknown' : ReleaseGroupName}
-                    <Icon className="text-panel-icon-action" path={mdiOpenInNew} size={1} />
-                  </div>
-                </a>
-              )}
-              <div
-                className="flex cursor-pointer items-center gap-x-2 text-panel-text-danger"
-                onClick={() => {
-                  setShowDeleteModal(true);
-                  setSelectedFileToDelete(selectedFile);
-                }}
-              >
-                <Icon path={mdiTrashCanOutline} size={1} />
-                Delete File
-              </div>
+            <div className="flex grow gap-x-2">
+              <div className="flex grow gap-x-3 rounded-md border border-panel-border bg-panel-background-alt px-4 py-3">
+                <div
+                  className="flex cursor-pointer items-center gap-x-2"
+                  onClick={async () => {
+                    await rescanFile(selectedFile.ID);
+                  }}
+                >
+                  <Icon className="text-panel-icon-action" path={mdiRefresh} size={1} />
+                  Force Update File Info
+                </div>
+                <div className="flex items-center gap-x-2">
+                  <Icon className="text-panel-icon-action" path={mdiEyeOutline} size={1} />
+                  {selectedFile.IsVariation ? 'Unmark' : 'Mark'}
+                  &nbsp;File as Variation
+                </div>
+                {selectedFile.AniDB && (
+                  <a href={`https://anidb.net/file/${selectedFile.AniDB.ID}`} target="_blank" rel="noopener noreferrer">
+                    <div className="flex items-center gap-x-2 font-semibold text-panel-text-primary">
+                      <div className="metadata-link-icon AniDB" />
+                      {`${selectedFile.AniDB.ID} (AniDB)`}
+                      <Icon className="text-panel-icon-action" path={mdiOpenInNew} size={1} />
+                    </div>
+                  </a>
+                )}
+                {ReleaseGroupID > 0 && (
+                  <a href={`https://anidb.net/group/${ReleaseGroupID}`} target="_blank" rel="noopener noreferrer">
+                    <div className="flex items-center gap-x-2 font-semibold text-panel-text-primary">
+                      <div className="metadata-link-icon AniDB" />
+                      {ReleaseGroupName === null ? 'Unknown' : ReleaseGroupName}
+                      &nbsp; (AniDB)
+                      <Icon className="text-panel-icon-action" path={mdiOpenInNew} size={1} />
+                    </div>
+                  </a>
+                )}
 
-              {selectedFile.IsVariation && (
-                <span className="ml-auto font-semibold text-panel-text-important">Variation</span>
-              )}
+                {selectedFile.IsVariation && (
+                  <span className="ml-auto font-semibold text-panel-text-important">Variation</span>
+                )}
+              </div>
+              <div className="flex text-center">
+                <Button
+                  buttonType="danger"
+                  className="flex gap-x-2 px-4 py-3"
+                  onClick={() => {
+                    setShowDeleteModal(true);
+                    setSelectedFileToDelete(selectedFile);
+                  }}
+                >
+                  <Icon path={mdiTrashCanOutline} size={1} />
+                  Delete File
+                </Button>
+              </div>
             </div>
 
             <EpisodeFileInfo file={selectedFile} />

--- a/src/components/Collection/Series/EpisodeFiles.tsx
+++ b/src/components/Collection/Series/EpisodeFiles.tsx
@@ -13,10 +13,11 @@ import EpisodeFileInfo from './EpisodeFileInfo';
 import type { FileType } from '@/core/types/api/file';
 
 type Props = {
+  animeId: number;
   episodeFiles: FileType[];
 };
 
-const EpisodeFiles = ({ episodeFiles }: Props) => {
+const EpisodeFiles = ({ animeId, episodeFiles }: Props) => {
   const [fileDeleteTrigger] = useDeleteFileMutation();
   const [fileRescanTrigger] = usePostFileRescanMutation();
   const [showDeleteModal, setShowDeleteModal] = useState(false);
@@ -88,7 +89,11 @@ const EpisodeFiles = ({ episodeFiles }: Props) => {
                   </a>
                 )}
                 {ReleaseGroupID > 0 && (
-                  <a href={`https://anidb.net/group/${ReleaseGroupID}`} target="_blank" rel="noopener noreferrer">
+                  <a
+                    href={`https://anidb.net/group/${ReleaseGroupID}/anime/${animeId}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
                     <div className="flex items-center gap-x-2 font-semibold text-panel-text-primary">
                       <div className="metadata-link-icon AniDB" />
                       {ReleaseGroupName === null ? 'Unknown' : ReleaseGroupName}

--- a/src/components/Collection/Series/SeriesEpisode.tsx
+++ b/src/components/Collection/Series/SeriesEpisode.tsx
@@ -19,6 +19,7 @@ import EpisodeFiles from './EpisodeFiles';
 import type { EpisodeType } from '@/core/types/api/episode';
 
 type Props = {
+  animeId: number;
   episode: EpisodeType;
 };
 
@@ -38,7 +39,7 @@ const StateButton = ({ active, icon, onClick }: { icon: string, active: boolean,
   </Button>
 );
 
-const SeriesEpisode = ({ episode }: Props) => {
+const SeriesEpisode = ({ animeId, episode }: Props) => {
   const thumbnail = useEpisodeThumbnail(episode);
   const [isOpen, setIsOpen] = useState(false);
   const episodeId = get(episode, 'IDs.ID', 0).toString();
@@ -104,7 +105,7 @@ const SeriesEpisode = ({ episode }: Props) => {
         />
       </div>
       <AnimateHeight height={isOpen ? 'auto' : 0}>
-        <EpisodeFiles episodeFiles={episodeFilesResult.data ?? []} />
+        <EpisodeFiles animeId={animeId} episodeFiles={episodeFilesResult.data ?? []} />
       </AnimateHeight>
     </>
   );

--- a/src/components/Collection/SeriesInfo.tsx
+++ b/src/components/Collection/SeriesInfo.tsx
@@ -62,24 +62,21 @@ const SeriesInfo = () => {
           </div>
         </div>
 
-        {(series.Sizes.Total.Episodes - series.Sizes.Local.Episodes !== 0
-          || series.Sizes.Total.Specials - series.Sizes.Local.Specials !== 0) && (
+        {(series.Sizes.Missing.Episodes !== 0 || series.Sizes.Missing.Specials !== 0) && (
           <div className="flex flex-col items-center">
             <div className="font-semibold ">Missing</div>
             <div className="flex flex-row gap-x-1">
-              {series.Sizes.Total.Episodes - series.Sizes.Local.Episodes !== 0 && (
+              {series.Sizes.Missing.Episodes !== 0 && (
                 <>
                   <span>EP:</span>
-                  <span>{formatThousand(series.Sizes.Total.Episodes - series.Sizes.Local.Episodes)}</span>
+                  <span>{formatThousand(series.Sizes.Missing.Episodes)}</span>
                 </>
               )}
-              {series.Sizes.Total.Episodes - series.Sizes.Local.Episodes !== 0
-                && series.Sizes.Total.Specials - series.Sizes.Local.Specials !== 0
-                && <span>|</span>}
-              {series.Sizes.Total.Specials - series.Sizes.Local.Specials !== 0 && (
+              {series.Sizes.Missing.Episodes !== 0 && series.Sizes.Missing.Specials !== 0 && <span>|</span>}
+              {series.Sizes.Missing.Specials !== 0 && (
                 <>
                   <span>SP:</span>
-                  <span>{formatThousand(series.Sizes.Total.Specials - series.Sizes.Local.Specials)}</span>
+                  <span>{formatThousand(series.Sizes.Missing.Specials)}</span>
                 </>
               )}
             </div>

--- a/src/components/Collection/SeriesInfo.tsx
+++ b/src/components/Collection/SeriesInfo.tsx
@@ -47,7 +47,7 @@ const SeriesInfo = () => {
     <div className="flex w-full max-w-[31.25rem] flex-col gap-y-8">
       <div className="flex w-full flex-row justify-around gap-y-4 rounded-md border border-panel-border bg-panel-background-transparent p-8">
         <div className="flex flex-col items-center">
-          <div className="font-semibold ">File Count</div>
+          <div className="font-semibold ">Local</div>
           <div className="flex flex-row gap-x-1">
             <span>EP:</span>
             <span>{formatThousand(series.Sizes.Local.Episodes)}</span>

--- a/src/components/Collection/SeriesInfo.tsx
+++ b/src/components/Collection/SeriesInfo.tsx
@@ -14,7 +14,10 @@ const SeriesInfo = () => {
   // Series Data;
   const seriesOverviewData = useGetSeriesOverviewQuery({ SeriesID: seriesId! }, { skip: !seriesId });
   const overview = useMemo(() => seriesOverviewData?.data || {} as WebuiSeriesDetailsType, [seriesOverviewData]);
-  const seriesData = useGetSeriesQuery({ seriesId: seriesId!, includeDataFrom: ['AniDB'] }, { skip: !seriesId });
+  const seriesData = useGetSeriesQuery({ seriesId: seriesId!, includeDataFrom: ['AniDB'] }, {
+    refetchOnMountOrArgChange: false,
+    skip: !seriesId,
+  });
   const series = useMemo(() => seriesData?.data ?? null, [seriesData]);
 
   const startDate = useMemo(() => (series?.AniDB?.AirDate != null ? dayjs(series?.AniDB?.AirDate) : null), [series]);

--- a/src/components/Collection/SeriesInfo.tsx
+++ b/src/components/Collection/SeriesInfo.tsx
@@ -48,57 +48,6 @@ const SeriesInfo = () => {
 
   return (
     <div className="flex w-full max-w-[31.25rem] flex-col gap-y-8">
-      <div className="flex w-full flex-row justify-around gap-y-4 rounded-md border border-panel-border bg-panel-background-transparent p-8">
-        <div className="flex flex-col items-center">
-          <div className="font-semibold ">Local</div>
-          <div className="flex flex-row gap-x-1">
-            <span>EP:</span>
-            <span>{formatThousand(series.Sizes.Local.Episodes)}</span>
-            {series.Sizes.Local.Specials !== 0 && (
-              <>
-                <span>|</span>
-                <span>SP:</span>
-                <span>{formatThousand(series.Sizes.Local.Specials)}</span>
-              </>
-            )}
-          </div>
-        </div>
-        <div className="flex flex-col items-center">
-          <div className="font-semibold ">Watched</div>
-          <div className="flex flex-row gap-x-1">
-            <span>EP:</span>
-            <span>{formatThousand(series.Sizes.Watched.Episodes)}</span>
-            {(series.Sizes.Total.Specials !== 0 && series.Sizes.Local.Specials !== 0) && (
-              <>
-                <span>|</span>
-                <span>SP:</span>
-                <span>{formatThousand(series.Sizes.Watched.Specials)}</span>
-              </>
-            )}
-          </div>
-        </div>
-
-        {(series.Sizes.Missing.Episodes !== 0 || series.Sizes.Missing.Specials !== 0) && (
-          <div className="flex flex-col items-center">
-            <div className="font-semibold ">Missing</div>
-            <div className="flex flex-row gap-x-1">
-              {series.Sizes.Missing.Episodes !== 0 && (
-                <>
-                  <span>EP:</span>
-                  <span>{formatThousand(series.Sizes.Missing.Episodes)}</span>
-                </>
-              )}
-              {series.Sizes.Missing.Episodes !== 0 && series.Sizes.Missing.Specials !== 0 && <span>|</span>}
-              {series.Sizes.Missing.Specials !== 0 && (
-                <>
-                  <span>SP:</span>
-                  <span>{formatThousand(series.Sizes.Missing.Specials)}</span>
-                </>
-              )}
-            </div>
-          </div>
-        )}
-      </div>
       <div className="flex w-full flex-col gap-y-3 rounded-md border border-panel-border bg-panel-background-transparent p-8">
         <div className="flex justify-between capitalize">
           <div className="font-semibold">Type</div>
@@ -151,6 +100,57 @@ const SeriesInfo = () => {
           <div className="font-semibold">Studio</div>
           <div>{overview?.Studios?.[0] ? overview?.Studios?.[0].Name : 'Studio Not Listed'}</div>
         </div>
+      </div>
+      <div className="flex w-full flex-row justify-around gap-y-4 rounded-md border border-panel-border bg-panel-background-transparent p-8">
+        <div className="flex flex-col items-center">
+          <div className="font-semibold ">Local</div>
+          <div className="flex flex-row gap-x-1">
+            <span>EP:</span>
+            <span>{formatThousand(series.Sizes.Local.Episodes)}</span>
+            {series.Sizes.Local.Specials !== 0 && (
+              <>
+                <span>|</span>
+                <span>SP:</span>
+                <span>{formatThousand(series.Sizes.Local.Specials)}</span>
+              </>
+            )}
+          </div>
+        </div>
+        <div className="flex flex-col items-center">
+          <div className="font-semibold ">Watched</div>
+          <div className="flex flex-row gap-x-1">
+            <span>EP:</span>
+            <span>{formatThousand(series.Sizes.Watched.Episodes)}</span>
+            {(series.Sizes.Total.Specials !== 0 && series.Sizes.Local.Specials !== 0) && (
+              <>
+                <span>|</span>
+                <span>SP:</span>
+                <span>{formatThousand(series.Sizes.Watched.Specials)}</span>
+              </>
+            )}
+          </div>
+        </div>
+
+        {(series.Sizes.Missing.Episodes !== 0 || series.Sizes.Missing.Specials !== 0) && (
+          <div className="flex flex-col items-center">
+            <div className="font-semibold ">Missing</div>
+            <div className="flex flex-row gap-x-1">
+              {series.Sizes.Missing.Episodes !== 0 && (
+                <>
+                  <span>EP:</span>
+                  <span>{formatThousand(series.Sizes.Missing.Episodes)}</span>
+                </>
+              )}
+              {series.Sizes.Missing.Episodes !== 0 && series.Sizes.Missing.Specials !== 0 && <span>|</span>}
+              {series.Sizes.Missing.Specials !== 0 && (
+                <>
+                  <span>SP:</span>
+                  <span>{formatThousand(series.Sizes.Missing.Specials)}</span>
+                </>
+              )}
+            </div>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/components/Collection/SeriesInfo.tsx
+++ b/src/components/Collection/SeriesInfo.tsx
@@ -18,9 +18,12 @@ const SeriesInfo = () => {
   const seriesData = useGetSeriesQuery({ seriesId: seriesId!, includeDataFrom: ['AniDB'] }, { skip: !seriesId });
   const series = useMemo(() => seriesData?.data ?? {} as SeriesDetailsType, [seriesData]);
 
-  const startDate = useMemo(() => dayjs(series.AniDB?.AirDate), [series]);
-  const endDate = useMemo(() => (series.AniDB?.EndDate !== null ? dayjs(series.AniDB?.EndDate) : null), [series]);
-  const airDate = () => {
+  const startDate = useMemo(() => (series.AniDB?.AirDate != null ? dayjs(series.AniDB?.AirDate) : null), [series]);
+  const endDate = useMemo(() => (series.AniDB?.EndDate != null ? dayjs(series.AniDB?.EndDate) : null), [series]);
+  const airDate = useMemo(() => {
+    if (!startDate) {
+      return 'Unknown';
+    }
     if (endDate) {
       if (startDate.format('MMM DD, YYYY') === endDate.format('MMM DD, YYYY')) {
         return startDate.format('MMM DD, YYYY');
@@ -28,7 +31,16 @@ const SeriesInfo = () => {
       return `${startDate.format('MMM DD, YYYY')} - ${endDate.format('MMM DD, YYYY')}`;
     }
     return `${startDate.format('MMM DD, YYYY')} - Ongoing`;
-  };
+  }, [startDate, endDate]);
+  const status = useMemo(() => {
+    if (!startDate) {
+      return 'Unknown';
+    }
+    if (endDate && endDate.isAfter(dayjs())) {
+      return 'Ongoing';
+    }
+    return 'Finished';
+  }, [startDate, endDate]);
 
   return (
     <div className="flex w-full max-w-[31.25rem] flex-col gap-y-8">
@@ -93,15 +105,21 @@ const SeriesInfo = () => {
           {overview.SourceMaterial}
         </div>
         <div className="flex justify-between capitalize">
+          <div className="font-semibold">Restricted</div>
+          <div>
+            {series.AniDB?.Restricted ? 'Yes' : 'No'}
+          </div>
+        </div>
+        <div className="flex justify-between capitalize">
           <div className="font-semibold">Air Date</div>
           <div>
-            {airDate()}
+            {airDate}
           </div>
         </div>
         <div className="flex justify-between capitalize">
           <div className="font-semibold">Status</div>
           {/* TODO: Check if there are more status types */}
-          {(series.AniDB?.EndDate && dayjs(series.AniDB.EndDate).isAfter(dayjs())) ? 'Ongoing' : 'Finished'}
+          {status}
         </div>
         <div className="flex justify-between capitalize">
           <div className="font-semibold">Episodes</div>

--- a/src/components/Collection/SeriesInfo.tsx
+++ b/src/components/Collection/SeriesInfo.tsx
@@ -109,12 +109,6 @@ const SeriesInfo = () => {
           {overview.SourceMaterial}
         </div>
         <div className="flex justify-between capitalize">
-          <div className="font-semibold">Restricted</div>
-          <div>
-            {series.AniDB?.Restricted ? 'Yes' : 'No'}
-          </div>
-        </div>
-        <div className="flex justify-between capitalize">
           <div className="font-semibold">Air Date</div>
           <div>
             {airDate}

--- a/src/components/Collection/SeriesInfo.tsx
+++ b/src/components/Collection/SeriesInfo.tsx
@@ -6,7 +6,6 @@ import { useGetSeriesQuery } from '@/core/rtkQuery/splitV3Api/seriesApi';
 import { useGetSeriesOverviewQuery } from '@/core/rtkQuery/splitV3Api/webuiApi';
 import { dayjs, formatThousand } from '@/core/util';
 
-import type { SeriesDetailsType } from '@/core/types/api/series';
 import type { WebuiSeriesDetailsType } from '@/core/types/api/webui';
 
 const SeriesInfo = () => {
@@ -16,10 +15,10 @@ const SeriesInfo = () => {
   const seriesOverviewData = useGetSeriesOverviewQuery({ SeriesID: seriesId! }, { skip: !seriesId });
   const overview = useMemo(() => seriesOverviewData?.data || {} as WebuiSeriesDetailsType, [seriesOverviewData]);
   const seriesData = useGetSeriesQuery({ seriesId: seriesId!, includeDataFrom: ['AniDB'] }, { skip: !seriesId });
-  const series = useMemo(() => seriesData?.data ?? {} as SeriesDetailsType, [seriesData]);
+  const series = useMemo(() => seriesData?.data ?? null, [seriesData]);
 
-  const startDate = useMemo(() => (series.AniDB?.AirDate != null ? dayjs(series.AniDB?.AirDate) : null), [series]);
-  const endDate = useMemo(() => (series.AniDB?.EndDate != null ? dayjs(series.AniDB?.EndDate) : null), [series]);
+  const startDate = useMemo(() => (series?.AniDB?.AirDate != null ? dayjs(series?.AniDB?.AirDate) : null), [series]);
+  const endDate = useMemo(() => (series?.AniDB?.EndDate != null ? dayjs(series?.AniDB?.EndDate) : null), [series]);
   const airDate = useMemo(() => {
     if (!startDate) {
       return 'Unknown';
@@ -41,6 +40,8 @@ const SeriesInfo = () => {
     }
     return 'Finished';
   }, [startDate, endDate]);
+
+  if (!series || !seriesId) return null;
 
   return (
     <div className="flex w-full max-w-[31.25rem] flex-col gap-y-8">

--- a/src/components/Collection/SeriesMetadata.tsx
+++ b/src/components/Collection/SeriesMetadata.tsx
@@ -3,9 +3,12 @@ import { mdiCloseCircleOutline, mdiOpenInNew, mdiPencilCircleOutline, mdiPlusCir
 import { Icon } from '@mdi/react';
 
 import Button from '@/components/Input/Button';
+import { useDeleteSeriesTvdbLinkMutation } from '@/core/rtkQuery/splitV3Api/seriesApi';
 
-const MetadataLink = ({ id, site }: { site: string, id: number | number[] }) => {
+const MetadataLink = ({ id, seriesId, site }: { id: number | number[], seriesId: number, site: string }) => {
   const linkId = Array.isArray(id) ? id[0] : id;
+
+  const [disableTvDBTrigger] = useDeleteSeriesTvdbLinkMutation();
 
   const siteLink = useMemo(() => {
     switch (site) {
@@ -23,6 +26,18 @@ const MetadataLink = ({ id, site }: { site: string, id: number | number[] }) => 
         return '#';
     }
   }, [linkId, site]);
+
+  const canDisable = site === 'TvDB';
+
+  const disableMetadata = () => {
+    switch (site) {
+      case 'TvDB':
+        disableTvDBTrigger({ seriesId, tvdbShowId: linkId }).catch(() => {});
+        break;
+      default:
+        break;
+    }
+  };
 
   return (
     <div key={site} className="flex justify-between">
@@ -50,7 +65,7 @@ const MetadataLink = ({ id, site }: { site: string, id: number | number[] }) => 
                 <Button disabled>
                   <Icon className="text-panel-icon-action" path={mdiPencilCircleOutline} size={1} />
                 </Button>
-                <Button disabled>
+                <Button disabled={!canDisable} onClick={disableMetadata}>
                   <Icon className="text-panel-icon-danger" path={mdiCloseCircleOutline} size={1} />
                 </Button>
               </>

--- a/src/components/Utilities/Unrecognized/AvDumpSeriesSelectModal.tsx
+++ b/src/components/Utilities/Unrecognized/AvDumpSeriesSelectModal.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import React, { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { mdiFileDocumentMultipleOutline, mdiLoading, mdiMagnify, mdiOpenInNew } from '@mdi/js';
 import { Icon } from '@mdi/react';
 import { debounce, forEach } from 'lodash';
@@ -8,29 +8,33 @@ import Button from '@/components/Input/Button';
 import Input from '@/components/Input/Input';
 import ModalPanel from '@/components/Panels/ModalPanel';
 import toast from '@/components/Toast';
+import { usePostFileRescanMutation } from '@/core/rtkQuery/splitV3Api/fileApi';
 import { useLazyGetSeriesAniDBSearchQuery } from '@/core/rtkQuery/splitV3Api/seriesApi';
 import { copyToClipboard } from '@/core/util';
 import { detectShow, findMostCommonShowName } from '@/core/utilities/auto-match-logic';
 
 type Props = {
   show: boolean;
-  onClose(): void;
-  getLinks(): string[];
+  onClose(refresh?: boolean): void;
+  getLinks(): { fileIds: number[], links: string[] };
 };
 
 function AvDumpSeriesSelectModal({ getLinks, onClose, show }: Props) {
-  const { ed2kLinks, links } = useMemo(() => {
-    if (!show) return { ed2kLinks: '', links: [] };
-    const tempLinks = getLinks();
+  const [fileRescanTrigger] = usePostFileRescanMutation();
+  const [clickedLink, setClickedLink] = useState(false);
+  const { ed2kLinks, fileIds, links } = useMemo(() => {
+    if (!show) return { ed2kLinks: '', links: [], fileIds: [] };
+    const { fileIds: tempFileIds, links: tempLinks } = getLinks();
     let tempEd2kLinks = '';
     forEach(tempLinks, (link) => {
       tempEd2kLinks += `${link}\n`;
     });
-    return { ed2kLinks: tempEd2kLinks, links: tempLinks };
+    return { ed2kLinks: tempEd2kLinks, links: tempLinks, fileIds: tempFileIds };
   }, [getLinks, show]);
   const commonSeries = useMemo(() => findMostCommonShowName(links.map(link => detectShow(link.split('|')[2]))), [
     links,
   ]);
+  const initRef = useRef(false);
   const [searchText, setSearchText] = useState(() => commonSeries);
   const [searchTrigger, searchResults] = useLazyGetSeriesAniDBSearchQuery();
 
@@ -42,7 +46,14 @@ function AvDumpSeriesSelectModal({ getLinks, onClose, show }: Props) {
 
   const handleSearch = useEventCallback((query: string) => {
     setSearchText(query);
-    if (query !== '') debouncedSearch(query);
+    if (query !== '') {
+      if (initRef.current) {
+        initRef.current = false;
+        searchTrigger({ query, pageSize: 20 }).catch(() => {});
+      } else {
+        debouncedSearch(query);
+      }
+    }
   });
 
   useEffect(() => () => {
@@ -53,30 +64,56 @@ function AvDumpSeriesSelectModal({ getLinks, onClose, show }: Props) {
     handleSearch(commonSeries);
   }, [commonSeries, handleSearch]);
 
+  useLayoutEffect(() => () => {
+    if (show) return;
+    initRef.current = true;
+    setSearchText('');
+    setClickedLink(false);
+  }, [show]);
+
   const handleCopy = () => {
     copyToClipboard(ed2kLinks)
       .then(() => toast.success('ED2K hashes copied to clipboard!'))
       .catch(() => toast.error('ED2K hashes copy failed!'));
   };
 
+  const rescanFiles = useEventCallback(() => {
+    onClose(true);
+
+    let failedFiles = 0;
+    forEach(fileIds, (fileId) => {
+      fileRescanTrigger(fileId).unwrap().catch((error) => {
+        failedFiles += 1;
+        console.error(error);
+      });
+    });
+
+    if (failedFiles) toast.error(`Rescan failed for ${failedFiles} files!`);
+    if (failedFiles !== fileIds.length) toast.success(`Rescanning ${fileIds.length} files!`);
+  });
   return (
     <ModalPanel
       show={show}
       onRequestClose={onClose}
-      title="AvDump Series Select"
+      title="Add Series To AniDB"
     >
       <div className="flex flex-col gap-y-4">
+        <div className="font-semibold">Copy the ED2K hashes.</div>
+        <div className="flex h-auto max-h-64 flex-col gap-y-1 overflow-y-auto break-all rounded-md bg-panel-input p-4 text-sm">
+          {links.length
+            ? links.map(link => <div key={`link-${link.split('|')[4]}`}>{link}</div>)
+            : <div>No files selected.</div>}
+        </div>
         <Button
           buttonType="primary"
           className="flex w-full items-center justify-center gap-x-2.5 p-2"
+          disabled={!links.length}
           onClick={handleCopy}
         >
           <Icon path={mdiFileDocumentMultipleOutline} size={0.833} />
           Copy ED2K Hashes
         </Button>
-        <div className="flex h-auto max-h-64 flex-col gap-y-1 overflow-y-auto break-all rounded-md bg-panel-input p-4 text-sm">
-          {links.map(link => <div key={`link-${link.split('|')[4]}`}>{link}</div>)}
-        </div>
+        <div className="font-semibold">Find series and link the hashes on AniDB.</div>
         <div className="flex flex-col gap-y-2">
           <Input
             id="search"
@@ -88,7 +125,7 @@ function AvDumpSeriesSelectModal({ getLinks, onClose, show }: Props) {
           />
           <div className="w-full rounded-md border border-panel-border bg-panel-input p-4 capitalize">
             <div className="flex h-72 flex-col gap-y-1 overflow-y-auto overflow-x-clip rounded-md bg-panel-input pr-2 ">
-              {searchResults.isLoading
+              {initRef.current || searchResults.isError || searchResults.isFetching
                 ? (
                   <div className="flex h-full items-center justify-center">
                     <Icon path={mdiLoading} size={3} spin className="text-panel-text-primary" />
@@ -101,6 +138,7 @@ function AvDumpSeriesSelectModal({ getLinks, onClose, show }: Props) {
                     target="_blank"
                     rel="noopener noreferrer"
                     className="flex items-center justify-between"
+                    onClick={() => setClickedLink(true)}
                   >
                     <div className="line-clamp-1">{result.Title}</div>
                     <div className="text-panel-text-primary">
@@ -111,6 +149,16 @@ function AvDumpSeriesSelectModal({ getLinks, onClose, show }: Props) {
             </div>
           </div>
         </div>
+        <div className="font-semibold">Once added to AniDB, click below to rescan.</div>
+        <Button
+          buttonType="primary"
+          className="flex w-full items-center justify-center gap-x-2.5 p-2"
+          disabled={!clickedLink}
+          onClick={rescanFiles}
+        >
+          <Icon path={mdiFileDocumentMultipleOutline} size={0.833} />
+          Rescan Files
+        </Button>
       </div>
     </ModalPanel>
   );

--- a/src/components/Utilities/Unrecognized/AvDumpSeriesSelectModal.tsx
+++ b/src/components/Utilities/Unrecognized/AvDumpSeriesSelectModal.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
-import { mdiFileDocumentMultipleOutline, mdiLoading, mdiMagnify, mdiOpenInNew } from '@mdi/js';
+import { mdiInformationOutline, mdiLoading, mdiMagnify, mdiOpenInNew } from '@mdi/js';
 import { Icon } from '@mdi/react';
 import { debounce, forEach } from 'lodash';
 import { useEventCallback } from 'usehooks-ts';
@@ -19,6 +19,37 @@ type Props = {
   getLinks(): { fileIds: number[], links: string[] };
 };
 
+const Title = ({ count, step, stepCount }: { count: number, step: number, stepCount: number }) => (
+  <div className="flex items-center gap-x-0.5 font-semibold">
+    <div className="flex flex-col gap-y-1">
+      <div className="flex text-xl">
+        Add Series to AniDB
+      </div>
+      <div className="flex text-base font-semibold">
+        Step &nbsp;
+        {step}
+        /
+        {stepCount}
+      </div>
+    </div>
+    <div className="flex grow" />
+    <div className="flex gap-x-1">
+      <div className="text-panel-text-important">{count < 0 ? '-' : count}</div>
+      &nbsp;
+      {count === 1 ? 'File' : 'Files'}
+    </div>
+  </div>
+);
+
+const StepDescription = ({ children }: { children: React.ReactNode }) => (
+  <div className="flex justify-start gap-x-2 ">
+    <Icon className="shrink-0" path={mdiInformationOutline} size={1} />
+    <div className="flex">
+      {children}
+    </div>
+  </div>
+);
+
 function AvDumpSeriesSelectModal({ getLinks, onClose, show }: Props) {
   const [fileRescanTrigger] = usePostFileRescanMutation();
   const [clickedLink, setClickedLink] = useState(false);
@@ -37,12 +68,27 @@ function AvDumpSeriesSelectModal({ getLinks, onClose, show }: Props) {
   const initRef = useRef(false);
   const [searchText, setSearchText] = useState(() => commonSeries);
   const [searchTrigger, searchResults] = useLazyGetSeriesAniDBSearchQuery();
+  const [activeStep, setActiveStep] = useState(1);
+  const [copyFailed, setCopyFailed] = useState(false);
 
   const debouncedSearch = useRef(
     debounce((query: string) => {
       searchTrigger({ query, pageSize: 20 }).catch(() => {});
     }, 200),
   ).current;
+
+  const handleClose = () => {
+    onClose(false);
+  };
+
+  const handleNextStep = () => {
+    setActiveStep(activeStep + 1);
+  };
+
+  const handlePreviousStep = () => {
+    setCopyFailed(false);
+    setActiveStep(activeStep - 1);
+  };
 
   const handleSearch = useEventCallback((query: string) => {
     setSearchText(query);
@@ -56,25 +102,16 @@ function AvDumpSeriesSelectModal({ getLinks, onClose, show }: Props) {
     }
   });
 
-  useEffect(() => () => {
-    debouncedSearch.cancel();
-  }, [debouncedSearch]);
-
-  useEffect(() => {
-    handleSearch(commonSeries);
-  }, [commonSeries, handleSearch]);
-
-  useLayoutEffect(() => () => {
-    if (show) return;
-    initRef.current = true;
-    setSearchText('');
-    setClickedLink(false);
-  }, [show]);
-
   const handleCopy = () => {
     copyToClipboard(ed2kLinks)
-      .then(() => toast.success('ED2K hashes copied to clipboard!'))
-      .catch(() => toast.error('ED2K hashes copy failed!'));
+      .then(() => {
+        toast.success('ED2K hashes copied to clipboard!');
+        setActiveStep(s => s + 1);
+      })
+      .catch(() => {
+        toast.error('ED2K hashes copy failed!');
+        setCopyFailed(true);
+      });
   };
 
   const rescanFiles = useEventCallback(() => {
@@ -91,74 +128,140 @@ function AvDumpSeriesSelectModal({ getLinks, onClose, show }: Props) {
     if (failedFiles) toast.error(`Rescan failed for ${failedFiles} files!`);
     if (failedFiles !== fileIds.length) toast.success(`Rescanning ${fileIds.length} files!`);
   });
+
+  useEffect(() => () => {
+    debouncedSearch.cancel();
+  }, [debouncedSearch]);
+
+  useEffect(() => {
+    handleSearch(commonSeries);
+  }, [commonSeries, handleSearch]);
+
+  useLayoutEffect(() => () => {
+    if (show) return;
+    initRef.current = true;
+    setSearchText('');
+    setClickedLink(false);
+    setCopyFailed(false);
+    setActiveStep(1);
+  }, [show]);
+
   return (
     <ModalPanel
       show={show}
       onRequestClose={onClose}
-      title="Add Series To AniDB"
+      title={<Title step={1} stepCount={2} count={fileIds.length} />}
+      size="sm"
+      titleLeft
+      noPadding
     >
-      <div className="flex flex-col gap-y-4">
-        <div className="font-semibold">Copy the ED2K hashes.</div>
-        <div className="flex h-auto max-h-64 flex-col gap-y-1 overflow-y-auto break-all rounded-md bg-panel-input p-4 text-sm">
-          {links.length
-            ? links.map(link => <div key={`link-${link.split('|')[4]}`}>{link}</div>)
-            : <div>No files selected.</div>}
-        </div>
-        <Button
-          buttonType="primary"
-          className="flex w-full items-center justify-center gap-x-2.5 p-2"
-          disabled={!links.length}
-          onClick={handleCopy}
-        >
-          <Icon path={mdiFileDocumentMultipleOutline} size={0.833} />
-          Copy ED2K Hashes
-        </Button>
-        <div className="font-semibold">Find series and link the hashes on AniDB.</div>
-        <div className="flex flex-col gap-y-2">
-          <Input
-            id="search"
-            value={searchText}
-            type="text"
-            placeholder="Search..."
-            onChange={e => handleSearch(e.target.value)}
-            startIcon={mdiMagnify}
-          />
-          <div className="w-full rounded-md border border-panel-border bg-panel-input p-4 capitalize">
-            <div className="flex h-72 flex-col gap-y-1 overflow-y-auto overflow-x-clip rounded-md bg-panel-input pr-2 ">
-              {initRef.current || searchResults.isError || searchResults.isFetching
+      <div className="flex flex-col gap-y-4 p-5">
+        {activeStep === 1 && (
+          <>
+            <StepDescription>
+              {copyFailed
                 ? (
-                  <div className="flex h-full items-center justify-center">
-                    <Icon path={mdiLoading} size={3} spin className="text-panel-text-primary" />
-                  </div>
+                  'Manually copy the ED2K hashes from the box below, then proceed to the next step.'
                 )
-                : (searchResults.data ?? []).map(result => (
-                  <a
-                    href={`https://anidb.net/anime/${result.ID}/release/add`}
-                    key={result.ID}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="flex items-center justify-between"
-                    onClick={() => setClickedLink(true)}
-                  >
-                    <div className="line-clamp-1">{result.Title}</div>
-                    <div className="text-panel-text-primary">
-                      <Icon path={mdiOpenInNew} size={0.833} />
-                    </div>
-                  </a>
-                ))}
+                : (
+                  'Click the blue button below to copy the ED2K hashes for use in the next step.'
+                )}
+            </StepDescription>
+            <div className="shoko-scrollbar flex h-[14.5rem] flex-col gap-y-1 overflow-y-scroll break-all rounded-md bg-panel-input p-4 text-sm">
+              {links.length
+                ? links.map(link => <div key={`link-${link.split('|')[4]}`}>{link}</div>)
+                : <div>No files selected.</div>}
             </div>
-          </div>
-        </div>
-        <div className="font-semibold">Once added to AniDB, click below to rescan.</div>
-        <Button
-          buttonType="primary"
-          className="flex w-full items-center justify-center gap-x-2.5 p-2"
-          disabled={!clickedLink}
-          onClick={rescanFiles}
-        >
-          <Icon path={mdiFileDocumentMultipleOutline} size={0.833} />
-          Rescan Files
-        </Button>
+            <div className="flex justify-end gap-x-2.5">
+              <Button
+                buttonType="secondary"
+                className="flex items-center justify-center px-4 py-2"
+                onClick={handleClose}
+              >
+                Cancel
+              </Button>
+              {copyFailed || !links.length
+                ? (
+                  <Button
+                    buttonType="primary"
+                    className="flex items-center justify-center px-4 py-2"
+                    onClick={handleNextStep}
+                  >
+                    Next Step
+                  </Button>
+                )
+                : (
+                  <Button
+                    buttonType="primary"
+                    className="flex items-center justify-center px-4 py-2"
+                    onClick={handleCopy}
+                  >
+                    Copy ED2K Hashes
+                  </Button>
+                )}
+            </div>
+          </>
+        )}
+        {activeStep === 2 && (
+          <>
+            <StepDescription>
+              Search for a series using the provided search, then click on a result to add the copied hashes to AniDB,
+              then click on the &apos;Rescan Files&apos; button afterwards.
+            </StepDescription>
+            <div className="flex flex-col gap-y-2">
+              <Input
+                id="search"
+                value={searchText}
+                type="text"
+                placeholder="Search..."
+                onChange={e => handleSearch(e.target.value)}
+                startIcon={mdiMagnify}
+              />
+              <div className="w-full rounded-md border border-panel-border bg-panel-input p-4 capitalize">
+                <div className="shoko-scrollbar flex h-[9.5rem] flex-col gap-y-1 overflow-x-clip overflow-y-scroll rounded-md bg-panel-input pr-2 ">
+                  {initRef.current || searchResults.isError || searchResults.isFetching
+                    ? (
+                      <div className="flex h-full items-center justify-center">
+                        <Icon path={mdiLoading} size={3} spin className="text-panel-text-primary" />
+                      </div>
+                    )
+                    : (searchResults.data ?? []).map(result => (
+                      <a
+                        href={`https://anidb.net/anime/${result.ID}/release/add`}
+                        key={result.ID}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="flex items-center justify-between"
+                        onClick={() => setClickedLink(true)}
+                      >
+                        <div className="line-clamp-1">{result.Title}</div>
+                        <div className="text-panel-text-primary">
+                          <Icon path={mdiOpenInNew} size={0.833} />
+                        </div>
+                      </a>
+                    ))}
+                </div>
+              </div>
+            </div>
+            <div className="flex justify-end gap-x-2.5">
+              <Button
+                buttonType="secondary"
+                className="flex items-center justify-center px-4 py-2"
+                onClick={handlePreviousStep}
+              >
+                Previous Step
+              </Button>
+              <Button
+                buttonType="primary"
+                className="flex items-center justify-center px-4 py-2"
+                disabled={!clickedLink}
+                onClick={rescanFiles}
+              >
+                Rescan Files
+              </Button>
+            </div>
+          </>
+        )}
       </div>
     </ModalPanel>
   );

--- a/src/components/Utilities/Unrecognized/ItemCount.tsx
+++ b/src/components/Utilities/Unrecognized/ItemCount.tsx
@@ -6,7 +6,8 @@ const ItemCount = ({ filesCount, series = false }: { filesCount: number, series?
       {filesCount}
       &nbsp;
     </span>
-    {series ? 'Series' : 'Files'}
+    {series && 'Series'}
+    {!series && (filesCount === 1 ? 'File' : 'Files')}
   </div>
 );
 

--- a/src/components/Utilities/Unrecognized/Title.tsx
+++ b/src/components/Utilities/Unrecognized/Title.tsx
@@ -17,7 +17,7 @@ const Title = () => (
     <div>|</div>
     <TabButton id="manually-linked-files" name="Manually Linked" />
     <div>|</div>
-    <TabButton id="ignored-files" name="Ignored Files" />
+    <TabButton id="ignored-files" name="Ignored" />
   </div>
 );
 

--- a/src/core/router/AuthenticatedRoute.tsx
+++ b/src/core/router/AuthenticatedRoute.tsx
@@ -1,6 +1,6 @@
 import React, { type JSX } from 'react';
 import { useSelector } from 'react-redux';
-import { Navigate } from 'react-router';
+import { Navigate, useLocation } from 'react-router';
 
 import { useGetInitStatusQuery } from '@/core/rtkQuery/splitV3Api/initApi';
 
@@ -11,13 +11,15 @@ type Props = {
 };
 
 function AuthenticatedRoute(props: Props) {
+  const location = useLocation();
+  const from = encodeURIComponent(location.pathname + location.search + location.hash);
   const isAuthenticated = useSelector((state: RootState) => state.apiSession.apikey !== '');
   const serverStatus = useGetInitStatusQuery();
   const serverState = serverStatus.data?.State ?? 2;
 
   return (serverState === 2 && isAuthenticated)
     ? props.children
-    : <Navigate to="/webui/login" replace />;
+    : <Navigate to={`/webui/login#?returnTo=${from}`} replace />;
 }
 
 export default AuthenticatedRoute;

--- a/src/core/router/AuthenticatedRoute.tsx
+++ b/src/core/router/AuthenticatedRoute.tsx
@@ -19,7 +19,7 @@ function AuthenticatedRoute(props: Props) {
 
   return (serverState === 2 && isAuthenticated)
     ? props.children
-    : <Navigate to={`/webui/login#?returnTo=${from}`} replace />;
+    : <Navigate to={from === '/' || from === '/webui/' ? '/webui/login' : `/webui/login#?returnTo=${from}`} replace />;
 }
 
 export default AuthenticatedRoute;

--- a/src/core/rtkQuery/splitV3Api/episodeApi.ts
+++ b/src/core/rtkQuery/splitV3Api/episodeApi.ts
@@ -34,6 +34,7 @@ const episodeApi = splitV3Api.injectEndpoints({
     // Get the Shoko.Server.API.v3.Models.Shoko.Files for the Shoko.Server.API.v3.Models.Shoko.Episode with the given episodeID.
     getEpisodeFiles: build.query<FileType[], EpisodeFilesQuery>({
       query: ({ episodeId, ...params }) => ({ url: `Episode/${episodeId}/File?includeAbsolutePaths=true`, params }),
+      providesTags: ['FileDeleted', 'FileMatched'],
     }),
     // Set the watched status on an episode
     postEpisodeWatched: build.mutation<void, { episodeId: string, watched: boolean }>({

--- a/src/core/rtkQuery/splitV3Api/episodeApi.ts
+++ b/src/core/rtkQuery/splitV3Api/episodeApi.ts
@@ -53,7 +53,7 @@ const episodeApi = splitV3Api.injectEndpoints({
           updateStats: true,
         },
       }),
-      invalidatesTags: ['SeriesEpisodes'],
+      invalidatesTags: ['SeriesEpisodes', 'SeriesAniDB'],
     }),
   }),
 });

--- a/src/core/rtkQuery/splitV3Api/fileApi.ts
+++ b/src/core/rtkQuery/splitV3Api/fileApi.ts
@@ -12,6 +12,7 @@ const fileApi = splitV3Api.injectEndpoints({
         params,
         method: 'DELETE',
       }),
+      invalidatesTags: ['SeriesEpisodes', 'SeriesUpdated', 'SeriesAniDB'],
     }),
 
     // Mark or unmark a file as ignored.

--- a/src/core/rtkQuery/splitV3Api/seriesApi.ts
+++ b/src/core/rtkQuery/splitV3Api/seriesApi.ts
@@ -53,6 +53,15 @@ const seriesApi = splitV3Api.injectEndpoints({
       invalidatesTags: ['SeriesUpdated'],
     }),
 
+    deleteSeriesTvdbLink: build.mutation<void, { seriesId: number, tvdbShowId: number }>({
+      query: ({ seriesId, tvdbShowId }) => ({
+        url: `Series/${seriesId}/TvDB`,
+        method: 'DELETE',
+        body: { ID: tvdbShowId },
+      }),
+      invalidatesTags: ['SeriesUpdated', 'SeriesAniDB', 'SeriesEpisodes'],
+    }),
+
     // Get a paginated list of Shoko.Server.API.v3.Models.Shoko.Series without local files, available to the current Shoko.Server.API.v3.Models.Shoko.User.
     getSeriesWithoutFiles: build.query<ListResultType<SeriesType[]>, PaginationType>({
       query: params => ({ url: 'Series/WithoutFiles', params }),
@@ -245,6 +254,7 @@ const seriesApi = splitV3Api.injectEndpoints({
 export const {
   useChangeSeriesImageMutation,
   useDeleteSeriesMutation,
+  useDeleteSeriesTvdbLinkMutation,
   useGetAniDBRecommendedAnimeQuery,
   useGetAniDBRelatedQuery,
   useGetAniDBSimilarQuery,

--- a/src/core/types/api/collection.ts
+++ b/src/core/types/api/collection.ts
@@ -12,6 +12,7 @@ export type CollectionGroupType = {
   SortName: string | null;
   Description: string | null;
   HasCustomName: boolean;
+  HasCustomDescription: boolean;
   Images: ImagesType;
   Name: string;
   Size: number;
@@ -20,6 +21,7 @@ export type CollectionGroupType = {
 
 export type GroupSizesType = SeriesSizesType & {
   SeriesTypes: GroupSizesSeriesTypesType;
+  SubGroups: number;
 };
 
 export type GroupSizesSeriesTypesType = {

--- a/src/core/types/api/series.ts
+++ b/src/core/types/api/series.ts
@@ -129,6 +129,7 @@ export type SeriesSizesType = {
   Local: SeriesSizesEpisodeCountsType;
   Watched: SeriesSizesEpisodeCountsType;
   Total: SeriesSizesEpisodeCountsType;
+  Missing: SeriesSizesReducedEpisodeCountsType;
 };
 
 export type SeriesSizesFileSourcesType = {
@@ -151,6 +152,11 @@ export type SeriesSizesEpisodeCountsType = {
   Trailers: number;
   Parodies: number;
   Others: number;
+};
+
+export type SeriesSizesReducedEpisodeCountsType = {
+  Episodes: number;
+  Specials: number;
 };
 
 export type SeriesRecommendedType = {

--- a/src/core/utilities/auto-match-logic.ts
+++ b/src/core/utilities/auto-match-logic.ts
@@ -154,8 +154,8 @@ export function detectShow(filePath: string | undefined | null): PathDetails | n
   return null;
 }
 
-export function findMostCommonShowName(showList: PathDetails[] | null): string {
-  if (!showList || showList.length === 0) {
+export function findMostCommonShowName(showList: (PathDetails | null)[]): string {
+  if (showList.length === 0) {
     return '';
   }
 

--- a/src/hooks/query.ts
+++ b/src/hooks/query.ts
@@ -1,0 +1,116 @@
+import { useCallback, useEffect, useState } from 'react';
+import { useLocation, useNavigate } from 'react-router';
+import { forEach } from 'lodash';
+
+export type Query<T> = T & Record<string, string | undefined>;
+
+export function useURLSearch<T extends Query<Record<string, unknown>>>(
+  isHash: boolean,
+): [value: T, setValue: (value: T | ((previousValue: T) => T), replace?: boolean) => void] {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const getQueryString = useCallback(() => (isHash ? location.hash.slice(1) : location.search), [location, isHash]);
+  const [[search, value], setSearch] = useState(() => {
+    const currentSearch = getQueryString();
+    const currentValue = parseQuery<T>(currentSearch);
+    return [currentSearch, currentValue];
+  });
+
+  const setValueAndModifyHistory = useCallback(
+    (valueOrFn: T | ((previousValue: T) => T), replace: boolean = false): void => {
+      const query = new URLSearchParams();
+      const nextValue = typeof valueOrFn === 'function' ? valueOrFn(value) : valueOrFn;
+      forEach(nextValue, (val, key) => {
+        if (val !== undefined) query.set(key, val);
+      });
+      const queryString = query.toString();
+      let nextTo = location.pathname;
+      if (isHash) {
+        nextTo += location.search + (queryString ? `#?${queryString}` : '');
+      } else {
+        nextTo += (queryString ? `#?${queryString}` : '') + location.hash;
+      }
+      navigate(nextTo, { replace });
+    },
+    [navigate, location, value, isHash],
+  );
+
+  useEffect(() => {
+    const currentSearch = getQueryString();
+    if (currentSearch !== search) {
+      setSearch([currentSearch, parseQuery<T>(currentSearch)]);
+    }
+  }, [search, getQueryString]);
+
+  return [value, setValueAndModifyHistory];
+}
+
+export function useURLParameter(
+  key: string,
+  initialValue: string,
+  isHash?: boolean,
+): [value: string, setValue: (value: string | null, replace?: boolean) => void];
+export function useURLParameter(
+  key: string,
+  initialValue?: string | null,
+  isHash?: boolean,
+): [value: string | null, setValue: (value: string | null, replace?: boolean) => void];
+export function useURLParameter(
+  key: string,
+  initialValue: string | null = null,
+  isHash: boolean = false,
+): [value: string | null, setValue: (value: string | null, replace?: boolean) => void] {
+  const [query, setQuery] = useURLSearch(isHash);
+  const currentValue = query[key] || initialValue;
+
+  const setQueryParameter = useCallback((value: string | null, replace: boolean = false) => {
+    setQuery(prev => ({ ...prev, [key]: value === null ? undefined : value }), replace);
+  }, [key, setQuery]);
+
+  return [currentValue, setQueryParameter];
+}
+
+export const useQuery = <T extends Query<Record<string, unknown>>>() => useURLSearch<T>(false);
+
+export const useHashQuery = <T extends Query<Record<string, unknown>>>() => useURLSearch<T>(true);
+
+export function useQueryParameter(
+  key: string,
+): [value: string | null, setValue: (value: string | null, replace?: boolean) => void];
+export function useQueryParameter(
+  key: string,
+  initialValue: string,
+): [value: string, setValue: (value: string | null, replace?: boolean) => void];
+export function useQueryParameter(
+  key: string,
+  initialValue?: string | null,
+): [value: string | null, setValue: (value: string | null, replace?: boolean) => void];
+export function useQueryParameter(
+  key: string,
+  initialValue?: string | null,
+): [value: string | null, setValue: (value: string | null, replace?: boolean) => void] {
+  return useURLParameter(key, initialValue, false);
+}
+
+export function useHashQueryParameter(
+  key: string,
+): [value: string | null, setValue: (value: string | null, replace?: boolean) => void];
+export function useHashQueryParameter(
+  key: string,
+  initialValue: string,
+): [value: string, setValue: (value: string | null, replace?: boolean) => void];
+export function useHashQueryParameter(
+  key: string,
+  initialValue?: string | null,
+): [value: string | null, setValue: (value: string | null, replace?: boolean) => void];
+export function useHashQueryParameter(
+  key: string,
+  initialValue?: string | null,
+): [value: string | null, setValue: (value: string | null, replace?: boolean) => void] {
+  return useURLParameter(key, initialValue, true);
+}
+
+function parseQuery<T extends Query<Record<string, unknown>>>(queryString: string): T {
+  const query = new URLSearchParams(queryString);
+  return Object.fromEntries(query.entries()) as T;
+}

--- a/src/hooks/useMainPoster.ts
+++ b/src/hooks/useMainPoster.ts
@@ -4,7 +4,7 @@ import type { CollectionGroupType } from '@/core/types/api/collection';
 import type { ImageType } from '@/core/types/api/common';
 import type { SeriesType } from '@/core/types/api/series';
 
-function useMainPoster(target: SeriesType | CollectionGroupType): ImageType | null {
+function useMainPoster(target: SeriesType | CollectionGroupType | null | undefined): ImageType | null {
   return useMemo(() => {
     const posters = target?.Images?.Posters ?? [];
     return posters.find(poster => poster.Preferred) ?? posters[0] ?? null;

--- a/src/pages/collection/Series.tsx
+++ b/src/pages/collection/Series.tsx
@@ -98,7 +98,13 @@ const Series = () => {
             <BackgroundImagePlaceholderDiv
               image={mainPoster}
               className="h-[25.75rem] w-[18.188rem] rounded drop-shadow-md"
-            />
+            >
+              {(series.AniDB?.Restricted ?? false) && (
+                <div className="absolute bottom-0 left-0 flex w-full justify-center bg-panel-background-overlay py-1.5 text-sm font-semibold text-panel-text opacity-100 transition-opacity group-hover:opacity-0">
+                  18+ Adults Only
+                </div>
+              )}
+            </BackgroundImagePlaceholderDiv>
             <div className="flex w-full max-w-[56.25rem] grow flex-col gap-y-2">
               <div className="flex justify-between">
                 <div className="flex gap-x-2">

--- a/src/pages/collection/Series.tsx
+++ b/src/pages/collection/Series.tsx
@@ -27,9 +27,7 @@ import {
 } from '@/core/rtkQuery/splitV3Api/seriesApi';
 import useMainPoster from '@/hooks/useMainPoster';
 
-import type { CollectionGroupType } from '@/core/types/api/collection';
 import type { ImageType } from '@/core/types/api/common';
-import type { SeriesDetailsType } from '@/core/types/api/series';
 import type { TagType } from '@/core/types/api/tags';
 
 const SeriesTab = ({ icon, text, to }) => (
@@ -66,16 +64,16 @@ const Series = () => {
   const { scrollRef } = useOutletContext<{ scrollRef: React.RefObject<HTMLDivElement> }>();
 
   const seriesData = useGetSeriesQuery({ seriesId: seriesId!, includeDataFrom: ['AniDB'] }, { skip: !seriesId });
-  const series = useMemo(() => seriesData?.data ?? {} as SeriesDetailsType, [seriesData]);
+  const series = useMemo(() => seriesData?.data ?? null, [seriesData]);
   const imagesData = useGetSeriesImagesQuery({ seriesId: seriesId! }, { skip: !seriesId });
-  const images = useMemo(() => imagesData ?? {} as SeriesDetailsType, [imagesData]);
+  const images = useMemo(() => imagesData ?? null, [imagesData]);
   const mainPoster = useMainPoster(series);
   const tagsData = useGetSeriesTagsQuery({ seriesId: seriesId!, excludeDescriptions: true }, { skip: !seriesId });
   const tags: TagType[] = tagsData?.data ?? [] as TagType[];
-  const groupData = useGetGroupQuery({ groupId: series.IDs?.ParentGroup.toString() }, {
-    skip: !series.IDs?.ParentGroup,
+  const groupData = useGetGroupQuery({ groupId: series?.IDs?.ParentGroup.toString() ?? '' }, {
+    skip: !series?.IDs?.ParentGroup,
   });
-  const group = groupData?.data ?? {} as CollectionGroupType;
+  const group = groupData?.data ?? null;
 
   useEffect(() => {
     const allFanarts: ImageType[] = get(images, 'data.Fanarts', []);
@@ -87,7 +85,7 @@ const Series = () => {
     }
   }, [images, imagesData]);
 
-  if (!seriesId || !seriesData.isSuccess) return null;
+  if (!series || !seriesId || !seriesData.isSuccess) return null;
 
   return (
     <>
@@ -105,7 +103,7 @@ const Series = () => {
                     Entire Collection
                   </Link>
                   <Icon className="text-panel-icon" path={mdiChevronRight} size={1} />
-                  {group.Size > 1 && (
+                  {group && group.Size > 1 && (
                     <>
                       <Link
                         className="font-semibold text-panel-text-primary"

--- a/src/pages/collection/Series.tsx
+++ b/src/pages/collection/Series.tsx
@@ -63,7 +63,10 @@ const Series = () => {
 
   const { scrollRef } = useOutletContext<{ scrollRef: React.RefObject<HTMLDivElement> }>();
 
-  const seriesData = useGetSeriesQuery({ seriesId: seriesId!, includeDataFrom: ['AniDB'] }, { skip: !seriesId });
+  const seriesData = useGetSeriesQuery({ seriesId: seriesId!, includeDataFrom: ['AniDB'] }, {
+    refetchOnMountOrArgChange: false,
+    skip: !seriesId,
+  });
   const series = useMemo(() => seriesData?.data ?? null, [seriesData]);
   const imagesData = useGetSeriesImagesQuery({ seriesId: seriesId! }, { skip: !seriesId });
   const images = useMemo(() => imagesData ?? null, [imagesData]);

--- a/src/pages/collection/series/SeriesEpisodes.tsx
+++ b/src/pages/collection/series/SeriesEpisodes.tsx
@@ -10,7 +10,7 @@ import SeriesEpisode from '@/components/Collection/Series/SeriesEpisode';
 import Input from '@/components/Input/Input';
 import Select from '@/components/Input/Select';
 import ShokoPanel from '@/components/Panels/ShokoPanel';
-import { useLazyGetSeriesEpisodesInfiniteQuery } from '@/core/rtkQuery/splitV3Api/seriesApi';
+import { useGetSeriesQuery, useLazyGetSeriesEpisodesInfiniteQuery } from '@/core/rtkQuery/splitV3Api/seriesApi';
 
 const pageSize = 26;
 
@@ -23,6 +23,11 @@ const SeriesEpisodes = () => {
   const [episodeFilterHidden, setEpisodeFilterHidden] = useState('false');
   const [fetchingPage, setFetchingPage] = useState(false);
   const [fetchEpisodes, episodesData] = useLazyGetSeriesEpisodesInfiniteQuery();
+  const seriesData = useGetSeriesQuery({ seriesId: seriesId!, includeDataFrom: ['AniDB'] }, {
+    refetchOnMountOrArgChange: false,
+    skip: !seriesId,
+  });
+  const animeId = useMemo(() => seriesData?.data?.IDs.AniDB ?? 0, [seriesData]);
   const episodePages = episodesData.data?.pages ?? {};
   const episodeTotal = episodesData.data?.total ?? 0;
 
@@ -171,7 +176,7 @@ const SeriesEpisodes = () => {
                       className="flex flex-col rounded-md border border-panel-border bg-panel-background-transparent"
                       data-index={virtualItem.index}
                     >
-                      {item ? <SeriesEpisode episode={item} /> : (
+                      {item ? <SeriesEpisode animeId={animeId} episode={item} /> : (
                         // 332px is the minimum height of a loaded row
                         <div className="flex h-[332px] items-center justify-center p-8 text-panel-text-primary">
                           <Icon path={mdiLoading} spin size={3} />

--- a/src/pages/collection/series/SeriesOverview.tsx
+++ b/src/pages/collection/series/SeriesOverview.tsx
@@ -38,7 +38,10 @@ const MetadataLinks = ['AniDB', 'TMDB', 'TvDB', 'TraktTv'];
 const SeriesOverview = () => {
   const { seriesId } = useParams();
 
-  const seriesData = useGetSeriesQuery({ seriesId: seriesId!, includeDataFrom: ['AniDB'] }, { skip: !seriesId });
+  const seriesData = useGetSeriesQuery({ seriesId: seriesId!, includeDataFrom: ['AniDB'] }, {
+    refetchOnMountOrArgChange: false,
+    skip: !seriesId,
+  });
   const series = useMemo(() => seriesData?.data, [seriesData]);
   const nextUpEpisodeData = useNextUpEpisodeQuery({ seriesId: toNumber(seriesId) });
   const nextUpEpisode: EpisodeType = nextUpEpisodeData?.data ?? {} as EpisodeType;

--- a/src/pages/collection/series/SeriesOverview.tsx
+++ b/src/pages/collection/series/SeriesOverview.tsx
@@ -32,6 +32,9 @@ const NextUpEpisode = ({ nextUpEpisode }: { nextUpEpisode: EpisodeType }) => {
   );
 };
 
+// Links
+const MetadataLinks = ['AniDB', 'TMDB', 'TvDB', 'TraktTv'];
+
 const SeriesOverview = () => {
   const { seriesId } = useParams();
 
@@ -43,9 +46,6 @@ const SeriesOverview = () => {
   const related: SeriesAniDBRelatedType[] = relatedData?.data ?? [] as SeriesAniDBRelatedType[];
   const similarData = useGetAniDBSimilarQuery({ seriesId: seriesId! }, { skip: !seriesId });
   const similar: SeriesAniDBSimilarType[] = similarData?.data ?? [] as SeriesAniDBSimilarType[];
-
-  // Links
-  const metadataLinks = ['AniDB', 'TMDB', 'TvDB', 'TraktTv'];
 
   if (!seriesId || !series) return null;
 
@@ -68,11 +68,28 @@ const SeriesOverview = () => {
             transparent
           >
             <div className="flex flex-col gap-y-2">
-              {metadataLinks.map(site => (
-                <div className="rounded border border-panel-border bg-panel-background-alt px-4 py-3" key={site}>
-                  <SeriesMetadata site={site} id={series.IDs[site]} />
-                </div>
-              ))}
+              {MetadataLinks.map((site) => {
+                const idOrIds = series.IDs[site] as number | number[];
+                if (typeof idOrIds === 'number' || idOrIds.length === 0) {
+                  const id = typeof idOrIds === 'number' ? idOrIds : idOrIds[0] || 0;
+                  return (
+                    <div
+                      className="rounded border border-panel-border bg-panel-background-alt px-4 py-3"
+                      key={`${site}-${id}`}
+                    >
+                      <SeriesMetadata site={site} id={idOrIds} seriesId={series.IDs.ID} />
+                    </div>
+                  );
+                }
+                return idOrIds.map(id => (
+                  <div
+                    className="rounded border border-panel-border bg-panel-background-alt px-4 py-3"
+                    key={`${site}-${id}`}
+                  >
+                    <SeriesMetadata site={site} id={id} seriesId={series.IDs.ID} />
+                  </div>
+                ));
+              })}
             </div>
           </ShokoPanel>
         </div>

--- a/src/pages/dashboard/components/SeriesDetails.tsx
+++ b/src/pages/dashboard/components/SeriesDetails.tsx
@@ -25,7 +25,10 @@ function SeriesDetails(props: { series: SeriesType }): JSX.Element {
         <div className="pointer-events-none z-50 flex h-full bg-panel-background-transparent p-3 opacity-0 transition-opacity group-hover:pointer-events-auto group-hover:opacity-100" />
       </BackgroundImagePlaceholderDiv>
       <p className="mb-1 truncate text-center text-sm font-semibold" title={series.Name}>{series.Name}</p>
-      <p className="truncate text-center text-sm font-semibold opacity-65" title={`${series.Size} Files`}>
+      <p
+        className="truncate text-center text-sm font-semibold opacity-65"
+        title={`${series.Size} ${series.Size === 1 ? 'File' : 'Files'}`}
+      >
         {series.Size}
         &nbsp;
         {series.Size === 1 ? 'File' : 'Files'}

--- a/src/pages/dashboard/panels/UnrecognizedFiles.tsx
+++ b/src/pages/dashboard/panels/UnrecognizedFiles.tsx
@@ -46,7 +46,9 @@ function UnrecognizedFiles() {
           <div>
             <span className="text-panel-text-important">{files.List.length}</span>
             &nbsp;
-            <span>Files</span>
+            <span>
+              {files.List.length === 1 ? 'File' : 'Files'}
+            </span>
           </div>
         </div>
       }

--- a/src/pages/login/LoginPage.tsx
+++ b/src/pages/login/LoginPage.tsx
@@ -65,7 +65,7 @@ function LoginPage() {
     if (!status.data) setPollingInterval(500);
     else if (status.data?.State !== 1) setPollingInterval(0);
 
-    if (status.data?.State === 2 && apiSession.rememberUser && apiSession.apikey !== '') {
+    if (status.data?.State === 2 && apiSession.apikey !== '') {
       navigate(returnTo, { replace: true });
     }
   }, [status, apiSession, navigate, returnTo]);

--- a/src/pages/login/LoginPage.tsx
+++ b/src/pages/login/LoginPage.tsx
@@ -18,12 +18,12 @@ import { usePostAuthMutation } from '@/core/rtkQuery/splitApi/authApi';
 import { useGetRandomMetadataQuery } from '@/core/rtkQuery/splitV3Api/imageApi';
 import { useGetInitStatusQuery, useGetInitVersionQuery } from '@/core/rtkQuery/splitV3Api/initApi';
 import { ImageTypeEnum } from '@/core/types/api/common';
-import { useHashQuery } from '@/hooks/query';
+import { useHashQueryParameter } from '@/hooks/query';
 
 import type { RootState } from '@/core/store';
 
 function LoginPage() {
-  const [{ returnTo = '/', ...rest }, setHashQuery] = useHashQuery();
+  const [returnTo, setReturnTo] = useHashQueryParameter('returnTo', '/webui/');
   const navigate = useNavigate();
 
   const apiSession = useSelector((state: RootState) => state.apiSession);
@@ -45,7 +45,7 @@ function LoginPage() {
 
   const setRedirect = () => {
     if (seriesId === 0) return;
-    setHashQuery({ returnTo: `/webui/collection/series/${seriesId}`, ...rest });
+    setReturnTo(`/webui/collection/series/${seriesId}`);
   };
 
   useEffect(() => {

--- a/src/pages/login/LoginPage.tsx
+++ b/src/pages/login/LoginPage.tsx
@@ -18,10 +18,12 @@ import { usePostAuthMutation } from '@/core/rtkQuery/splitApi/authApi';
 import { useGetRandomMetadataQuery } from '@/core/rtkQuery/splitV3Api/imageApi';
 import { useGetInitStatusQuery, useGetInitVersionQuery } from '@/core/rtkQuery/splitV3Api/initApi';
 import { ImageTypeEnum } from '@/core/types/api/common';
+import { useHashQuery } from '@/hooks/query';
 
 import type { RootState } from '@/core/store';
 
 function LoginPage() {
+  const [{ returnTo = '/' }] = useHashQuery();
   const navigate = useNavigate();
 
   const apiSession = useSelector((state: RootState) => state.apiSession);
@@ -54,9 +56,9 @@ function LoginPage() {
     else if (status.data?.State !== 1) setPollingInterval(0);
 
     if (status.data?.State === 2 && apiSession.rememberUser && apiSession.apikey !== '') {
-      navigate('/', { replace: true });
+      navigate(returnTo, { replace: true });
     }
-  }, [status, apiSession, navigate]);
+  }, [status, apiSession, navigate, returnTo]);
 
   useEffect(() => {
     if (!get(version, 'data.Server', false)) return;
@@ -75,7 +77,7 @@ function LoginPage() {
       pass: password,
       device: 'web-ui',
       rememberUser,
-    }).unwrap().then(() => navigate('/'), error => console.error(error));
+    }).unwrap().then(() => navigate(returnTo), error => console.error(error));
   };
 
   const parsedVersion = useMemo(() => {

--- a/src/pages/utilities/UnrecognizedUtilityTabs/IgnoredFilesTab.tsx
+++ b/src/pages/utilities/UnrecognizedUtilityTabs/IgnoredFilesTab.tsx
@@ -113,7 +113,8 @@ function IgnoredFilesTab() {
                 {selectedRows.length}
                 &nbsp;
               </span>
-              Files Selected
+              {selectedRows.length === 1 ? 'File' : 'Files'}
+              &nbsp; Selected
             </div>
           </div>
         </ShokoPanel>

--- a/src/pages/utilities/UnrecognizedUtilityTabs/LinkFilesTab.tsx
+++ b/src/pages/utilities/UnrecognizedUtilityTabs/LinkFilesTab.tsx
@@ -27,11 +27,7 @@ import ItemCount from '@/components/Utilities/Unrecognized/ItemCount';
 import MenuButton from '@/components/Utilities/Unrecognized/MenuButton';
 import RangeFillModal from '@/components/Utilities/Unrecognized/RangeFillModal';
 import Title from '@/components/Utilities/Unrecognized/Title';
-import {
-  useGetFilesQuery,
-  usePostFileLinkManyMutation,
-  usePostFileLinkOneMutation,
-} from '@/core/rtkQuery/splitV3Api/fileApi';
+import { usePostFileLinkManyMutation, usePostFileLinkOneMutation } from '@/core/rtkQuery/splitV3Api/fileApi';
 import {
   useDeleteSeriesMutation,
   useGetSeriesAniDBEpisodesQuery,
@@ -237,7 +233,6 @@ function LinkFilesTab() {
     pageSize: 0,
     includeMissing: 'true',
   }, { skip: !selectedSeries.ID || selectedSeries.Type === SeriesTypeEnum.Unknown });
-  const filesQuery = useGetFilesQuery({ pageSize: 0, includeUnrecognized: 'only' });
 
   const showDataMap = useMemo(() =>
     new Map(
@@ -529,7 +524,6 @@ function LinkFilesTab() {
       }),
     ]);
 
-    await filesQuery.refetch();
     setLoading({ isLinking: false, isLinkingRunning: false, createdNewSeries: false });
     setLinks([]);
     setSelectedSeries({} as SeriesAniDBSearchResult);

--- a/src/pages/utilities/UnrecognizedUtilityTabs/LinkFilesTab.tsx
+++ b/src/pages/utilities/UnrecognizedUtilityTabs/LinkFilesTab.tsx
@@ -200,7 +200,7 @@ const AnimeSelectPanel = (
         inputClassName="!p-4"
         startIcon={mdiMagnify}
       />
-      <div className="flex flex-col overflow-y-auto rounded-md border border-panel-border bg-panel-input p-4">
+      <div className="flex grow flex-col overflow-y-auto rounded-md border border-panel-border bg-panel-input p-4">
         {searchRows}
       </div>
     </div>

--- a/src/pages/utilities/UnrecognizedUtilityTabs/ManuallyLinkedTab.tsx
+++ b/src/pages/utilities/UnrecognizedUtilityTabs/ManuallyLinkedTab.tsx
@@ -160,7 +160,8 @@ const Menu = (
         {Object.keys(selectedFiles).length}
         &nbsp;
       </span>
-      Files Selected
+      {Object.keys(selectedFiles).length === 1 ? 'File' : 'Files'}
+      &nbsp; Selected
     </div>
   );
 };

--- a/src/pages/utilities/UnrecognizedUtilityTabs/UnrecognizedTab.tsx
+++ b/src/pages/utilities/UnrecognizedUtilityTabs/UnrecognizedTab.tsx
@@ -182,7 +182,8 @@ const Menu = (
         {selectedRows.length}
         &nbsp;
       </span>
-      Files Selected
+      {selectedRows.length === 1 ? 'File' : 'Files'}
+      &nbsp; Selected
       <DeleteFilesModal
         show={showConfirmModal}
         selectedFiles={selectedRows}

--- a/src/pages/utilities/UnrecognizedUtilityTabs/UnrecognizedTab.tsx
+++ b/src/pages/utilities/UnrecognizedUtilityTabs/UnrecognizedTab.tsx
@@ -162,13 +162,13 @@ const Menu = (
         <MenuButton
           onClick={() => setSeriesSelectModal(true)}
           icon={mdiFileDocumentOutline}
-          name="Copy All ED2K Hashes"
+          name="Add All To AniDB"
         />
       </TransitionDiv>
       <TransitionDiv className="absolute flex grow gap-x-4" show={selectedRows.length !== 0}>
         <MenuButton onClick={() => rescanFiles(true)} icon={mdiDatabaseSearchOutline} name="Rescan" />
         <MenuButton onClick={() => rehashFiles(true)} icon={mdiDatabaseSyncOutline} name="Rehash" />
-        <MenuButton onClick={() => setSeriesSelectModal(true)} icon={mdiFileDocumentOutline} name="Copy ED2K Hash" />
+        <MenuButton onClick={() => setSeriesSelectModal(true)} icon={mdiFileDocumentOutline} name="Add To AniDB" />
         <MenuButton onClick={ignoreFiles} icon={mdiEyeOffOutline} name="Ignore" />
         <MenuButton onClick={showDeleteConfirmation} icon={mdiMinusCircleOutline} name="Delete" highlight />
         <MenuButton
@@ -259,12 +259,15 @@ function UnrecognizedTab() {
 
   const getED2KLinks = useEventCallback(() => {
     const fileList = selectedRows.length > 0 ? selectedRows : files.List;
-    return fileList.map(
-      file =>
-        `ed2k://|file|${
-          file.Locations[0]?.RelativePath?.split(/[\\/]+/g).pop() ?? ''
-        }|${file.Size}|${file.Hashes.ED2K}|/`,
-    );
+    return {
+      fileIds: fileList.map(file => file.ID),
+      links: fileList.map(
+        file =>
+          `ed2k://|file|${
+            file.Locations[0]?.RelativePath?.split(/[\\/]+/g).pop() ?? ''
+          }|${file.Size}|${file.Hashes.ED2K}|/`,
+      ),
+    };
   });
 
   return (
@@ -335,7 +338,10 @@ function UnrecognizedTab() {
 
       <AvDumpSeriesSelectModal
         show={seriesSelectModal}
-        onClose={() => setSeriesSelectModal(false)}
+        onClose={(refresh?: boolean) => {
+          if (refresh) table.resetRowSelection();
+          setSeriesSelectModal(false);
+        }}
         getLinks={getED2KLinks}
       />
     </>

--- a/src/pages/utilities/UnrecognizedUtilityTabs/UnrecognizedTab.tsx
+++ b/src/pages/utilities/UnrecognizedUtilityTabs/UnrecognizedTab.tsx
@@ -228,6 +228,9 @@ function UnrecognizedTab() {
   const table = useReactTable({
     data: files.List,
     columns,
+    getRowId(row) {
+      return row.ID.toString();
+    },
     getCoreRowModel: getCoreRowModel(),
     filterFns: {
       fuzzy: fuzzyFilter,


### PR DESCRIPTION
- `misc`: Fix up method signatures.

- `misc`: Add more fields to collection group type.

- `feat`: Add proper redirect when unauthenticated.

- `misc`: Add a redirect when clicking on the series name in the top-right corner on the login screen, for easier removal of incorrect TvDB/TDMB auto-links.

- `misc`: Display the episode type on the card, making it easier to distinguish which type it is if you have multiple types in view, or just in general.

- `misc`: Remove the duplicate 'files' ending for the 'ignored files' tab in the unrecognized utility.

  It would previously read;
  "Unrecognized Files > Unrecognized | Manually Linked | Ignored Files"
  which have now been changed to;
  "Unrecognized Files > Unrecognized | Manually Linked | Ignored"

- `misc`: Remove empty files.

- `fix`: Don't try to refresh and discard files query before returning from the manually linking page to the unrecognized files utility. This was slowing the process down **a lot** while I was trying to mass manually link files. The files query on the unrecognized utility
  also might require different parameters the next time it renders so the response we got will be discarded anyways. :shrug:

- `misc`: Update the 'Add to AniDB' modal (previously known as the 'Copy ED2K Hashes' modal) to be more useful and less finicky.

  This adds a new button at the bottom to re-scan the files, fixes the stall
  search results from a previous search or use of the modal, and disables
  the copy button if no files are selected.

- `feat`: Add ability to remove TvDB links, and also make it display all links for a given site, since you want to delete the right link if you have multiple.

- `fix`: Fix missing stats for series.

- `misc`: Update series info to include the restricted flag and fix the air date and status if the start date is unknown.
  E.g.

  ![image](https://github.com/ShokoAnime/Shoko-WebUI/assets/7761729/e383deed-e702-42f4-b970-12d7ba101033) 
  ![image](https://github.com/ShokoAnime/Shoko-WebUI/assets/7761729/7fa95c9c-dde8-4f33-8461-9e31b26e0a7e)

- `fix`: Fix error rendering series page while data is fetching.

- `fix`: Fix navigation to login page while logged in not redirecting the user away from the login page.

- `fix`: Fix row selection on unrecognized table by changing the id selector for each row.

  **FINALLY!**

  No more shifting around the selection!

- `feat`: Add the ability to delete files for episodes on the series page using a confirm modal. Because what kind of monster have a single button to delete files without confirmation?

- `misc`: rename 'File Count' → 'Local' for better clarity of what it is. it is not files, and the count part is infer-able. it is for _local_ episodes.

- `fix`: Fix up the delete button so it matches the mock-up.

- `fix`: Fix AniDB Release Group link for files, and apply a band-aid to stop re-fetching the same data over and over… but only for series data.

- `fix`: Move restricted indicator from the series info panel to a in indicator on the poster per the new mock-up.

- `fix`: Move around the series info panels to align with the mock-up.

- `fix`: Fix up "Add Series to AniDB" modal to align more with the mock-up.

- `fix`: Fix "1 Files" when displayed number of files equals 1.