### PR TITLE
Fix episode view

### DIFF
--- a/src/pages/collection/series/SeriesEpisodes.tsx
+++ b/src/pages/collection/series/SeriesEpisodes.tsx
@@ -197,7 +197,7 @@ const SeriesEpisodes = () => {
                   }
                   return (
                     <div
-                      key={virtualItem.key}
+                      key={`${episodesData.requestId}-${virtualItem.key}`}
                       className="flex flex-col rounded-md border border-panel-border bg-panel-background-transparent"
                       data-index={virtualItem.index}
                     >


### PR DESCRIPTION
Fix Opening an entry and changing filter causes the first entry in the new filter to render as expanded. (issue #590)