### PR TITLE
Fix filters being cut off in Filters modal

### DIFF
--- a/src/core/react-query/filter/queries.ts
+++ b/src/core/react-query/filter/queries.ts
@@ -11,7 +11,7 @@ import type { SeriesType } from '@/core/types/api/series';
 export const useFiltersQuery = (enabled = false) =>
   useQuery<ListResultType<CollectionFilterType>>({
     queryKey: ['filter', 'all'],
-    queryFn: () => axios.get('Filter'),
+    queryFn: () => axios.get('Filter', { params: { pageSize: 0 } }),
     enabled,
   });
 


### PR DESCRIPTION
...because pageSize not being set means it will return 10 filters. Setting it to 0 for now as we assume it's fast enough and users don't have like 30+ filters.