### PR TITLE
Adds the time an AniDB ban is expected to expire to the modal

### DIFF
--- a/src/components/Layout/AniDBBanDetectionItem.tsx
+++ b/src/components/Layout/AniDBBanDetectionItem.tsx
@@ -4,6 +4,7 @@ import Icon from '@mdi/react';
 
 import ModalPanel from '@/components/Panels/ModalPanel';
 import { AniDBBanTypeEnum } from '@/core/types/signalr';
+import { dayjs } from '@/core/util';
 
 import type { AniDBBanItemType } from '@/core/types/signalr';
 
@@ -41,6 +42,10 @@ const AniDBBanDetectionItem = ({ banStatus, type }: Props) => {
             <span className="font-bold text-panel-text-important">temporarily banned</span>
             &nbsp;for excessive connection attempts. It happens and just means you’ll need to wait a bit for the
             temporary ban to expire.
+          </p>
+          <p>
+            Shoko will automatically check if this ban has expired at&nbsp;
+            {dayjs(banStatus.UpdateTime).add(banStatus.PauseTimeSecs, 's').format('HH:mm [on] dddd, MMMM DD[.]')}
           </p>
           <p>
             Click the link below to learn more and how you can minimize the chances of an AniDB Ban.

--- a/src/components/Layout/AniDBBanDetectionItem.tsx
+++ b/src/components/Layout/AniDBBanDetectionItem.tsx
@@ -22,6 +22,8 @@ const AniDBBanDetectionItem = ({ banStatus, type }: Props) => {
     return null;
   }
 
+  const expiryTime = dayjs(banStatus.UpdateTime).add(banStatus.PauseTimeSecs, 's');
+
   return (
     <>
       <div className="flex cursor-pointer items-center gap-x-2.5 font-semibold" onClick={() => setModalOpen(true)}>
@@ -44,8 +46,11 @@ const AniDBBanDetectionItem = ({ banStatus, type }: Props) => {
             temporary ban to expire.
           </p>
           <p>
-            Shoko will automatically check if this ban has expired at&nbsp;
-            {dayjs(banStatus.UpdateTime).add(banStatus.PauseTimeSecs, 's').format('HH:mm [on] dddd, MMMM DD[.]')}
+            Shoko will automatically check your ban status on:
+            <br />
+            <span className="font-bold text-panel-text-important">{expiryTime.format('MMMM DD')}</span>
+            &nbsp;at&nbsp;
+            <span className="font-bold text-panel-text-important">{expiryTime.format('h:mm A')}</span>
           </p>
           <p>
             Click the link below to learn more and how you can minimize the chances of an AniDB Ban.


### PR DESCRIPTION
Following on from my bodged work in the server... The reason should now be clear!

This change should provide an estimate of when an AniDB ban will be tested for expiry in the ban information modal. Screenshot of what it looks like as per the below.

![2024-04-03_22-39-49_firefox](https://github.com/ShokoAnime/Shoko-WebUI/assets/13705865/916ae875-5237-4da0-8d9c-67fed8db5716)



Whilst I have tested this and it works fine when everything is set from the initial `AniDB:OnConnected` event, I stress that as I've managed to get myself banned again, I can't definitively confirm that this also works as expected after the WebUI receives an updated ban status.