### PR TITLE
Truncates anime title on login page as rationally expected

### DIFF
--- a/src/pages/login/LoginPage.tsx
+++ b/src/pages/login/LoginPage.tsx
@@ -257,7 +257,7 @@ function LoginPage() {
                   : (
                     <>
                       <span className="truncate" title={seriesName}>{seriesName}</span>
-                      <Icon className="text-panel-text-primary shrink-0" path={mdiOpenInNew} size={1} />
+                      <Icon className="shrink-0 text-panel-text-primary" path={mdiOpenInNew} size={1} />
                     </>
                   )}
               </div>

--- a/src/pages/login/LoginPage.tsx
+++ b/src/pages/login/LoginPage.tsx
@@ -244,7 +244,7 @@ function LoginPage() {
             <div className="flex gap-x-2">
               <div
                 className={cx(
-                  'flex gap-x-2 items-center font-semibold truncate max-w-[23rem]',
+                  'flex gap-x-2 items-center font-semibold max-w-[23rem]',
                   seriesId && 'cursor-pointer text-panel-text-primary',
                 )}
                 onClick={setRedirect}
@@ -256,8 +256,8 @@ function LoginPage() {
                   ? 'Series Not Found'
                   : (
                     <>
-                      {seriesName}
-                      <Icon className="text-panel-text-primary" path={mdiOpenInNew} size={1} />
+                      <span className="truncate" title={seriesName}>{seriesName}</span>
+                      <Icon className="text-panel-text-primary shrink-0" path={mdiOpenInNew} size={1} />
                     </>
                   )}
               </div>


### PR DESCRIPTION
Prevents the icon from shrinking & ensures that the series name truncates as logically expected.

With changes applied, hovering over the anime title now looks like the below:
![2024-04-10_14-35-05_firefox](https://github.com/ShokoAnime/Shoko-WebUI/assets/13705865/956a7dd2-f95f-448b-811f-0a708c879b5c)

_(Please don't make me inspect element to get the full anime title when it's truncated :^) )_