### PR TITLE
Fix: Collection settings tweaked to match what server expects

### DIFF
--- a/src/pages/settings/tabs/CollectionSettings.tsx
+++ b/src/pages/settings/tabs/CollectionSettings.tsx
@@ -77,11 +77,11 @@ const CollectionSettings = () => {
       name: 'Same Setting',
     },
     altSetting: {
-      id: 'alternative setting',
+      id: 'alternate setting',
       name: 'Alternative Setting',
     },
     altVersion: {
-      id: 'alternative version',
+      id: 'alternate version',
       name: 'Alternative Version',
     },
     parentStory: {


### PR DESCRIPTION
As was originally reported on Discord in [#support](https://discord.com/channels/96234011612958720/96235819366371328/1227599299165290528) earlier today, the `Alternative Setting` setting appeared to be non-functional...

Thought this was a server issue as the tag wasn't being excluded in the logs either, but upon further inspection, it looks like it's just down to a typo for how it was set in the WebUI (unless this has been an issue for a long time?)