### PR TITLE
Selectively clear localStorage

### DIFF
--- a/src/core/localStorage.ts
+++ b/src/core/localStorage.ts
@@ -21,7 +21,8 @@ export const loadState = (): RootState => {
     }
     const apiSession: unknown = JSON.parse(apiSessionString);
     if (!isApiSession(apiSession)) {
-      globalThis.localStorage.clear();
+      globalThis.localStorage.removeItem('apiSession');
+      globalThis.localStorage.removeItem('theme');
       return {} as RootState;
     }
     return { ...serializedState, apiSession };

--- a/src/core/localStorage.ts
+++ b/src/core/localStorage.ts
@@ -22,7 +22,6 @@ export const loadState = (): RootState => {
     const apiSession: unknown = JSON.parse(apiSessionString);
     if (!isApiSession(apiSession)) {
       globalThis.localStorage.removeItem('apiSession');
-      globalThis.localStorage.removeItem('theme');
       return {} as RootState;
     }
     return { ...serializedState, apiSession };

--- a/src/core/store.ts
+++ b/src/core/store.ts
@@ -15,7 +15,7 @@ const rootReducer = (state: ReturnType<typeof combinedReducer>, action: UnknownA
     globalThis.localStorage.removeItem('apiSession');
     globalThis.localStorage.removeItem('theme');
 
-    globalThis.sessionStorage.removeItem('state');
+    globalThis.sessionStorage.clear();
     return combinedReducer(undefined, action);
   }
   return combinedReducer(state, action);

--- a/src/core/store.ts
+++ b/src/core/store.ts
@@ -12,8 +12,10 @@ import type { UnknownAction } from 'redux';
 
 const rootReducer = (state: ReturnType<typeof combinedReducer>, action: UnknownAction) => {
   if (action.type === Events.AUTH_LOGOUT) { // check for action type
-    globalThis.localStorage.clear();
-    globalThis.sessionStorage.clear();
+    globalThis.localStorage.removeItem('apiSession');
+    globalThis.localStorage.removeItem('theme');
+
+    globalThis.sessionStorage.removeItem('state');
     return combinedReducer(undefined, action);
   }
   return combinedReducer(state, action);

--- a/src/core/store.ts
+++ b/src/core/store.ts
@@ -13,8 +13,6 @@ import type { UnknownAction } from 'redux';
 const rootReducer = (state: ReturnType<typeof combinedReducer>, action: UnknownAction) => {
   if (action.type === Events.AUTH_LOGOUT) { // check for action type
     globalThis.localStorage.removeItem('apiSession');
-    globalThis.localStorage.removeItem('theme');
-
     globalThis.sessionStorage.clear();
     return combinedReducer(undefined, action);
   }


### PR DESCRIPTION
I've been wondering why I had to always keep on re-authorizing swagger given that it's meant to have persistent authorization... realised it's more likely than not due to the entirety of `localStorage` being cleared on WebUI updates, rather than selectively clearing entries. (which, after testing my changes, is confirmed to _probably_ be the cause)

`apiSession` & `theme` appear to be the only keys saved in `localStorage` across the repo. Not too sure if it's intended for the theme to be cleared as well, but I'll keep the behaviour the same for now and leave this as a draft PR.