### PR TITLE
Fix: Prevent setting migrations failing

### DIFF
--- a/src/core/patches.ts
+++ b/src/core/patches.ts
@@ -14,23 +14,19 @@ export const webuiSettingsPatches = {
   },
   6: (oldWebuiSettings) => {
     const webuiSettings = oldWebuiSettings;
-    if (webuiSettings?.collection) {
-      delete webuiSettings.collection.list.showRandomPoster;
-      delete webuiSettings.collection.poster.showRandomPoster;
-      webuiSettings.collection.image = {
-        showRandomPoster: (oldWebuiSettings?.collection?.list?.showRandomPoster
-          || oldWebuiSettings?.collection?.poster?.showRandomPoster)
+    delete webuiSettings.collection.list.showRandomPoster;
+    delete webuiSettings.collection.poster.showRandomPoster;
+    webuiSettings.collection.image = {
+      showRandomPoster:
+        (oldWebuiSettings.collection.list.showRandomPoster || oldWebuiSettings.collection.poster.showRandomPoster)
           ?? false,
-        showRandomFanart: false,
-      };
-    }
+      showRandomFanart: false,
+    };
     return { ...webuiSettings, settingsRevision: 6 };
   },
   7: (oldWebuiSettings) => {
     const webuiSettings = oldWebuiSettings;
-    if (webuiSettings?.collection?.image) {
-      webuiSettings.collection.image.useThumbnailFallback = false;
-    }
+    webuiSettings.collection.image.useThumbnailFallback = false;
     return { ...webuiSettings, settingsRevision: 7 };
   },
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/core/patches.ts
+++ b/src/core/patches.ts
@@ -14,19 +14,23 @@ export const webuiSettingsPatches = {
   },
   6: (oldWebuiSettings) => {
     const webuiSettings = oldWebuiSettings;
-    delete webuiSettings.collection.list.showRandomPoster;
-    delete webuiSettings.collection.poster.showRandomPoster;
-    webuiSettings.collection.image = {
-      showRandomPoster:
-        (oldWebuiSettings?.collection?.list?.showRandomPoster || oldWebuiSettings?.collection?.poster?.showRandomPoster)
+    if (webuiSettings?.collection) {
+      delete webuiSettings.collection.list.showRandomPoster;
+      delete webuiSettings.collection.poster.showRandomPoster;
+      webuiSettings.collection.image = {
+        showRandomPoster: (oldWebuiSettings?.collection?.list?.showRandomPoster
+          || oldWebuiSettings?.collection?.poster?.showRandomPoster)
           ?? false,
-      showRandomFanart: false,
-    };
+        showRandomFanart: false,
+      };
+    }
     return { ...webuiSettings, settingsRevision: 6 };
   },
   7: (oldWebuiSettings) => {
     const webuiSettings = oldWebuiSettings;
-    webuiSettings.collection.image.useThumbnailFallback = false;
+    if (webuiSettings?.collection?.image) {
+      webuiSettings.collection.image.useThumbnailFallback = false;
+    }
     return { ...webuiSettings, settingsRevision: 7 };
   },
   // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
Started (the proper) tests by getting my WebUI_Settings in a similar state to what was raised as causing an issue in #support... When setting the browser debugger to pause on the returns of the patches... It didn't seem to ever pause!

My debug instance seems to have started working when using these changes.