### PR TITLE
Fix: Hide EditSeriesModal on route change

### DIFF
--- a/src/components/Collection/Series/EditSeriesModal.tsx
+++ b/src/components/Collection/Series/EditSeriesModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import cx from 'classnames';
 import { map } from 'lodash';
@@ -51,6 +51,8 @@ const EditSeriesModal = () => {
   const onClose = useEventCallback(() => {
     dispatch(setSeriesId(-1));
   });
+
+  useEffect(() => onClose, [onClose]);
 
   const seriesId = useSelector((state: RootState) => state.modals.editSeries.seriesId);
 


### PR DESCRIPTION
This fix will, as a byproduct, cause an extra call of `onClose` whenever the EditSeriesModal component mounts, and not just unmounts. I wouldn't imagine that this should cause any issues at least given that it's effectively a no-op.