### PR TITLE
Feat: Add edit group modal

### DIFF
--- a/src/components/Collection/Group/EditGroupModal.tsx
+++ b/src/components/Collection/Group/EditGroupModal.tsx
@@ -1,0 +1,75 @@
+import React, { useEffect, useState } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import cx from 'classnames';
+import { map } from 'lodash';
+
+import NameTab from '@/components/Collection/Group/EditGroupTabs/NameTab';
+import SeriesTab from '@/components/Collection/Group/EditGroupTabs/SeriesTab';
+import ModalPanel from '@/components/Panels/ModalPanel';
+import { setGroupId } from '@/core/slices/modals/editGroup';
+import useEventCallback from '@/hooks/useEventCallback';
+
+import type { RootState } from '@/core/store';
+
+const tabs = {
+  name: 'Name',
+  series: 'Series',
+};
+
+const renderTab = (activeTab: string, groupId: number) => {
+  if (groupId === -1) {
+    return null;
+  }
+
+  switch (activeTab) {
+    case 'series':
+      return <SeriesTab groupId={groupId} />;
+    case 'name':
+    default:
+      return <NameTab groupId={groupId} />;
+  }
+};
+
+const EditGroupModal = () => {
+  const dispatch = useDispatch();
+
+  const onClose = useEventCallback(() => {
+    dispatch(setGroupId(-1));
+  });
+
+  useEffect(() => onClose, [onClose]);
+
+  const groupId = useSelector((state: RootState) => state.modals.editGroup.groupId);
+
+  const [activeTab, setActiveTab] = useState<keyof typeof tabs>('name');
+
+  return (
+    <ModalPanel show={groupId !== -1} onRequestClose={onClose} header="Edit Group" size="md" noPadding noGap>
+      <div className="flex h-[26rem] flex-row gap-x-6 p-6">
+        <div className="flex shrink-0 gap-y-6 font-semibold">
+          <div className="flex flex-col gap-y-1">
+            {map(tabs, (value: string, key: keyof typeof tabs) => (
+              <div
+                className={cx(
+                  activeTab === key
+                    ? 'w-[12rem] text-center bg-panel-menu-item-background p-3 rounded-lg text-panel-menu-item-text cursor-pointer'
+                    : 'w-[12rem] text-center p-3 rounded-lg hover:bg-panel-menu-item-background-hover cursor-pointer',
+                )}
+                key={key}
+                onClick={() => setActiveTab(key)}
+              >
+                {value}
+              </div>
+            ))}
+          </div>
+        </div>
+        <div className="border-r border-panel-border" />
+        <div className="grow">
+          {renderTab(activeTab, groupId)}
+        </div>
+      </div>
+    </ModalPanel>
+  );
+};
+
+export default EditGroupModal;

--- a/src/components/Collection/Group/EditGroupTabs/NameTab.tsx
+++ b/src/components/Collection/Group/EditGroupTabs/NameTab.tsx
@@ -12,7 +12,7 @@ type Props = {
   groupId: number;
 };
 
-const NameTab = ({ groupId }: Props) => {
+const NameTab = React.memo(({ groupId }: Props) => {
   const {
     data: groupData,
     isError: groupError,
@@ -133,6 +133,6 @@ const NameTab = ({ groupId }: Props) => {
       )}
     </div>
   );
-};
+});
 
 export default NameTab;

--- a/src/components/Collection/Group/EditGroupTabs/NameTab.tsx
+++ b/src/components/Collection/Group/EditGroupTabs/NameTab.tsx
@@ -24,7 +24,7 @@ const NameTab = React.memo(({ groupId }: Props) => {
     isError: seriesError,
     isFetching: seriesFetching,
     isSuccess: seriesSuccess,
-  } = useGroupSeriesQuery({ groupId });
+  } = useGroupSeriesQuery(groupId);
 
   const [groupName, setGroupName] = useState(groupData?.Name ?? '');
   useEffect(() => {

--- a/src/components/Collection/Group/EditGroupTabs/NameTab.tsx
+++ b/src/components/Collection/Group/EditGroupTabs/NameTab.tsx
@@ -24,7 +24,7 @@ const NameTab = React.memo(({ groupId }: Props) => {
     isError: seriesError,
     isFetching: seriesFetching,
     isSuccess: seriesSuccess,
-  } = useGroupSeriesQuery(groupId);
+  } = useGroupSeriesQuery({ groupId });
 
   const [groupName, setGroupName] = useState(groupData?.Name ?? '');
   useEffect(() => {

--- a/src/components/Collection/Group/EditGroupTabs/NameTab.tsx
+++ b/src/components/Collection/Group/EditGroupTabs/NameTab.tsx
@@ -1,0 +1,138 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { mdiCheckUnderlineCircleOutline, mdiCloseCircleOutline, mdiPencilCircleOutline } from '@mdi/js';
+import cx from 'classnames';
+import { useToggle } from 'usehooks-ts';
+
+import Input from '@/components/Input/Input';
+import { usePatchGroupMutation } from '@/core/react-query/group/mutations';
+import { useGroupQuery, useGroupSeriesQuery } from '@/core/react-query/group/queries';
+import useEventCallback from '@/hooks/useEventCallback';
+
+type Props = {
+  groupId: number;
+};
+
+const NameTab = ({ groupId }: Props) => {
+  const {
+    data: groupData,
+    isError: groupError,
+    isFetching: groupFetching,
+    isSuccess: groupSuccess,
+  } = useGroupQuery(groupId);
+  const {
+    data: seriesData,
+    isError: seriesError,
+    isFetching: seriesFetching,
+    isSuccess: seriesSuccess,
+  } = useGroupSeriesQuery(groupId);
+
+  const [groupName, setGroupName] = useState(groupData?.Name ?? '');
+  useEffect(() => {
+    setGroupName(groupData?.Name ?? '');
+  }, [groupData?.Name]);
+
+  const [nameEditable, toggleNameEditable] = useToggle(false);
+
+  const { mutate: renameGroupMutation } = usePatchGroupMutation();
+  const renameGroup = useEventCallback(() => {
+    if (groupName !== groupData?.Name) {
+      renameGroupMutation(
+        {
+          seriesId: 0, // Hack to avoid creating a new mutation...
+          groupId,
+          operations: [
+            { op: 'replace', path: 'Name', value: groupName },
+            { op: 'replace', path: 'HasCustomName', value: 'true' },
+          ],
+        },
+      );
+    }
+    toggleNameEditable();
+  });
+
+  const updateName = useEventCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    setGroupName(e.target.value);
+  });
+
+  const resetName = useEventCallback(() => {
+    toggleNameEditable();
+    setGroupName(groupData?.Name ?? '');
+  });
+
+  const nameInputIcons = useMemo(() => {
+    if (!nameEditable || groupFetching || seriesFetching) {
+      return [{
+        icon: mdiPencilCircleOutline,
+        className: 'text-panel-text-primary',
+        onClick: toggleNameEditable,
+        tooltip: 'Edit name',
+      }];
+    }
+
+    if (!(groupSuccess && seriesSuccess)) return [];
+
+    return [
+      {
+        icon: mdiCloseCircleOutline,
+        className: 'text-panel-text-danger',
+        onClick: resetName,
+        tooltip: 'Cancel',
+      },
+      {
+        icon: mdiCheckUnderlineCircleOutline,
+        className: 'text-panel-text-success',
+        onClick: renameGroup,
+        tooltip: 'Confirm',
+      },
+    ];
+  }, [
+    groupFetching,
+    groupSuccess,
+    nameEditable,
+    renameGroup,
+    resetName,
+    seriesFetching,
+    seriesSuccess,
+    toggleNameEditable,
+  ]);
+
+  return (
+    <div className="flex h-full flex-col">
+      {(groupError || seriesError) && (
+        <div className="m-auto text-lg font-semibold text-panel-text-danger">
+          Group & Series data could not be loaded!
+        </div>
+      )}
+
+      <Input
+        id="group-name"
+        type="text"
+        onChange={updateName}
+        value={groupName}
+        placeholder={(groupFetching || seriesFetching) ? 'Loading...' : undefined}
+        label="Name"
+        className="mb-4"
+        inputClassName={cx(nameInputIcons.length > 1 ? 'pr-[5rem]' : 'pr-12', 'truncate')}
+        endIcons={nameInputIcons}
+        disabled={!nameEditable}
+      />
+      {nameEditable && (
+        <div className="flex cursor-pointer overflow-y-auto rounded-lg border border-panel-border bg-panel-input p-6">
+          <div className="shoko-scrollbar flex grow flex-col gap-y-2 overflow-y-auto bg-panel-input pr-4">
+            {seriesData?.map(series => (
+              <div
+                className="flex justify-between last:border-none hover:text-panel-text-primary"
+                key={series.IDs.ID}
+                onClick={() => setGroupName(series.Name)}
+              >
+                <div>{series.Name}</div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default NameTab;

--- a/src/components/Collection/Group/EditGroupTabs/SeriesTab.tsx
+++ b/src/components/Collection/Group/EditGroupTabs/SeriesTab.tsx
@@ -1,0 +1,117 @@
+import React from 'react';
+import type { PlacesType } from 'react-tooltip';
+import { mdiArrowRightThinCircleOutline, mdiLoading, mdiStarCircleOutline } from '@mdi/js';
+import Icon from '@mdi/react';
+import cx from 'classnames';
+
+import { useCreateGroupMutation, usePatchGroupMutation } from '@/core/react-query/group/mutations';
+import { useGroupQuery, useGroupSeriesQuery } from '@/core/react-query/group/queries';
+import { invalidateQueries } from '@/core/react-query/queryClient';
+import useEventCallback from '@/hooks/useEventCallback';
+
+type Props = {
+  groupId: number;
+};
+
+const SeriesTab = ({ groupId }: Props) => {
+  const {
+    data: groupData,
+    isError: groupError,
+    isPending: groupPending,
+    isSuccess: groupSuccess,
+  } = useGroupQuery(groupId);
+  const {
+    data: seriesData,
+    isError: seriesError,
+    isPending: seriesPending,
+    isSuccess: seriesSuccess,
+  } = useGroupSeriesQuery(groupId);
+
+  const { mutate: moveToNewGroupMutation } = useCreateGroupMutation();
+  const { mutate: setGroupMainSeriesMutation } = usePatchGroupMutation();
+
+  const moveSeriesToNewGroup = useEventCallback((seriesId: number) => {
+    moveToNewGroupMutation(seriesId, {
+      onSuccess: () => {
+        invalidateQueries(['group', groupId]);
+        invalidateQueries(['group-series', groupId]);
+      },
+    });
+  });
+
+  const setMainSeries = useEventCallback((seriesId: number) => {
+    if (groupData!.IDs.MainSeries !== seriesId) {
+      setGroupMainSeriesMutation({
+        groupId,
+        seriesId,
+        operations: [{ op: 'replace', path: 'PreferredSeriesID', value: seriesId }],
+      }, {
+        onSuccess: () => {
+          invalidateQueries(['group', groupId]);
+          invalidateQueries(['group-series', groupId]);
+        },
+      });
+    }
+  });
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="flex overflow-y-auto rounded-lg border border-panel-border bg-panel-input p-6">
+        <div className="shoko-scrollbar flex grow flex-col gap-y-2 overflow-y-auto bg-panel-input pr-4">
+          {(seriesPending || groupPending) && (
+            <Icon
+              path={mdiLoading}
+              size={3}
+              className="my-auto self-center text-panel-text-primary"
+              spin
+            />
+          )}
+          {(seriesError || groupError) && (
+            <span className="my-auto self-center text-panel-text-danger">Error, please refresh!</span>
+          )}
+          {(seriesSuccess && groupSuccess) && seriesData.map((series) => {
+            const isMainSeries = series.IDs.ID === groupData?.IDs.MainSeries;
+
+            const baseTooltipAttribs = {
+              'data-tooltip-id': 'tooltip',
+              'data-tooltip-place': 'top' as PlacesType,
+              'data-tooltip-delay-show': 500,
+            };
+            const mainSeriesTooltip = isMainSeries
+              ? {}
+              : { ...baseTooltipAttribs, 'data-tooltip-content': 'Set as main series' };
+            const moveToNewGroupTooltip = { ...baseTooltipAttribs, 'data-tooltip-content': 'Move series to new group' };
+
+            return (
+              <div
+                className="flex justify-between gap-x-2 last:border-none hover:text-panel-text-primary"
+                key={series.IDs.ID}
+              >
+                <div className="grow select-none">{series.Name}</div>
+                <div
+                  className={cx(
+                    'shrink-0',
+                    isMainSeries ? 'text-panel-icon-warning opacity-65' : 'text-panel-icon-action cursor-pointer',
+                  )}
+                  {...mainSeriesTooltip}
+                  onClick={() => setMainSeries(series.IDs.ID)}
+                >
+                  <Icon path={mdiStarCircleOutline} size={1} />
+                </div>
+                <div
+                  className="shrink-0 cursor-pointer text-panel-icon-action"
+                  {...moveToNewGroupTooltip}
+                  onClick={() => moveSeriesToNewGroup(series.IDs.ID)}
+                >
+                  <Icon path={mdiArrowRightThinCircleOutline} size={1} />
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default SeriesTab;

--- a/src/components/Collection/Group/EditGroupTabs/SeriesTab.tsx
+++ b/src/components/Collection/Group/EditGroupTabs/SeriesTab.tsx
@@ -57,7 +57,12 @@ const SeriesTab = React.memo(({ groupId }: Props) => {
   return (
     <div className="flex h-full flex-col">
       <div className="flex overflow-y-auto rounded-lg border border-panel-border bg-panel-input p-6">
-        <div className="shoko-scrollbar flex grow flex-col gap-y-2 overflow-y-auto bg-panel-input pr-4">
+        <div
+          className={cx(
+            'shoko-scrollbar flex grow flex-col gap-y-2 overflow-y-auto bg-panel-input',
+            (seriesSuccess && seriesData.length > 9) && 'pr-4',
+          )}
+        >
           {(seriesPending || groupPending) && (
             <Icon
               path={mdiLoading}

--- a/src/components/Collection/Group/EditGroupTabs/SeriesTab.tsx
+++ b/src/components/Collection/Group/EditGroupTabs/SeriesTab.tsx
@@ -25,7 +25,7 @@ const SeriesTab = React.memo(({ groupId }: Props) => {
     isError: seriesError,
     isPending: seriesPending,
     isSuccess: seriesSuccess,
-  } = useGroupSeriesQuery(groupId);
+  } = useGroupSeriesQuery({ groupId, sorted: true });
 
   const { mutate: moveToNewGroupMutation } = useCreateGroupMutation();
   const { mutate: setGroupMainSeriesMutation } = usePatchGroupMutation();

--- a/src/components/Collection/Group/EditGroupTabs/SeriesTab.tsx
+++ b/src/components/Collection/Group/EditGroupTabs/SeriesTab.tsx
@@ -13,7 +13,7 @@ type Props = {
   groupId: number;
 };
 
-const SeriesTab = ({ groupId }: Props) => {
+const SeriesTab = React.memo(({ groupId }: Props) => {
   const {
     data: groupData,
     isError: groupError,
@@ -112,6 +112,6 @@ const SeriesTab = ({ groupId }: Props) => {
       </div>
     </div>
   );
-};
+});
 
 export default SeriesTab;

--- a/src/components/Collection/Group/EditGroupTabs/SeriesTab.tsx
+++ b/src/components/Collection/Group/EditGroupTabs/SeriesTab.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import type { PlacesType } from 'react-tooltip';
 import { mdiArrowRightThinCircleOutline, mdiLoading, mdiStarCircleOutline } from '@mdi/js';
 import Icon from '@mdi/react';
@@ -25,7 +25,9 @@ const SeriesTab = React.memo(({ groupId }: Props) => {
     isError: seriesError,
     isPending: seriesPending,
     isSuccess: seriesSuccess,
-  } = useGroupSeriesQuery({ groupId, sorted: true });
+  } = useGroupSeriesQuery(groupId);
+
+  const sortedSeriesData = useMemo(() => seriesData?.sort((a, b) => (a.IDs.ID > b.IDs.ID ? 1 : -1)), [seriesData]);
 
   const { mutate: moveToNewGroupMutation } = useCreateGroupMutation();
   const { mutate: setGroupMainSeriesMutation } = usePatchGroupMutation();
@@ -74,7 +76,7 @@ const SeriesTab = React.memo(({ groupId }: Props) => {
           {(seriesError || groupError) && (
             <span className="my-auto self-center text-panel-text-danger">Error, please refresh!</span>
           )}
-          {(seriesSuccess && groupSuccess) && seriesData.map((series) => {
+          {(seriesSuccess && groupSuccess) && sortedSeriesData?.map((series) => {
             const isMainSeries = series.IDs.ID === groupData?.IDs.MainSeries;
 
             const baseTooltipAttribs = {

--- a/src/components/Collection/ListViewItem.tsx
+++ b/src/components/Collection/ListViewItem.tsx
@@ -19,6 +19,7 @@ import BackgroundImagePlaceholderDiv from '@/components/BackgroundImagePlacehold
 import { listItemSize } from '@/components/Collection/constants';
 import { useSeriesTagsQuery } from '@/core/react-query/series/queries';
 import { useSettingsQuery } from '@/core/react-query/settings/queries';
+import { setGroupId } from '@/core/slices/modals/editGroup';
 import { setSeriesId } from '@/core/slices/modals/editSeries';
 import { dayjs, formatThousand } from '@/core/util';
 import useEventCallback from '@/hooks/useEventCallback';
@@ -131,6 +132,12 @@ const ListViewItem = ({ groupExtras, isSeries, isSidebarOpen, item }: Props) => 
     dispatch(setSeriesId(('MainSeries' in item.IDs) ? item.IDs.MainSeries : item.IDs.ID));
   });
 
+  const editGroupModalCallback = useEventCallback((event: React.MouseEvent) => {
+    event.stopPropagation();
+    event.preventDefault();
+    dispatch(setGroupId(item.IDs.ParentGroup ?? item.IDs.TopLevelGroup));
+  });
+
   return (
     <div
       className="flex h-full shrink-0 grow flex-col content-center gap-y-3 rounded-lg border border-panel-border bg-panel-background p-6"
@@ -147,18 +154,16 @@ const ListViewItem = ({ groupExtras, isSeries, isSidebarOpen, item }: Props) => 
             zoomOnHover
           >
             <div className="pointer-events-none z-10 flex h-full bg-panel-background-poster-overlay p-3 opacity-0 transition-opacity group-hover:pointer-events-auto group-hover:opacity-100">
-              {(isSeries || item.Size === 1) && (
-                <div
-                  className="pointer-events-auto h-fit"
-                  onClick={editSeriesModalCallback}
-                >
-                  <Icon
-                    path={mdiPencilCircleOutline}
-                    size="2rem"
-                    className="text-panel-icon"
-                  />
-                </div>
-              )}
+              <div
+                className="pointer-events-auto h-fit"
+                onClick={(isSeries || item.Size === 1) ? editSeriesModalCallback : editGroupModalCallback}
+              >
+                <Icon
+                  path={mdiPencilCircleOutline}
+                  size="2rem"
+                  className="text-panel-icon"
+                />
+              </div>
             </div>
             {showGroupIndicator && groupCount > 1 && (
               <div className="absolute bottom-0 left-0 flex w-full justify-center rounded-bl-md bg-panel-background-overlay py-1.5 text-sm font-semibold opacity-100 transition-opacity group-hover:opacity-0">

--- a/src/components/Collection/PosterViewItem.tsx
+++ b/src/components/Collection/PosterViewItem.tsx
@@ -7,6 +7,7 @@ import { reduce } from 'lodash';
 
 import BackgroundImagePlaceholderDiv from '@/components/BackgroundImagePlaceholderDiv';
 import { useSettingsQuery } from '@/core/react-query/settings/queries';
+import { setGroupId } from '@/core/slices/modals/editGroup';
 import { setSeriesId } from '@/core/slices/modals/editSeries';
 import useEventCallback from '@/hooks/useEventCallback';
 import useMainPoster from '@/hooks/useMainPoster';
@@ -54,6 +55,12 @@ const PosterViewItem = ({ isSeries = false, item }: Props) => {
     dispatch(setSeriesId(('MainSeries' in item.IDs) ? item.IDs.MainSeries : item.IDs.ID));
   });
 
+  const editGroupModalCallback = useEventCallback((event: React.MouseEvent) => {
+    event.stopPropagation();
+    event.preventDefault();
+    dispatch(setGroupId(item.IDs.ParentGroup ?? item.IDs.TopLevelGroup));
+  });
+
   return (
     <Link to={viewRouteLink()}>
       <div
@@ -74,18 +81,16 @@ const PosterViewItem = ({ isSeries = false, item }: Props) => {
             </div>
           )}
           <div className="pointer-events-none z-10 flex h-full bg-panel-background-poster-overlay p-3 opacity-0 transition-opacity group-hover:pointer-events-auto group-hover:opacity-100">
-            {(isSeries || item.Size === 1) && (
-              <div
-                className="pointer-events-auto h-fit"
-                onClick={editSeriesModalCallback}
-              >
-                <Icon
-                  path={mdiPencilCircleOutline}
-                  size="2rem"
-                  className="text-panel-icon"
-                />
-              </div>
-            )}
+            <div
+              className="pointer-events-auto h-fit"
+              onClick={(isSeries || item.Size === 1) ? editSeriesModalCallback : editGroupModalCallback}
+            >
+              <Icon
+                path={mdiPencilCircleOutline}
+                size="2rem"
+                className="text-panel-icon"
+              />
+            </div>
           </div>
           {showGroupIndicator && !isSeries && groupCount > 1 && (
             <div className="absolute bottom-4 left-3 flex w-[90%] justify-center rounded-lg bg-panel-background-overlay py-2 text-sm font-semibold text-panel-text opacity-100 transition-opacity group-hover:opacity-0">

--- a/src/core/react-query/group/mutations.ts
+++ b/src/core/react-query/group/mutations.ts
@@ -14,6 +14,12 @@ import type { MoveSeriesGroupRequestType, PatchGroupRequestType } from '@/core/r
  * It should probably also invalidate the cache for:
  *  * Any series belonging to the "original" groups of a series.
  */
+const defaultInvalidations = (seriesId: number) => {
+  invalidateQueries(['series', seriesId, 'data']);
+  invalidateQueries(['series', seriesId, 'group']);
+  // TODO: Specifically fix this next invalidation to be less aggressive
+  invalidateQueries(['filter', 'preview']);
+};
 
 // Also the server isn't sending SeriesUpdated events for the group changes
 
@@ -21,8 +27,7 @@ export const usePatchGroupMutation = () =>
   useMutation({
     mutationFn: ({ groupId, operations }: PatchGroupRequestType) => axios.patch(`Group/${groupId}`, operations),
     onSuccess: (_, { seriesId }) => {
-      invalidateQueries(['series', seriesId, 'data']);
-      invalidateQueries(['series', seriesId, 'group']);
+      defaultInvalidations(seriesId);
       toast.success('Group updated!');
     },
   });
@@ -38,8 +43,7 @@ export const useCreateGroupMutation = () =>
         },
       ),
     onSuccess: (_, seriesId) => {
-      invalidateQueries(['series', seriesId, 'data']);
-      invalidateQueries(['series', seriesId, 'group']);
+      defaultInvalidations(seriesId);
       toast.success('Created new group!');
     },
   });
@@ -49,8 +53,7 @@ export const useMoveGroupMutation = () =>
     mutationFn: ({ groupId, seriesId }: MoveSeriesGroupRequestType) =>
       axios.patch(`Series/${seriesId}/Move/${groupId}`),
     onSuccess: (_, { seriesId }) => {
-      invalidateQueries(['series', seriesId, 'data']);
-      invalidateQueries(['series', seriesId, 'group']);
+      defaultInvalidations(seriesId);
       toast.success('Moved series into new group!');
     },
   });

--- a/src/core/react-query/group/queries.ts
+++ b/src/core/react-query/group/queries.ts
@@ -2,7 +2,7 @@ import { useInfiniteQuery, useQuery } from '@tanstack/react-query';
 
 import { axios } from '@/core/axios';
 
-import type { GroupSeriesRequestType, GroupsInfiniteRequestType } from '@/core/react-query/group/types';
+import type { GroupsInfiniteRequestType } from '@/core/react-query/group/types';
 import type { ListResultType } from '@/core/types/api';
 import type { CollectionGroupType } from '@/core/types/api/collection';
 import type { SeriesType } from '@/core/types/api/series';
@@ -34,10 +34,9 @@ export const useGroupsInfiniteQuery = (params: GroupsInfiniteRequestType) =>
     },
   });
 
-export const useGroupSeriesQuery = ({ enabled = true, groupId, sorted = false }: GroupSeriesRequestType) =>
+export const useGroupSeriesQuery = (groupId: number, enabled = true) =>
   useQuery<SeriesType[]>({
     queryKey: ['group-series', groupId],
     queryFn: () => axios.get(`Group/${groupId}/Series`),
-    select: data => (sorted ? data.sort((a, b) => (a.IDs.ID > b.IDs.ID ? 1 : -1)) : data),
     enabled,
   });

--- a/src/core/react-query/group/queries.ts
+++ b/src/core/react-query/group/queries.ts
@@ -5,6 +5,7 @@ import { axios } from '@/core/axios';
 import type { GroupsInfiniteRequestType } from '@/core/react-query/group/types';
 import type { ListResultType } from '@/core/types/api';
 import type { CollectionGroupType } from '@/core/types/api/collection';
+import type { SeriesType } from '@/core/types/api/series';
 
 export const useGroupQuery = (groupId: number, enabled = true) =>
   useQuery<CollectionGroupType>({
@@ -31,4 +32,11 @@ export const useGroupsInfiniteQuery = (params: GroupsInfiniteRequestType) =>
       if (!params.pageSize || lastPage.Total / params.pageSize <= lastPageParam) return undefined;
       return lastPageParam + 1;
     },
+  });
+
+export const useGroupSeriesQuery = (groupId: number, enabled = true) =>
+  useQuery<SeriesType[]>({
+    queryKey: ['group-series', groupId],
+    queryFn: () => axios.get(`Group/${groupId}/Series`),
+    enabled,
   });

--- a/src/core/react-query/group/queries.ts
+++ b/src/core/react-query/group/queries.ts
@@ -2,7 +2,7 @@ import { useInfiniteQuery, useQuery } from '@tanstack/react-query';
 
 import { axios } from '@/core/axios';
 
-import type { GroupsInfiniteRequestType } from '@/core/react-query/group/types';
+import type { GroupSeriesRequestType, GroupsInfiniteRequestType } from '@/core/react-query/group/types';
 import type { ListResultType } from '@/core/types/api';
 import type { CollectionGroupType } from '@/core/types/api/collection';
 import type { SeriesType } from '@/core/types/api/series';
@@ -34,9 +34,10 @@ export const useGroupsInfiniteQuery = (params: GroupsInfiniteRequestType) =>
     },
   });
 
-export const useGroupSeriesQuery = (groupId: number, enabled = true) =>
+export const useGroupSeriesQuery = ({ enabled = true, groupId, sorted = false }: GroupSeriesRequestType) =>
   useQuery<SeriesType[]>({
     queryKey: ['group-series', groupId],
     queryFn: () => axios.get(`Group/${groupId}/Series`),
+    select: data => (sorted ? data.sort((a, b) => (a.IDs.ID > b.IDs.ID ? 1 : -1)) : data),
     enabled,
   });

--- a/src/core/react-query/group/types.ts
+++ b/src/core/react-query/group/types.ts
@@ -18,3 +18,9 @@ export type MoveSeriesGroupRequestType = {
   seriesId: number;
   groupId: number;
 };
+
+export type GroupSeriesRequestType = {
+  groupId: number;
+  enabled?: boolean;
+  sorted?: boolean;
+};

--- a/src/core/react-query/group/types.ts
+++ b/src/core/react-query/group/types.ts
@@ -18,9 +18,3 @@ export type MoveSeriesGroupRequestType = {
   seriesId: number;
   groupId: number;
 };
-
-export type GroupSeriesRequestType = {
-  groupId: number;
-  enabled?: boolean;
-  sorted?: boolean;
-};

--- a/src/core/slices/modals.ts
+++ b/src/core/slices/modals.ts
@@ -1,6 +1,7 @@
 import { combineReducers } from '@reduxjs/toolkit';
 
 import browseFolderReducer from './modals/browseFolder';
+import editGroupReducer from './modals/editGroup';
 import editSeriesReducer from './modals/editSeries';
 import importFolderReducer from './modals/importFolder';
 import profileReducer from './modals/profile';
@@ -10,4 +11,5 @@ export default combineReducers({
   importFolder: importFolderReducer,
   profile: profileReducer,
   editSeries: editSeriesReducer,
+  editGroup: editGroupReducer,
 });

--- a/src/core/slices/modals/editGroup.ts
+++ b/src/core/slices/modals/editGroup.ts
@@ -1,0 +1,19 @@
+import { createSlice } from '@reduxjs/toolkit';
+
+import type { PayloadAction } from '@reduxjs/toolkit';
+
+const editGroupSlice = createSlice({
+  name: 'editGroup',
+  initialState: {
+    groupId: -1,
+  },
+  reducers: {
+    setGroupId(sliceState, action: PayloadAction<number>) {
+      sliceState.groupId = action.payload;
+    },
+  },
+});
+
+export const { setGroupId } = editGroupSlice.actions;
+
+export default editGroupSlice.reducer;

--- a/src/pages/collection/Collection.tsx
+++ b/src/pages/collection/Collection.tsx
@@ -8,6 +8,7 @@ import { useDebounceValue, useToggle } from 'usehooks-ts';
 import CollectionTitle from '@/components/Collection/CollectionTitle';
 import CollectionView from '@/components/Collection/CollectionView';
 import FilterSidebar from '@/components/Collection/Filter/FilterSidebar';
+import EditGroupModal from '@/components/Collection/Group/EditGroupModal';
 import EditSeriesModal from '@/components/Collection/Series/EditSeriesModal';
 import TimelineSidebar from '@/components/Collection/TimelineSidebar';
 import TitleOptions from '@/components/Collection/TitleOptions';
@@ -246,6 +247,7 @@ function Collection() {
         {isSeries && <TimelineSidebar series={timelineSeries} isFetching={seriesQuery.isPending} />}
       </div>
       <EditSeriesModal />
+      <EditGroupModal />
     </div>
   );
 }


### PR DESCRIPTION
This PR will most certainly require a proper review before merging 🙃 (my apologies)


From testing, things do at least seem to work 'okay'. My tests haven't included any nested groups at all, so I'm making no guarantees that things will work fine in this situation...

I'll also note that the SeriesTab's layout will look a little odd in terms of the amount of padding for any group with a single normal series, but additional empty series will only show a single series in the list as empty series aren't currently requested in the list of series.

It may also be worth giving consideration to either sorting the series list for the group by series ID, or forcing a ~500ms loading animation after a fetch starts for group data on the SeriesTab. As it currently stands, when changing the preferred series, the list is re-ordered and the visual jump is a little jarring.