### PR TITLE
Misc: Fetch all files belonging to manually linked series

### DIFF
--- a/src/pages/utilities/UnrecognizedUtilityTabs/ManuallyLinkedTab.tsx
+++ b/src/pages/utilities/UnrecognizedUtilityTabs/ManuallyLinkedTab.tsx
@@ -202,7 +202,7 @@ function ManuallyLinkedTab() {
   });
 
   const onExpand = async (id: number) => {
-    await prefetchSeriesFilesQuery(id, { include: ['XRefs'], include_only: ['ManualLinks'] });
+    await prefetchSeriesFilesQuery(id, { pageSize: 0, include: ['XRefs'], include_only: ['ManualLinks'] });
     await prefetchSeriesEpisodesInfiniteQuery(id, { pageSize: 0, includeMissing: 'true', includeDataFrom: ['AniDB'] });
   };
 


### PR DESCRIPTION
I *think* this might (naïvely) fix the issue that is screenshot below, as per the `#support` channel on Discord... But I can't test it as I have nothing manually linked, nor do I properly understand how the utilities table works.

I suspect that the performance implications of my tweak may present an issue, especially if someone were to collect different resolutions for the same episodes across a series like Meitantei Conan?

![image](https://github.com/ShokoAnime/Shoko-WebUI/assets/13705865/40dd09e0-bb28-48c8-bbaa-4f0d0e8aaeab)
![image](https://github.com/ShokoAnime/Shoko-WebUI/assets/13705865/ca6cc1f9-c327-4aa0-8679-86e74e93f3f9)
