### PR TITLE
Use clearer language for Episode on Deck when all eps watched

### DIFF
--- a/src/pages/collection/series/SeriesOverview.tsx
+++ b/src/pages/collection/series/SeriesOverview.tsx
@@ -145,7 +145,11 @@ const SeriesOverview = () => {
           >
             {nextUpEpisodeQuery.isSuccess && nextUpEpisodeQuery.data
               ? <EpisodeSummary seriesId={toNumber(seriesId)} episode={nextUpEpisodeQuery.data} nextUp />
-              : <div className="flex grow items-center justify-center font-semibold">No Episode Data Available!</div>}
+              : (
+                <div className="flex grow items-center justify-center font-semibold">
+                  All available episodes have already been watched
+                </div>
+              )}
           </ShokoPanel>
         </div>
       </div>


### PR DESCRIPTION
`No Episode Data Available!` sounds like there is missing metadata or something has gone wrong and should be fixed.

I think `All available episodes have already been watched` is more neutral and more accurately reflects the show viewing state to the user.