### PR TITLE
Fix Mark as Watched tooltip

### DIFF
--- a/src/components/Collection/Episode/EpisodeSummary.tsx
+++ b/src/components/Collection/Episode/EpisodeSummary.tsx
@@ -136,7 +136,7 @@ const EpisodeSummary = React.memo(
                       icon={mdiEyeCheckOutline}
                       active={!!episode.Watched}
                       onClick={handleMarkWatched}
-                      tooltip={`Mark ${episode.Watched ? 'Watched' : 'Unwatched'}`}
+                      tooltip={`Mark ${episode.Watched ? 'Unwatched' : 'Watched'}`}
                     />
                   )}
                   <StateButton


### PR DESCRIPTION
Tooltip was inverted, it would say `Mark as Unwatched` when hovering over the mark as watched button for an unwatched episode.