### PR TITLE
Minor Top Nav Tweaks

### DIFF
--- a/src/components/Layout/ExternalLinkMenuItem.tsx
+++ b/src/components/Layout/ExternalLinkMenuItem.tsx
@@ -20,7 +20,7 @@ const ExternalLinkMenuItem = React.memo(({
     data-tooltip-id="tooltip"
     data-tooltip-content={name}
   >
-    <Icon className="text-topnav-icon" path={icon} size={1} />
+    <Icon className="text-topnav-icon hover:text-topnav-icon-primary" path={icon} size={1} />
   </a>
 ));
 

--- a/src/components/Layout/ExternalLinkMenuItem.tsx
+++ b/src/components/Layout/ExternalLinkMenuItem.tsx
@@ -20,7 +20,7 @@ const ExternalLinkMenuItem = React.memo(({
     data-tooltip-id="tooltip"
     data-tooltip-content={name}
   >
-    <Icon className="text-topnav-icon hover:text-topnav-icon-primary" path={icon} size={1} />
+    <Icon className="text-topnav-icon transition-colors hover:text-topnav-icon-primary" path={icon} size={1} />
   </a>
 ));
 

--- a/src/components/Layout/LinkMenuItem.tsx
+++ b/src/components/Layout/LinkMenuItem.tsx
@@ -22,7 +22,8 @@ const LinkMenuItem = React.memo((props: LinkMenuItemProps) => {
       to={path}
       key={path.split('/')
         .pop()}
-      className={({ isActive }) => cx('flex items-center gap-x-3', isActive && 'text-topnav-text-primary')}
+      className={({ isActive }) =>
+        cx('flex items-center gap-x-3 hover:text-topnav-text-primary', isActive && 'text-topnav-text-primary')}
       onClick={onClick}
     >
       <Icon path={icon} size={1} />

--- a/src/components/Layout/LinkMenuItem.tsx
+++ b/src/components/Layout/LinkMenuItem.tsx
@@ -23,7 +23,10 @@ const LinkMenuItem = React.memo((props: LinkMenuItemProps) => {
       key={path.split('/')
         .pop()}
       className={({ isActive }) =>
-        cx('flex items-center gap-x-3 hover:text-topnav-text-primary', isActive && 'text-topnav-text-primary')}
+        cx(
+          'flex items-center gap-x-3 transition-colors hover:text-topnav-text-primary',
+          isActive && 'text-topnav-text-primary',
+        )}
       onClick={onClick}
     >
       <Icon path={icon} size={1} />

--- a/src/components/Layout/MenuItem.tsx
+++ b/src/components/Layout/MenuItem.tsx
@@ -13,7 +13,10 @@ export type MenuItemProps = {
 const MenuItem = React.memo(({ icon, id, isHighlighted, onClick, text }: MenuItemProps) => (
   <div
     key={id}
-    className={cx('flex items-center gap-x-3 cursor-pointer', isHighlighted && 'text-topnav-text-primary')}
+    className={cx(
+      'flex items-center gap-x-3 cursor-pointer hover:text-topnav-text-primary',
+      isHighlighted && 'text-topnav-text-primary',
+    )}
     onClick={onClick}
   >
     <Icon path={icon} size={1} />

--- a/src/components/Layout/MenuItem.tsx
+++ b/src/components/Layout/MenuItem.tsx
@@ -14,7 +14,7 @@ const MenuItem = React.memo(({ icon, id, isHighlighted, onClick, text }: MenuIte
   <div
     key={id}
     className={cx(
-      'flex items-center gap-x-3 cursor-pointer hover:text-topnav-text-primary',
+      'flex items-center gap-x-3 cursor-pointer transition-colors hover:text-topnav-text-primary',
       isHighlighted && 'text-topnav-text-primary',
     )}
     onClick={onClick}

--- a/src/components/Layout/TopNav.tsx
+++ b/src/components/Layout/TopNav.tsx
@@ -170,7 +170,7 @@ function TopNav() {
         <div className="mx-auto flex w-full max-w-[120rem] items-center justify-between p-6">
           <Link to="/webui/dashboard" className="flex items-center gap-x-3">
             <ShokoIcon className="w-20" />
-            <span className="mt-1 text-xl font-semibold text-header-text">Shoko</span>
+            <span className="mt-1 text-2xl font-semibold text-header-text">Shoko</span>
           </Link>
           <div className="flex items-center gap-x-6">
             <QueueCount />
@@ -191,10 +191,21 @@ function TopNav() {
               data-tooltip-content="Settings"
               data-tooltip-place="bottom"
             >
-              <Icon path={mdiCogOutline} size={1} />
+              <Icon
+                className="hover:text-header-icon-primary"
+                path={mdiCogOutline}
+                size={1}
+              />
             </NavLink>
-            <Button onClick={handleLogout} tooltip="Log out">
-              <Icon path={mdiLogout} size={1} />
+            <Button onClick={handleLogout}>
+              <Icon
+                className="hover:text-header-icon-primary"
+                data-tooltip-id="tooltip"
+                data-tooltip-content="Log out"
+                data-tooltip-place="bottom"
+                path={mdiLogout}
+                size={1}
+              />
             </Button>
           </div>
         </div>

--- a/src/components/Layout/TopNav.tsx
+++ b/src/components/Layout/TopNav.tsx
@@ -192,14 +192,14 @@ function TopNav() {
               data-tooltip-place="bottom"
             >
               <Icon
-                className="hover:text-header-icon-primary"
+                className="transition-colors hover:text-header-icon-primary"
                 path={mdiCogOutline}
                 size={1}
               />
             </NavLink>
             <Button onClick={handleLogout}>
               <Icon
-                className="hover:text-header-icon-primary"
+                className="transition-colors hover:text-header-icon-primary"
                 data-tooltip-id="tooltip"
                 data-tooltip-content="Log out"
                 data-tooltip-place="bottom"


### PR DESCRIPTION

![firefox_2024-08-20_15-51-33](https://github.com/user-attachments/assets/277dac0e-9601-40d4-a558-fc3f98a8214b)


- Slightly Increase "Shoko" text size to account for the larger logo
- Change the "Log Out" tooltip direction to match the "Settings" one
- Add hover colour to top nav links and icons