### PR TITLE
Fix Series Info Panel Text Overflow

### DIFF
--- a/src/components/Collection/Episode/EpisodeFiles.tsx
+++ b/src/components/Collection/Episode/EpisodeFiles.tsx
@@ -158,7 +158,7 @@ const EpisodeFiles = ({ anidbSeriesId, episodeFiles, episodeId }: Props) => {
                     <div className="flex items-center gap-x-2 font-semibold text-panel-text-primary">
                       <div className="metadata-link-icon AniDB" />
                       {ReleaseGroupName ?? 'Unknown'}
-                      &nbsp; (AniDB)
+                      &nbsp;(AniDB)
                       <Icon className="text-panel-icon-action" path={mdiOpenInNew} size={1} />
                     </div>
                   </a>

--- a/src/components/Collection/SeriesInfo.tsx
+++ b/src/components/Collection/SeriesInfo.tsx
@@ -26,12 +26,12 @@ const SeriesInfo = ({ series }: SeriesInfoProps) => {
       return 'Unknown';
     }
     if (endDate) {
-      if (startDate.format('MMM DD/YY') === endDate.format('MMM DD/YY')) {
-        return startDate.format('MMM DD/YY');
+      if (startDate.format('MMM DD, YYYY') === endDate.format('MMM DD, YYYY')) {
+        return startDate.format('MMM DD, YYYY');
       }
-      return `${startDate.format('MMM DD/YY')} - ${endDate.format('MMM DD/YY')}`;
+      return `${startDate.format('MMM DD, YYYY')} - ${endDate.format('MMM DD, YYYY')}`;
     }
-    return `${startDate.format('MMM DD/YY')} - Ongoing`;
+    return `${startDate.format('MMM DD, YYYY')} - Ongoing`;
   }, [startDate, endDate]);
 
   const status = useMemo(() => {
@@ -87,14 +87,14 @@ const SeriesInfo = ({ series }: SeriesInfoProps) => {
             {series?.Sizes.Total.Episodes}
             &nbsp;
             {series?.Sizes.Total.Episodes > 1
-              ? 'Eps'
-              : 'Ep'}
+              ? 'Episodes'
+              : 'Episode'}
             <span className="mx-1">|</span>
             {series?.Sizes.Total.Specials}
             &nbsp;
             {series?.Sizes.Total.Episodes > 1
-              ? 'Sps'
-              : 'Sp'}
+              ? 'Specials'
+              : 'Special'}
           </div>
         </div>
         <div className="flex justify-between capitalize">

--- a/src/components/Collection/SeriesInfo.tsx
+++ b/src/components/Collection/SeriesInfo.tsx
@@ -26,12 +26,12 @@ const SeriesInfo = ({ series }: SeriesInfoProps) => {
       return 'Unknown';
     }
     if (endDate) {
-      if (startDate.format('MMM DD, YYYY') === endDate.format('MMM DD, YYYY')) {
-        return startDate.format('MMM DD, YYYY');
+      if (startDate.format('MMM DD/YY') === endDate.format('MMM DD/YY')) {
+        return startDate.format('MMM DD/YY');
       }
-      return `${startDate.format('MMM DD, YYYY')} - ${endDate.format('MMM DD, YYYY')}`;
+      return `${startDate.format('MMM DD/YY')} - ${endDate.format('MMM DD/YY')}`;
     }
-    return `${startDate.format('MMM DD, YYYY')} - Ongoing`;
+    return `${startDate.format('MMM DD/YY')} - Ongoing`;
   }, [startDate, endDate]);
 
   const status = useMemo(() => {
@@ -51,57 +51,85 @@ const SeriesInfo = ({ series }: SeriesInfoProps) => {
       <div className="flex w-full flex-col gap-y-2">
         <div className="flex justify-between capitalize">
           <div className="font-semibold">Type</div>
-          {series?.AniDB?.Type}
+          <div className="truncate">
+            &nbsp;
+            {series?.AniDB?.Type}
+          </div>
         </div>
         <div className="flex justify-between capitalize">
           <div className="font-semibold">Source</div>
-          {overview.SourceMaterial}
+          <div className="truncate">
+            &nbsp;
+            {overview.SourceMaterial}
+          </div>
         </div>
         <div className="flex justify-between capitalize">
-          <div className="font-semibold">Air Date</div>
-          <div>
+          <div className="font-semibold">Airdate</div>
+          <div className="truncate">
+            &nbsp;
             {airDate}
           </div>
         </div>
         <div className="flex justify-between capitalize">
           <div className="font-semibold">Status</div>
           {/* TODO: Check if there are more status types */}
-          {status}
+          <div className="truncate">
+            &nbsp;
+            {status}
+          </div>
         </div>
       </div>
       <div className="flex w-full flex-col gap-y-2">
         <div className="flex justify-between capitalize">
           <div className="font-semibold">Episodes</div>
-          <div>
+          <div className="truncate">
+            &nbsp;
             {series?.Sizes.Total.Episodes}
-            &nbsp;Episodes
+            &nbsp;
+            {series?.Sizes.Total.Episodes > 1
+              ? 'Eps'
+              : 'Ep'}
             <span className="mx-1">|</span>
             {series?.Sizes.Total.Specials}
-            &nbsp;Specials
+            &nbsp;
+            {series?.Sizes.Total.Episodes > 1
+              ? 'Sps'
+              : 'Sp'}
           </div>
         </div>
         <div className="flex justify-between capitalize">
           <div className="font-semibold">Length</div>
-          {overview.RuntimeLength
-            ? `${dayjs.duration(convertTimeSpanToMs(overview.RuntimeLength)).asMinutes()} Minutes/Episode`
-            : '--'}
+          <div className="truncate">
+            &nbsp;
+            {overview.RuntimeLength
+              ? `${dayjs.duration(convertTimeSpanToMs(overview.RuntimeLength)).asMinutes()} Min/Ep`
+              : '--'}
+          </div>
         </div>
         <div className="flex justify-between capitalize">
           <div className="font-semibold">Season</div>
-          {overview?.FirstAirSeason
-            ? (
-              <Link
-                className="font-semibold text-panel-text-primary"
-                to={`/webui/collection/filter/${overview.FirstAirSeason.IDs.ID}`}
-              >
-                {overview.FirstAirSeason.Name}
-              </Link>
-            )
-            : '--'}
+          <div className="truncate">
+            &nbsp;
+            {overview?.FirstAirSeason
+              ? (
+                <Link
+                  className="font-semibold text-panel-text-primary"
+                  to={`/webui/collection/filter/${overview.FirstAirSeason.IDs.ID}`}
+                >
+                  {overview.FirstAirSeason.Name}
+                </Link>
+              )
+              : '--'}
+          </div>
         </div>
         <div className="flex justify-between capitalize">
           <div className="font-semibold">Studio</div>
-          <div>{overview?.Studios?.[0] ? overview?.Studios?.[0].Name : 'Studio Not Listed'}</div>
+          <div className="truncate">
+            &nbsp;
+            {overview?.Studios?.[0]
+              ? overview?.Studios?.[0].Name
+              : 'Studio Not Listed'}
+          </div>
         </div>
       </div>
     </>

--- a/src/components/Collection/SeriesTopPanel.tsx
+++ b/src/components/Collection/SeriesTopPanel.tsx
@@ -81,7 +81,7 @@ const SeriesTopPanel = React.memo(({ series }: SeriesSidePanelProps) => {
           className="!h-[14.5rem]"
           transparent
         >
-          <div className="grid h-32 grid-cols-1 gap-x-[4.5rem] gap-y-2 overflow-y-auto pr-2 text-base font-normal 2xl:grid-cols-2 2xl:pr-0">
+          <div className="shoko-scrollbar grid h-32 grid-cols-1 gap-x-12 gap-y-2 overflow-y-auto pr-2 text-base font-normal 2xl:grid-cols-2 2xl:pr-0">
             <SeriesInfo series={series} />
           </div>
         </ShokoPanel>


### PR DESCRIPTION
- enable truncate on info text (for extremely long studio names or 250%+ zoom)
- use shorthand for episodes/specials and the date to avoid truncation
- account for multi or single episode entries
- style the scrollbar
![firefox_2024-08-22_05-12-00](https://github.com/user-attachments/assets/a8eebbab-5b24-4755-83b0-094e16298b23)