### PR TITLE
Expose minimum server requirement in builds, discord, and GH releases

### DIFF
--- a/.github/workflows/Release-Dev-Auto.yml
+++ b/.github/workflows/Release-Dev-Auto.yml
@@ -81,7 +81,7 @@ jobs:
             **Version**: `${{ steps.semver.outputs.version_tag }}`
             **Minimum Server Version Required**: `${{ env.MIN_SERVER_REQUIREMENT }}`
 
-            Update from the Web UI or click [here](https://github.com/${{ github.repository }}/releases/tag/v${{ steps.semver.outputs.version_tag }}) to download!
+            Update from the Web UI or download it from this release!
 
             **Changes since last build**:
             ${{ env.CHANGELOG }}

--- a/.github/workflows/Release-Dev-Auto.yml
+++ b/.github/workflows/Release-Dev-Auto.yml
@@ -53,7 +53,13 @@ jobs:
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
 
-      - name: Create changelog
+      - name: Find Minimum Server Version
+        run: |
+          echo -e 'MIN_SERVER_REQUIREMENT=' >> $GITHUB_ENV
+          cat package.json | jq -r '.config."min-server-requirement"' | tr -d '\n' >> $GITHUB_ENV
+          echo -e '\n' >> $GITHUB_ENV
+
+      - name: Create Changelog
         run: |
           git log $(git describe --tags --abbrev=0)..HEAD --pretty=format:"* %B" > changelog.txt
           echo 'CHANGELOG<<CHANGELOG_END' >> $GITHUB_ENV
@@ -71,7 +77,14 @@ jobs:
           tag_name: v${{ steps.semver.outputs.version_tag }}
           prerelease: true
           fail_on_unmatched_files: true
-          body_path: ./changelog.txt
+          body: |
+            **Version**: `${{ steps.semver.outputs.version_tag }}`
+            **Minimum Server Version Required**: `${{ env.MIN_SERVER_REQUIREMENT }}`
+
+            Update from the Web UI or click [here](https://github.com/${{ github.repository }}/releases/tag/v${{ steps.semver.outputs.version_tag }}) to download!
+
+            **Changes since last build**:
+            ${{ env.CHANGELOG }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -90,6 +103,7 @@ jobs:
           embed-author-url: https://github.com/${{ github.repository }}
           embed-description: |
             **Version**: `${{ steps.semver.outputs.version_tag }}`
+            **Minimum Server Version Required**: `${{ env.MIN_SERVER_REQUIREMENT }}`
 
             Update from the Web UI or click [here](https://github.com/${{ github.repository }}/releases/tag/v${{ steps.semver.outputs.version_tag }}) to download!
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "name": "shoko-webui",
   "version": "2.1.0-dev.0",
+  "config": {
+    "min-server-requirement": "4.2.2.72"
+  },
   "private": true,
   "sideEffects": false,
   "engines": {

--- a/src/core/util.ts
+++ b/src/core/util.ts
@@ -19,7 +19,7 @@ export { default as dayjs } from 'dayjs';
 // Enables immer plugin to support Map and Set
 enableMapSet();
 
-const { DEV, VITE_APPVERSION, VITE_GITHASH } = import.meta.env;
+const { DEV, VITE_APPVERSION, VITE_GITHASH, VITE_MIN_SERVER_VERSION } = import.meta.env;
 
 export function uiVersion() {
   return DEV ? VITE_GITHASH : VITE_APPVERSION;
@@ -29,7 +29,7 @@ export function isDebug() {
   return DEV;
 }
 
-export const minimumSupportedServerVersion = '4.2.2.13';
+export const minimumSupportedServerVersion = VITE_MIN_SERVER_VERSION;
 
 export const parseServerVersion = (version: string) => {
   const semverVersion = semver.coerce(version)?.raw;

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -3,6 +3,7 @@
 interface ImportMetaEnv {
   readonly VITE_GITHASH: string;
   readonly VITE_APPVERSION: string;
+  readonly VITE_MIN_SERVER_VERSION: string;
   // more env variables...
 }
 /* eslint-disable-next-line  @typescript-eslint/consistent-type-definitions */

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -35,7 +35,7 @@ export default defineConfig(async () => {
 
   return {
     server: {
-      open: "/webui/",
+      open: '/webui/',
       port: 3000,
       proxy,
     },
@@ -49,7 +49,7 @@ export default defineConfig(async () => {
       chunkSizeWarningLimit: 2000
     },
     plugins: [react(), sentryPlugin, manualChunksPlugin()],
-    base: "/webui/"
+    base: '/webui/'
   };
 });
 
@@ -59,9 +59,9 @@ async function setupEnv(isDebug) {
 
   process.env.VITE_GITHASH = gitHash;
   process.env.VITE_APPVERSION = appVersion;
-  process.env.VITE_MIN_SERVER_VERSION = pkg.config["min-server-requirement"];
+  process.env.VITE_MIN_SERVER_VERSION = pkg.config['min-server-requirement'];
 
-  const output = JSON.stringify({ git: gitHash, package: appVersion, debug: isDebug, "min-server-requirement": pkg.config["min-server-requirement"] }, null, '  ');
+  const output = JSON.stringify({ git: gitHash, package: appVersion, debug: isDebug, 'min-server-requirement': pkg.config['min-server-requirement'] }, null, '  ');
   await writeFile('./public/version.json', output, 'utf8');
 
   return appVersion;

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -59,8 +59,9 @@ async function setupEnv(isDebug) {
 
   process.env.VITE_GITHASH = gitHash;
   process.env.VITE_APPVERSION = appVersion;
+  process.env.VITE_MIN_SERVER_VERSION = pkg.config["min-server-requirement"];
 
-  const output = JSON.stringify({ git: gitHash, package: appVersion, debug: isDebug }, null, '  ');
+  const output = JSON.stringify({ git: gitHash, package: appVersion, debug: isDebug, "min-server-requirement": pkg.config["min-server-requirement"] }, null, '  ');
   await writeFile('./public/version.json', output, 'utf8');
 
   return appVersion;


### PR DESCRIPTION

- Moved the min. server requirement to the `package.json`, making it easier to find when needed to be updated (impo), in addition to easier for both vite and the GH Action runner to programmatically find and use.

- Added the min. server requirement to the `version.json` produced and included with the builds, in addition to the discord embeds and GH pre-releases.