### PR TITLE
Remove "— written by" / "* Based on" Lines and Leftover BBCode From Series Descriptions

### DIFF
--- a/src/components/Collection/CleanDescription.tsx
+++ b/src/components/Collection/CleanDescription.tsx
@@ -3,6 +3,8 @@ import React, { useMemo } from 'react';
 // The question marks are there because people can't spell…
 const RemoveSummaryRegex = /\b(Sour?ce|Note|Summ?ary):([^\r\n]+|$)/mg;
 
+const RemoveWrittenByRegex = /^\u2014 ([^\r\n]+|$)/mg;
+
 const MultiSpacesRegex = /\s{2,}/g;
 
 const CleanMiscLinesRegex = /^(\*|--|~) /sg;
@@ -18,6 +20,7 @@ const CleanDescription = React.memo(({ className, text }: { text: string, classN
     const cleanedText = text
       .replaceAll(CleanMiscLinesRegex, '')
       .replaceAll(RemoveSummaryRegex, '')
+      .replaceAll(RemoveWrittenByRegex, '')
       .replaceAll(CleanMultiEmptyLinesRegex, '\n')
       .replaceAll(MultiSpacesRegex, ' ');
 

--- a/src/components/Collection/CleanDescription.tsx
+++ b/src/components/Collection/CleanDescription.tsx
@@ -5,6 +5,8 @@ const RemoveSummaryRegex = /\b(Sour?ce|Note|Summ?ary):([^\r\n]+|$)/mg;
 
 const RemoveWrittenByRegex = /^\u2014 ([^\r\n]+|$)/mg;
 
+const RemoveBBCodeRegex = /\[i\].*\[\/i\]/sg;
+
 const MultiSpacesRegex = /\s{2,}/g;
 
 const CleanMiscLinesRegex = /^(\*|--|~) /sg;
@@ -21,6 +23,7 @@ const CleanDescription = React.memo(({ className, text }: { text: string, classN
       .replaceAll(CleanMiscLinesRegex, '')
       .replaceAll(RemoveSummaryRegex, '')
       .replaceAll(RemoveWrittenByRegex, '')
+      .replaceAll(RemoveBBCodeRegex, '')
       .replaceAll(CleanMultiEmptyLinesRegex, '\n')
       .replaceAll(MultiSpacesRegex, ' ');
 

--- a/src/components/Collection/CleanDescription.tsx
+++ b/src/components/Collection/CleanDescription.tsx
@@ -3,13 +3,13 @@ import React, { useMemo } from 'react';
 // The question marks are there because people can't spell…
 const RemoveSummaryRegex = /\b(Sour?ce|Note|Summ?ary):([^\r\n]+|$)/mg;
 
-const RemoveWrittenByRegex = /^\u2014 ([^\r\n]+|$)/mg;
+const RemoveBasedOnWrittenByRegex = /^(\*|\u2014) ([^\r\n]+|$)/mg;
 
 const RemoveBBCodeRegex = /\[i\].*\[\/i\]/sg;
 
 const MultiSpacesRegex = /\s{2,}/g;
 
-const CleanMiscLinesRegex = /^(\*|--|~) /sg;
+const CleanMiscLinesRegex = /^(--|~) /sg;
 
 const CleanMultiEmptyLinesRegex = /\n{2,}/sg;
 
@@ -22,7 +22,7 @@ const CleanDescription = React.memo(({ className, text }: { text: string, classN
     const cleanedText = text
       .replaceAll(CleanMiscLinesRegex, '')
       .replaceAll(RemoveSummaryRegex, '')
-      .replaceAll(RemoveWrittenByRegex, '')
+      .replaceAll(RemoveBasedOnWrittenByRegex, '')
       .replaceAll(RemoveBBCodeRegex, '')
       .replaceAll(CleanMultiEmptyLinesRegex, '\n')
       .replaceAll(MultiSpacesRegex, ' ');


### PR DESCRIPTION
1. A significant amount of series contain text showing which anidb user wrote the description or what the anime is based on. This will remove that text.
![firefox_2024-08-30_17-29-56](https://github.com/user-attachments/assets/2cee2af4-725f-4913-ba36-4367751707cf)

2. In several rare instances, the anidb api will return descriptions containing BBCode. This will also strip out [i] tags and anything that they contain.
![firefox_2024-08-30_18-52-16](https://github.com/user-attachments/assets/f3099774-3ab9-444a-8796-bbd5134ccb5e)
