### PR TITLE
fix sorting of the manually linked files

### DIFF
--- a/src/components/Utilities/Unrecognized/ManuallyLinkedFilesRow.tsx
+++ b/src/components/Utilities/Unrecognized/ManuallyLinkedFilesRow.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { mdiOpenInNew } from '@mdi/js';
 import { Icon } from '@mdi/react';
 import cx from 'classnames';
-import { find, forEach, get, toNumber } from 'lodash';
+import { find, forEach, get, map, sortBy, toNumber } from 'lodash';
 
 import useRowSelection from '@/hooks/useRowSelection';
 
@@ -79,12 +79,19 @@ function ManuallyLinkedFilesRow(props: Props) {
           File
         </div>
       </div>
-      {files.map((file, index) => {
-        const episode = find(episodes, item => item.IDs.ID === get(file, 'SeriesIDs.0.EpisodeIDs.0.ID', 0))!;
-        const selected = rowSelection[file.ID];
-        const fileName = file.Locations?.[0].RelativePath.split(/[/\\]/g).pop() ?? '<missing file path>';
-
-        return (
+      {sortBy(
+        map(files, file =>
+          [
+            file,
+            find(episodes, item => item.IDs.ID === get(file, 'SeriesIDs.0.EpisodeIDs.0.ID', 0))!,
+            rowSelection[file.ID],
+            file.Locations?.[0].RelativePath.split(/[/\\]/g).pop() ?? '<missing file path>',
+          ] as const),
+        ([, episode]) => episode.AniDB!.Type,
+        ([, episode]) => episode.AniDB!.EpisodeNumber,
+        ([file]) => file.Created,
+      )
+        .map(([file, episode, selected, fileName], index) => (
           <div
             className={cx(
               'mt-2 border-panel-border border rounded-lg',
@@ -125,8 +132,7 @@ function ManuallyLinkedFilesRow(props: Props) {
               </div>
             </div>
           </div>
-        );
-      })}
+        ))}
     </div>
   );
 }


### PR DESCRIPTION
Fix sorting of the manually linked files by episode type, episode number, followed by file creation date.

If the manually linked components were refactored to use the episode endpoint first and foremost then we might have avoided to do this client-side sorting. But. I'm not going to put in the effort to refactor them all at this point in time, so this band-aid will do for now. At least until somebody puts in the time and effort to do the work.