### PR TITLE
Add  '🖋 Upload Theme' button to settings

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
   </head>
   <body>
     <!-- Theme must be loaded after main.css -->
-    <link rel="stylesheet" type="text/css" href="/api/v3/WebUI/Theme.css" />
+    <link id="theme-css" rel="stylesheet" type="text/css" href="/api/v3/WebUI/Theme.css" />
     <div id="modal-root"></div>
     <div id="app-root"></div>
     <script type="module" src="/src/main.tsx"></script>

--- a/src/core/react-query/webui/mutations.ts
+++ b/src/core/react-query/webui/mutations.ts
@@ -2,7 +2,22 @@ import { useMutation } from '@tanstack/react-query';
 
 import { axios } from '@/core/axios';
 
+import type { WebuiTheme } from '@/core/types/api/webui';
+
 export const useUpdateWebuiMutation = () =>
   useMutation({
     mutationFn: (channel: 'Stable' | 'Dev') => axios.post('WebUI/Update', null, { params: { channel } }),
+  });
+
+export const useWebuiUploadThemeMutation = () =>
+  useMutation<WebuiTheme, undefined, { file: File, preview?: boolean }>({
+    mutationFn: ({ file, preview }) => {
+      const formData = new FormData();
+      formData.append('file', file);
+      if (preview) {
+        formData.append('preview', 'true');
+      }
+
+      return axios.post('WebUI/Theme/AddFromFile', formData);
+    },
   });

--- a/src/core/router/index.tsx
+++ b/src/core/router/index.tsx
@@ -139,7 +139,7 @@ const Router = () => {
 
   useEffect(() => {
     document.body.className = `${
-      apikey === '' ? globalThis.localStorage.getItem('theme') : (webuiPreviewTheme ?? theme)
+      apikey === '' ? globalThis.localStorage.getItem('theme') : (webuiPreviewTheme || theme)
     } theme-shoko-gray`;
     const timeoutId = setTimeout(() => {
       if (bodyRef.current) {

--- a/src/core/router/index.tsx
+++ b/src/core/router/index.tsx
@@ -130,7 +130,7 @@ export const BodyVisibleContext = createContext(false);
 
 const Router = () => {
   const apikey = useSelector((state: RootState) => state.apiSession.apikey);
-  const webuiPreviewTheme = (useSelector((state: RootState) => state.misc.webuiPreviewTheme) as unknown) as string;
+  const webuiPreviewTheme = useSelector((state: RootState) => state.misc.webuiPreviewTheme);
 
   const settingsQuery = useSettingsQuery(!!apikey);
   const { theme } = settingsQuery.data.WebUI_Settings;

--- a/src/core/slices/misc.ts
+++ b/src/core/slices/misc.ts
@@ -2,6 +2,19 @@ import { createSlice } from '@reduxjs/toolkit';
 
 import type { PayloadAction } from '@reduxjs/toolkit';
 
+type State = {
+  trakt: {
+    usercode: string;
+    url: string;
+  };
+  plex: {
+    url: string;
+    authenticated: boolean;
+  };
+  webuiUpdateAvailable: boolean;
+  webuiPreviewTheme: string;
+};
+
 const miscSlice = createSlice({
   name: 'misc',
   initialState: {
@@ -14,8 +27,8 @@ const miscSlice = createSlice({
       authenticated: false,
     },
     webuiUpdateAvailable: false,
-    webuiPreviewTheme: null,
-  },
+    webuiPreviewTheme: '',
+  } as State,
   reducers: {
     setItem(sliceState, action: PayloadAction<object>) {
       return Object.assign({}, sliceState, action.payload);

--- a/src/core/util.ts
+++ b/src/core/util.ts
@@ -29,7 +29,7 @@ export function isDebug() {
   return DEV;
 }
 
-export const minimumSupportedServerVersion = '4.2.2.135';
+export const minimumSupportedServerVersion = '4.2.2.140';
 
 export const parseServerVersion = (version: string) => {
   const semverVersion = semver.coerce(version)?.raw;

--- a/src/pages/settings/SettingsPage.tsx
+++ b/src/pages/settings/SettingsPage.tsx
@@ -137,6 +137,11 @@ function SettingsPage() {
     patchSettings({ newSettings });
   });
 
+  const handleCancel = useEventCallback(() => {
+    setNewSettings(settings);
+    dispatch(setMiscItem({ webuiPreviewTheme: '' }));
+  });
+
   const [containerRef, containerBounds] = useMeasure();
 
   return (
@@ -174,7 +179,7 @@ function SettingsPage() {
               {isShowFooter && (
                 <div className="flex justify-end gap-x-3 font-semibold">
                   <Button
-                    onClick={() => setNewSettings(settings)}
+                    onClick={handleCancel}
                     buttonType="secondary"
                     buttonSize="normal"
                   >

--- a/src/pages/settings/tabs/GeneralSettings.tsx
+++ b/src/pages/settings/tabs/GeneralSettings.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/naming-convention */
-import React, { useMemo } from 'react';
-import { mdiOpenInNew, mdiRefresh } from '@mdi/js';
+import React, { useMemo, useRef } from 'react';
+import { toast } from 'react-toastify';
+import { mdiBrushOutline, mdiOpenInNew, mdiRefresh } from '@mdi/js';
 import { Icon } from '@mdi/react';
 import cx from 'classnames';
 
@@ -8,9 +9,13 @@ import Button from '@/components/Input/Button';
 import Checkbox from '@/components/Input/Checkbox';
 import SelectSmall from '@/components/Input/SelectSmall';
 import { useVersionQuery } from '@/core/react-query/init/queries';
+import { useWebuiUploadThemeMutation } from '@/core/react-query/webui/mutations';
 import { useWebuiThemesQuery, useWebuiUpdateCheckQuery } from '@/core/react-query/webui/queries';
 import { uiVersion } from '@/core/util';
+import useEventCallback from '@/hooks/useEventCallback';
 import useSettingsContext from '@/hooks/useSettingsContext';
+
+let themeUpdateCounter = 0;
 
 const UI_VERSION = uiVersion();
 
@@ -27,8 +32,49 @@ function GeneralSettings() {
     { channel: newSettings.WebUI_Settings.updateChannel, force: true },
     false,
   );
+  const themePathHref = useMemo(() => document.getElementById('theme-css')!.attributes.getNamedItem('href')!, []);
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
   const versionQuery = useVersionQuery();
   const themesQuery = useWebuiThemesQuery();
+  const { isPending: isUploading, mutate: uploadTheme } = useWebuiUploadThemeMutation();
+
+  const onOpenFileDialog = useEventCallback((event: React.SyntheticEvent) => {
+    if (isUploading) {
+      return;
+    }
+
+    event.preventDefault();
+    event.stopPropagation();
+    if (fileInputRef.current) {
+      fileInputRef.current.click();
+    }
+  });
+
+  const onFileChange = useEventCallback((event: React.ChangeEvent<HTMLInputElement>) => {
+    if (isUploading) {
+      return;
+    }
+
+    event.preventDefault();
+    event.stopPropagation();
+    const file = event.target.files?.[0];
+    if (!file) return;
+    uploadTheme({ file }, {
+      async onSuccess(data) {
+        await themesQuery.refetch();
+
+        let path = themePathHref.value;
+        const index = path.indexOf('?');
+        if (index !== -1) path = path.substring(0, index);
+        themeUpdateCounter += 1;
+        path += `?updateCount=${themeUpdateCounter}`;
+        themePathHref.value = path;
+
+        updateSetting('WebUI_Settings', 'theme', `theme-${data.ID}`);
+        toast.info(`Successfully uploaded theme "${data.Name}"`);
+      },
+    });
+  });
 
   const currentTheme = useMemo(() => (
     themesQuery.data?.find(theme => `theme-${theme.ID}` === WebUI_Settings.theme)
@@ -120,7 +166,32 @@ function GeneralSettings() {
       <div className="border-b border-panel-border" />
 
       <div className="flex flex-col gap-y-6">
-        <div className="flex items-center font-semibold">Theme Options</div>
+        <div className="flex items-center justify-between">
+          <div className="font-semibold">Theme Options</div>
+          <input
+            ref={fileInputRef}
+            className="hidden"
+            multiple
+            id="file-input-field"
+            name="file"
+            type="file"
+            onChange={onFileChange}
+          />
+          <Button
+            buttonType="secondary"
+            buttonSize="small"
+            className="flex flex-row flex-wrap items-center gap-x-2"
+            onClick={onOpenFileDialog}
+            disabled={isUploading}
+            tooltip="Upload or install a new Theme"
+          >
+            <Icon
+              path={mdiBrushOutline}
+              size={0.85}
+            />
+            <span>Upload Theme</span>
+          </Button>
+        </div>
         <div className="flex flex-col gap-y-1">
           <div className="flex items-center justify-between">
             Theme

--- a/src/pages/settings/tabs/GeneralSettings.tsx
+++ b/src/pages/settings/tabs/GeneralSettings.tsx
@@ -63,12 +63,12 @@ function GeneralSettings() {
       async onSuccess(data) {
         await themesQuery.refetch();
 
-        let path = themePathHref.value;
-        const index = path.indexOf('?');
-        if (index !== -1) path = path.substring(0, index);
         themeUpdateCounter += 1;
-        path += `?updateCount=${themeUpdateCounter}`;
-        themePathHref.value = path;
+        // URL cannot be built without a base, so we use localhost
+        const path = new URL(themePathHref.value, 'http://localhost');
+        path.searchParams.set('updateCount', themeUpdateCounter.toString());
+        // Remove base from URL and set value
+        themePathHref.value = `${path.pathname}${path.search}`;
 
         updateSetting('WebUI_Settings', 'theme', `theme-${data.ID}`);
         toast.info(`Successfully uploaded theme "${data.Name}"`);


### PR DESCRIPTION
`feat`: Add upload theme button to settings.

Added a new '🖋 Upload Theme' button to the 'Theme Options' section of the 'General' Settings tab in the settings page. With it you can upload JSON-only themes, CSS-only themes, and JSON-based online themes, all without having access to the file system of the server. The themes are also auto-applied in preview mode after they're successfully uploaded, so you can preview the theme right away before saving.

**P.S.**: _If somebody have issues with the implementation, then be my guest changing it, as long as user experience remains the same in the end._

`misc`: Bump min. server version.