### PR TITLE
Description Filter Tweaks

### DIFF
--- a/src/components/Collection/CleanDescription.tsx
+++ b/src/components/Collection/CleanDescription.tsx
@@ -4,7 +4,9 @@ import cx from 'classnames';
 import { useSettingsQuery } from '@/core/react-query/settings/queries';
 
 // The question marks are there because people can't spell…
-const CleanInfoLinesRegex = /\(?\b((Modified )?Sour?ce|Note( [1-9])?|Summ?ary|From|See Also):(?!$| a daikon)([^\r\n]+|$)/img;
+// eslint-disable-next-line operator-linebreak -- Because dprint and eslint can't agree otherwise. Feel free to fix it.
+const CleanInfoLinesRegex =
+  /\(?\b((Modified )?Sour?ce|Note( [1-9])?|Summ?ary|From|See Also):(?!$| a daikon)([^\r\n]+|$)/img;
 
 // eslint-disable-next-line operator-linebreak -- Because dprint and eslint can't agree otherwise. Feel free to fix it.
 const CleanMiscLinesRegex =

--- a/src/components/Collection/CleanDescription.tsx
+++ b/src/components/Collection/CleanDescription.tsx
@@ -4,7 +4,7 @@ import cx from 'classnames';
 import { useSettingsQuery } from '@/core/react-query/settings/queries';
 
 // The question marks are there because people can't spell…
-const CleanInfoLinesRegex = /\b((Modified )?Sour?ce|Note( [1-9])?|Summ?ary):(?!$)([^\r\n]+|$)/img;
+const CleanInfoLinesRegex = /\(?\b((Modified )?Sour?ce|Note( [1-9])?|Summ?ary|From|See Also):(?!$| a daikon)([^\r\n]+|$)/img;
 
 // eslint-disable-next-line operator-linebreak -- Because dprint and eslint can't agree otherwise. Feel free to fix it.
 const CleanMiscLinesRegex =


### PR DESCRIPTION
- clean lines starting with "From" / "See Also"
- account for some "Source" Lines being enclosed in brackets
- exclude an edge case describing what the word daikon means

New matches here (including the xml they are from): [Matches.txt](https://github.com/user-attachments/files/17034511/Matches.txt)
Edge case here: https://anidb.net/anime/2780