### PR TITLE
Add Force Refresh Button to Unrecognized Utility

### DIFF
--- a/src/pages/utilities/UnrecognizedUtilityTabs/LinkFilesTab.tsx
+++ b/src/pages/utilities/UnrecognizedUtilityTabs/LinkFilesTab.tsx
@@ -211,7 +211,7 @@ const LinkFilesTab = () => {
   const { mutateAsync: linkOneFileToManyEpisodes } = useLinkOneFileToManyEpisodesMutation();
   const { mutateAsync: linkManyFilesToOneEpisode } = useLinkManyFilesToOneEpisodeMutation();
 
-  const { mutate: refreshAnidb } = useRefreshSeriesAniDBInfoMutation(selectedSeries.ShokoID ?? 0);
+  const { mutate: refreshAnidb } = useRefreshSeriesAniDBInfoMutation(selectedSeries?.ShokoID ?? 0);
   const { mutate: deleteSeries } = useDeleteSeriesMutation();
   const { mutateAsync: refreshSeries } = useRefreshAniDBSeriesMutation();
   const { mutateAsync: getSeriesAniDBData } = useGetSeriesAniDBMutation();

--- a/src/pages/utilities/UnrecognizedUtilityTabs/LinkFilesTab.tsx
+++ b/src/pages/utilities/UnrecognizedUtilityTabs/LinkFilesTab.tsx
@@ -9,6 +9,7 @@ import {
   mdiOpenInNew,
   mdiPencilCircleOutline,
   mdiPlusCircleMultipleOutline,
+  mdiRefresh,
   mdiSortAlphabeticalAscending,
 } from '@mdi/js';
 import { Icon } from '@mdi/react';
@@ -35,6 +36,7 @@ import {
   useDeleteSeriesMutation,
   useGetSeriesAniDBMutation,
   useRefreshAniDBSeriesMutation,
+  useRefreshSeriesAniDBInfoMutation,
 } from '@/core/react-query/series/mutations';
 import {
   useSeriesAniDBEpisodesQuery,
@@ -209,6 +211,7 @@ const LinkFilesTab = () => {
   const { mutateAsync: linkOneFileToManyEpisodes } = useLinkOneFileToManyEpisodesMutation();
   const { mutateAsync: linkManyFilesToOneEpisode } = useLinkManyFilesToOneEpisodeMutation();
 
+  const { mutate: refreshAnidb } = useRefreshSeriesAniDBInfoMutation(selectedSeries.ShokoID ?? 0);
   const { mutate: deleteSeries } = useDeleteSeriesMutation();
   const { mutateAsync: refreshSeries } = useRefreshAniDBSeriesMutation();
   const { mutateAsync: getSeriesAniDBData } = useGetSeriesAniDBMutation();
@@ -330,6 +333,10 @@ const LinkFilesTab = () => {
 
     setSeriesUpdating(false);
   };
+
+  const refreshSelectedSeries = useEventCallback(() => {
+    refreshAnidb({ force: true });
+  });
 
   const editSelectedSeries = useEventCallback(() => {
     setSelectedSeries({ Type: SeriesTypeEnum.Unknown } as SeriesAniDBSearchResult);
@@ -701,7 +708,20 @@ const LinkFilesTab = () => {
                   {selectedSeries.Title}
                   <Icon path={mdiOpenInNew} size={1} className="ml-3" />
                 </a>
-                <Button onClick={editSelectedSeries} className="ml-auto text-panel-text-primary" disabled={isLinking}>
+                <Button
+                  onClick={refreshSelectedSeries}
+                  className="ml-auto text-panel-text-primary"
+                  tooltip="Force Refresh"
+                  disabled={isLinking}
+                >
+                  <Icon path={mdiRefresh} size={1} />
+                </Button>
+                <Button
+                  onClick={editSelectedSeries}
+                  className="ml-2 text-panel-text-primary"
+                  tooltip="Edit Link"
+                  disabled={isLinking}
+                >
                   <Icon path={mdiPencilCircleOutline} size={1} />
                 </Button>
               </div>


### PR DESCRIPTION
- also added a tooltip to the edit series button to match
<img width="1402" height="341" alt="firefox_2025-07-30_09-28-13" src="https://github.com/user-attachments/assets/8a73588a-3b11-4388-af2b-0ac8b97f9d0c" />

A couple of people have been asking about missing episodes in the unrecognized utility and I've been encountering it myself so I think that is enough to justify the inclusion of a little button.