### PR TITLE
feat: add simple anidb anime redirect

### DIFF
--- a/src/core/react-query/series/queries.ts
+++ b/src/core/react-query/series/queries.ts
@@ -39,6 +39,13 @@ export const useSeriesQuery = (
     enabled,
   });
 
+export const useSeriesByAnidbIdQuery = (anidbId: number, enabled = true) =>
+  useQuery<SeriesType>({
+    queryKey: ['series', 'anidb', anidbId, 'series'],
+    queryFn: () => axios.get(`Series/AniDB/${anidbId}/Series`),
+    enabled,
+  });
+
 export const useSeriesAniDBQuery = (anidbId: number, enabled = true) =>
   useQuery<SeriesAniDBSearchResult>({
     queryKey: ['series', 'anidb', anidbId],

--- a/src/core/router/index.tsx
+++ b/src/core/router/index.tsx
@@ -29,6 +29,7 @@ import StartServer from '@/pages/firstrun/StartServer';
 import LoginPage from '@/pages/login/LoginPage';
 import LogsPage from '@/pages/logs/LogsPage';
 import MainPage from '@/pages/main/MainPage';
+import AnidbAnimeRedirect from '@/pages/redirect/AnidbAnimeRedirect';
 import SettingsPage from '@/pages/settings/SettingsPage';
 import AniDBSettings from '@/pages/settings/tabs/AniDBSettings';
 import ApiKeys from '@/pages/settings/tabs/ApiKeys';
@@ -72,6 +73,14 @@ const router = sentryCreateBrowserRouter(
           <Route path="import-folders" element={<ImportFolders />} />
           <Route path="data-collection" element={<DataCollection />} />
         </Route>
+        <Route
+          path="redirect/anidb/anime/:animeId"
+          element={
+            <AuthenticatedRoute>
+              <AnidbAnimeRedirect />
+            </AuthenticatedRoute>
+          }
+        />
         <Route path="unsupported" element={<UnsupportedPage />} />
         <Route
           element={

--- a/src/pages/redirect/AnidbAnimeRedirect.tsx
+++ b/src/pages/redirect/AnidbAnimeRedirect.tsx
@@ -1,0 +1,81 @@
+import React, { useEffect, useState } from 'react';
+import { useParams } from 'react-router';
+import { Slide, ToastContainer } from 'react-toastify';
+import { mdiAlertCircleOutline, mdiLoading } from '@mdi/js';
+import { Icon } from '@mdi/react';
+import cx from 'classnames';
+
+import { useRandomImageMetadataQuery } from '@/core/react-query/image/queries';
+import { useSeriesByAnidbIdQuery } from '@/core/react-query/series/queries';
+import { ImageTypeEnum } from '@/core/types/api/common';
+import useNavigateVoid from '@/hooks/useNavigateVoid';
+
+const AnidbAnimeRedirect = () => {
+  const navigate = useNavigateVoid();
+  const { animeId } = useParams();
+  const query = useSeriesByAnidbIdQuery(Number(animeId), !Number.isNaN(Number(animeId)));
+  const imageMetadataQuery = useRandomImageMetadataQuery(ImageTypeEnum.Backdrop);
+
+  const [{ imageUrl }, setImage] = useState(() => ({
+    imageUrl: '',
+  }));
+
+  useEffect(() => {
+    if (imageMetadataQuery.isPending) return;
+    if (!imageMetadataQuery.isSuccess || !imageMetadataQuery.data.Type) {
+      setImage({ imageUrl: 'default' });
+      return;
+    }
+    const { ID, Source, Type } = imageMetadataQuery.data;
+    setImage({
+      imageUrl: `/api/v3/Image/${Source}/${Type}/${ID}`,
+    });
+  }, [imageMetadataQuery.isSuccess, imageMetadataQuery.isPending, imageMetadataQuery.data]);
+
+  useEffect(() => {
+    if (query.isSuccess && query.data) {
+      navigate(`/webui/collection/series/${query.data.IDs.ID}`, { replace: true });
+    }
+  }, [query.isSuccess, query.data, navigate]);
+
+  return (
+    <>
+      <title>{`AniDB Anime ${animeId} | Redirect | Shoko`}</title>
+      <ToastContainer
+        position="bottom-right"
+        autoClose={4000}
+        transition={Slide}
+        className="mt-20 !w-[29.5rem]"
+        closeButton={false}
+        icon={false}
+      />
+      <div className="relative flex h-screen w-screen flex-col items-center justify-center gap-y-2">
+        <div className="flex flex-col items-center rounded-lg border border-panel-border bg-panel-background-transparent drop-shadow-md">
+          {/* Loading indicator */}
+          {(query.isLoading || query.isFetching) && (
+            <div className="flex items-center justify-center gap-x-2 p-4">
+              <Icon path={mdiLoading} spin size={1.5} />
+            </div>
+          )}
+          {(query.isError || !query.data) && (
+            <div className="flex items-center justify-center gap-x-2 p-4">
+              <Icon path={mdiAlertCircleOutline} size={1.5} />
+              <span>Something went wrong! Unable to find the requested series in the local collection.</span>
+            </div>
+          )}
+        </div>
+        <div
+          className={cx(
+            'fixed left-0 top-0 -z-10 h-full w-full opacity-20',
+            imageUrl === 'default' && 'login-image-default',
+          )}
+          style={imageUrl !== '' && imageUrl !== 'default'
+            ? { background: `center / cover no-repeat url('${imageUrl}')` }
+            : {}}
+        />
+      </div>
+    </>
+  );
+};
+
+export default AnidbAnimeRedirect;


### PR DESCRIPTION
I'm tired of searching for the anime in my collection by name when I already know the AniDB anime id. :pensive:

I couldn't care less of how the redirect page looks, so I just mashed together something based on the login page. It is based on the login page and not main page since I didn't want the main page frame on the redirect page, but if somebody has a burning passion that says it **N E E D S** to have the main page frame then feel free to edit this PR to change it. :slightly_smiling_face: