### PR TITLE
fix(images): use Available instead of RelativeFilepath

### DIFF
--- a/src/components/BackgroundImagePlaceholderDiv.tsx
+++ b/src/components/BackgroundImagePlaceholderDiv.tsx
@@ -38,7 +38,7 @@ const BackgroundImagePlaceholderDiv = React.memo((props: Props) => {
       return undefined;
     }
 
-    if (!settings.LoadImageMetadata && !image.RelativeFilepath) {
+    if (!settings.LoadImageMetadata && !image.Available) {
       return null;
     }
 

--- a/src/components/Collection/Credits/CreditsStaffPanel.tsx
+++ b/src/components/Collection/Credits/CreditsStaffPanel.tsx
@@ -7,7 +7,7 @@ import type { CreditsModeType } from '@/pages/collection/series/SeriesCredits';
 
 const getThumbnailUrl = (item: SeriesCast, mode: CreditsModeType) => {
   const thumbnail = item[mode]?.Image ?? null;
-  if (!thumbnail?.RelativeFilepath) return null;
+  if (!thumbnail?.Available) return null;
   return `/api/v3/Image/${thumbnail.Source}/${thumbnail.Type}/${thumbnail.ID}`;
 };
 

--- a/src/core/types/api/common.ts
+++ b/src/core/types/api/common.ts
@@ -2,7 +2,7 @@ export type ImageType = {
   Source: ImageSourceEnum;
   Type: ImageTypeEnum;
   ID: number;
-  RelativeFilepath: null;
+  Available: boolean;
   Preferred: boolean;
   Width: null;
   Height: null;
@@ -11,7 +11,7 @@ export type ImageType = {
   Source: ImageSourceEnum;
   Type: ImageTypeEnum;
   ID: number;
-  RelativeFilepath: string;
+  Available: boolean;
   Preferred: boolean;
   Width: number;
   Height: number;

--- a/src/core/types/api/image.ts
+++ b/src/core/types/api/image.ts
@@ -4,7 +4,7 @@ export type RandomImageMetadataResultType = {
   Source: string;
   Type: ImageTypeEnum;
   ID: string;
-  RelativeFilepath: string;
+  Available: boolean;
   Preferred: boolean;
   Width: number | null;
   Height: number | null;

--- a/src/pages/collection/series/SeriesImages.tsx
+++ b/src/pages/collection/series/SeriesImages.tsx
@@ -3,7 +3,7 @@ import { useOutletContext, useParams } from 'react-router';
 import { mdiStarCircleOutline } from '@mdi/js';
 import { Icon } from '@mdi/react';
 import cx from 'classnames';
-import { capitalize, split } from 'lodash';
+import { capitalize } from 'lodash';
 
 import BackgroundImagePlaceholderDiv from '@/components/BackgroundImagePlaceholderDiv';
 import Button from '@/components/Input/Button';
@@ -51,10 +51,6 @@ const SeriesImages = () => {
   const images = useSeriesImagesQuery(series.IDs.ID).data;
   const { mutate: changeImage } = useChangeSeriesImageMutation(series.IDs.ID);
 
-  const splitPath = split(selectedImage?.RelativeFilepath ?? '-', '/');
-  const filename = splitPath[0] === '-' ? '-' : splitPath.pop();
-  const filepath = splitPath[0] ? splitPath.join('/') : '-';
-
   const handleSelectionChange = (item: ImageType) => {
     setSelectedImage(old => ((old === item) ? null : item));
   };
@@ -83,8 +79,6 @@ const SeriesImages = () => {
             transparent
             sticky
           >
-            <InfoLine title="Filename" value={filename ?? 'N/A'} />
-            <InfoLine title="Location" value={filepath} />
             <InfoLine title="Source" value={selectedImage?.Source ?? '-'} />
             <InfoLine
               title="Size"


### PR DESCRIPTION
**Summary**

This updates WebUI image handling to match the current Shoko.Server image DTO. The server no longer exposes `RelativeFilepath` and now provides `Available`, so WebUI now uses `Available` for image availability checks instead of path presence.

**Changes**

- Added `Available` to the shared WebUI image DTO types
- Removed `RelativeFilepath` usage from WebUI image rendering logic
- Updated image availability checks in the shared background image placeholder and credits staff panel
- Kept image URL construction based on `Source`, `Type`, and `ID`
- Removed filename/location rows from the series image details panel because that metadata is no longer present in the server DTO

**Result**

Images that are available on the server now render correctly again even though `RelativeFilepath` is no longer part of the payload, including code paths that previously gated rendering on that field.

**Validation**

- Searched for `RelativeFilepath` usage under `src/` and removed remaining references
- Fixed lint issues surfaced by pre-commit for import grouping and optional chaining