### PR TITLE
fix ConfirmationPromptModal: reset loading state on error

### DIFF
--- a/src/components/Dialogs/ConfirmationPromptModal.tsx
+++ b/src/components/Dialogs/ConfirmationPromptModal.tsx
@@ -34,9 +34,11 @@ const ConfirmationPromptModal = ({
     setIsConfirmPending(true);
     Promise.resolve()
       .then(() => onConfirm())
-      .then(() => setIsConfirmPending(false))
       .catch(console.error)
-      .finally(() => onClose());
+      .finally(() => {
+        setIsConfirmPending(false);
+        onClose();
+      });
   };
 
   useToggleModalKeybinds(show, 'nested-modal');


### PR DESCRIPTION
## Problem

When the async `onConfirm` callback in `ConfirmationPromptModal` throws an error, `isConfirmPending` was never reset to `false` because the reset was only in the success `.then()` handler. Since the modal component is conditionally rendered (not unmounted), this leaked state caused the Confirm button to appear in a loading state on all future opens of any confirmation dialog.

## Fix

Move `setIsConfirmPending(false)` into the `.finally()` block so it always executes, regardless of success or failure. This ensures the loading spinner is properly cleared after every confirmation attempt.

## Impact

This affects all 5 consumers of `ConfirmationPromptModal` that pass async `onConfirm` handlers.