### PR TITLE
fix(api): align react-query endpoints with swagger spec

### DIFF
--- a/src/core/react-query/file/mutations.ts
+++ b/src/core/react-query/file/mutations.ts
@@ -30,8 +30,8 @@ export const useDeleteFilesMutation = () =>
 
 export const useDeleteFileMutation = (seriesId?: number, episodeId?: number) =>
   useMutation({
-    mutationFn: ({ fileId, removeFolder = true }: DeleteFileRequestType) =>
-      axios.delete(`File/${fileId}`, { data: { removeFolder } }),
+    mutationFn: ({ fileId, removeFiles = true, removeFolder = true }: DeleteFileRequestType) =>
+      axios.delete(`File/${fileId}`, { params: { removeFiles, removeFolder } }),
     onSuccess: () => {
       if (!seriesId || !episodeId) return;
 

--- a/src/core/react-query/file/types.ts
+++ b/src/core/react-query/file/types.ts
@@ -5,6 +5,7 @@ export type DeleteFilesRequestType = {
 
 export type DeleteFileRequestType = {
   fileId: number;
+  removeFiles?: boolean;
   removeFolder?: boolean;
 };
 

--- a/src/core/react-query/hashing/mutations.ts
+++ b/src/core/react-query/hashing/mutations.ts
@@ -8,12 +8,12 @@ import type { HashingSummaryType, UpdateHashingProviderType } from '@/core/react
 export const useUpdateHashingProviderMutation = () =>
   useMutation({
     mutationFn: ({ id, settings }: { id: string, settings: UpdateHashingProviderType }) =>
-      axios.put(`/Hashing/Provider/${id}`, settings),
+      axios.put(`Hashing/Provider/${id}`, settings),
     onSuccess: () => invalidateQueries(['hashing', 'providers']),
   });
 
-export const useUpdateHashingSettingsQuery = () =>
+export const useUpdateHashingSettingsMutation = () =>
   useMutation({
-    mutationFn: (data: HashingSummaryType) => axios.post('/Hashing/Settings', data),
+    mutationFn: (data: HashingSummaryType) => axios.post('Hashing/Settings', data),
     onSuccess: () => invalidateQueries(['hashing', 'summary']),
   });

--- a/src/core/react-query/release-info/mutations.ts
+++ b/src/core/react-query/release-info/mutations.ts
@@ -8,13 +8,13 @@ import type { ReleaseInfoType } from '@/core/types/api/file';
 
 export const useUpdateReleaseInfoSettingsMutation = () =>
   useMutation({
-    mutationFn: (settings: ReleaseInfoSettingsType) => axios.post('/ReleaseInfo/Settings', settings),
+    mutationFn: (settings: ReleaseInfoSettingsType) => axios.post('ReleaseInfo/Settings', settings),
     onSuccess: () => invalidateQueries(['release-info', 'summary']),
   });
 
 export const useUpdateReleaseInfoProvidersMutation = () =>
   useMutation({
-    mutationFn: (providers: UpdateReleaseInfoProvidersType[]) => axios.post('/ReleaseInfo/Provider', providers),
+    mutationFn: (providers: UpdateReleaseInfoProvidersType[]) => axios.post('ReleaseInfo/Provider', providers),
     onSuccess: (_, providers) => {
       queryClient.setQueryData(['release-info', 'providers'], providers);
       invalidateQueries(['release-info', 'providers']);
@@ -24,13 +24,13 @@ export const useUpdateReleaseInfoProvidersMutation = () =>
 export const useSubmitReleaseInfoForFileByIdMutation = () =>
   useMutation({
     mutationFn: ({ fileId, release }: { fileId: number, release: ReleaseInfoType }) =>
-      axios.post(`/ReleaseInfo/File/${fileId}`, release),
+      axios.post(`ReleaseInfo/File/${fileId}`, release),
   });
 
 export const useAutoPreviewReleaseInfoForFileByIdMutation = () =>
   useMutation<ReleaseInfoType | null, unknown, { fileId: number, providerIDs?: string[] }>({
     mutationFn: ({ fileId, providerIDs = [] }) =>
-      axios.post(`/ReleaseInfo/File/${fileId}/AutoPreview`, undefined, {
+      axios.post(`ReleaseInfo/File/${fileId}/AutoPreview`, undefined, {
         params: { providerIDs },
       }),
     scope: {
@@ -41,7 +41,7 @@ export const useAutoPreviewReleaseInfoForFileByIdMutation = () =>
 export const usePreviewReleaseInfoByProviderIdMutation = () =>
   useMutation<ReleaseInfoType, unknown, { id: string, providerId: string }>({
     mutationFn: ({ id, providerId }) =>
-      axios.get(`/ReleaseInfo/Provider/${providerId}/Preview/By-Release`, { params: { id } }),
+      axios.get(`ReleaseInfo/Provider/${providerId}/Preview/By-Release`, { params: { id } }),
     scope: {
       id: 'release-info',
     },

--- a/src/core/react-query/tmdb/mutations.ts
+++ b/src/core/react-query/tmdb/mutations.ts
@@ -45,7 +45,7 @@ export const useDeleteTmdbLinkMutation = (seriesId: number, linkType: 'Movie' | 
 export const useSetPreferredTmdbShowOrderingMutation = (showId: number) =>
   useMutation({
     mutationFn: (alternateOrderingId: string) =>
-      axios.post(`/TMDB/Show/${showId}/Ordering/SetPreferred`, { alternateOrderingId }),
+      axios.post(`Tmdb/Show/${showId}/Ordering/SetPreferred`, { AlternateOrderingID: alternateOrderingId }),
     onSuccess: () => {
       invalidateQueries(['series', 'tmdb', 'show']);
       invalidateQueries(['series', 'tmdb', 'episode']);

--- a/src/core/react-query/tmdb/queries.ts
+++ b/src/core/react-query/tmdb/queries.ts
@@ -148,6 +148,6 @@ export const useTmdbBulkMoviesOnlineQuery = (data: TmdbBulkRequestType, enabled 
 export const useTmdbShowOrderingQuery = (showId: number, enabled = true) =>
   useQuery<TmdbShowOrderingInformationType[]>({
     queryKey: ['series', 'tmdb', 'show', showId, 'ordering'],
-    queryFn: () => axios.get(`TMDB/Show/${showId}/Ordering`),
+    queryFn: () => axios.get(`Tmdb/Show/${showId}/Ordering`),
     enabled,
   });

--- a/src/pages/settings/tabs/HashingAndReleaseSettings.tsx
+++ b/src/pages/settings/tabs/HashingAndReleaseSettings.tsx
@@ -11,7 +11,7 @@ import Button from '@/components/Input/Button';
 import Checkbox from '@/components/Input/Checkbox';
 import ReleaseSettings from '@/components/Settings/HashingAndReleaseSettings/ReleaseSettings';
 import toast from '@/components/Toast';
-import { useUpdateHashingSettingsQuery } from '@/core/react-query/hashing/mutations';
+import { useUpdateHashingSettingsMutation } from '@/core/react-query/hashing/mutations';
 import { useHashingProvidersQuery, useHashingSummaryQuery } from '@/core/react-query/hashing/queries';
 import {
   useUpdateReleaseInfoProvidersMutation,
@@ -47,7 +47,7 @@ const HashingAndReleaseSettings = () => {
   const { mutate: patchSettings } = usePatchSettingsMutation();
   const { mutate: updateReleaseInfoSettings } = useUpdateReleaseInfoSettingsMutation();
   const { mutate: updateReleaseInfoProviders } = useUpdateReleaseInfoProvidersMutation();
-  const { mutate: updateHashingSettings } = useUpdateHashingSettingsQuery();
+  const { mutate: updateHashingSettings } = useUpdateHashingSettingsMutation();
 
   const [showHashTypesModal, setShowHashTypesModal] = useState(false);
   const [selectedProvider, setSelectedProvider] = useState<HashProviderInfoType | undefined>();


### PR DESCRIPTION
## Summary

Audited all React Query queries/mutations against the Swagger API spec and fixed 12 discrepancies.

### Changes

**Leading slash removal (7 mutations)**
- `release-info/mutations.ts`: 5 mutations — `/ReleaseInfo/...` → `ReleaseInfo/...`
- `hashing/mutations.ts`: 2 mutations — `/Hashing/...` → `Hashing/...`

**Parameter placement fix**
- `file/mutations.ts`: `useDeleteFileMutation` — `removeFolder` and `removeFiles` sent as query params instead of request body (per swagger spec)
- `file/types.ts`: Added missing `removeFiles` field to `DeleteFileRequestType`

**Path case fix**
- `tmdb/queries.ts`: `TMDB/Show/...` → `Tmdb/Show/...`
- `tmdb/mutations.ts`: `TMDB/Show/...` → `Tmdb/Show/...`

**Body key fix**
- `tmdb/mutations.ts`: `{ alternateOrderingId }` → `{ AlternateOrderingID: alternateOrderingId }` (PascalCase per swagger schema)

**Naming fix**
- `hashing/mutations.ts`: Renamed `useUpdateHashingSettingsQuery` → `useUpdateHashingSettingsMutation`
- `HashingAndReleaseSettings.tsx`: Updated import/usage

### Verification
- `pnpm lint` passes clean
- All other ~100+ endpoints verified correct against swagger spec