### PR TITLE
fix: use anidb title for anidb episode on tmdb linking page

### DIFF
--- a/src/components/Collection/Tmdb/AniDBEpisode.tsx
+++ b/src/components/Collection/Tmdb/AniDBEpisode.tsx
@@ -31,13 +31,13 @@ const AniDBEpisode = React.memo(({ episode, extra, isOdd, onIconClick }: Props) 
     <div
       className={cx('flex grow flex-col', extra && 'opacity-65')}
       data-tooltip-id="tooltip"
-      data-tooltip-content={episode.Name}
+      data-tooltip-content={episode.AniDB?.Title ?? `Episode ${episode.AniDB?.EpisodeNumber ?? '??'}`}
     >
       <div className="line-clamp-1 text-xs font-semibold opacity-65">
         {episode.AniDB?.AirDate ?? 'Airdate Unknown'}
       </div>
       <div className="line-clamp-1">
-        {episode.Name}
+        {episode.AniDB?.Title ?? `Episode ${episode.AniDB?.EpisodeNumber ?? '??'}`}
       </div>
     </div>
 


### PR DESCRIPTION
To prevent the TMDB title from appearing for the anidb episode on the tmdb linking page, we'll use the anidb episode title instead of the shoko episode title.