### PR TITLE
fix: scope dumpInProgress to selected rows in unrecognized util

### DIFF
--- a/src/pages/utilities/UnrecognizedUtilityTabs/UnrecognizedTab.tsx
+++ b/src/pages/utilities/UnrecognizedUtilityTabs/UnrecognizedTab.tsx
@@ -333,7 +333,11 @@ const UnrecognizedTab = () => {
       : false),
     [selectedRows, avdumpList],
   );
-  const dumpInProgress = some(avdumpList.sessions, session => session.status === 'Running');
+  const dumpInProgress = selectedRows.length > 0
+    && some(
+      selectedRows,
+      row => avdumpList.sessions[avdumpList.sessionMap[row.ID]]?.status === 'Running',
+    );
 
   const handleAvdumpClick = () => {
     if (isAvdumpFinished && !dumpInProgress) {


### PR DESCRIPTION
Scope `dumpInProgress` to only check selected rows' AVDump sessions instead of all sessions globally, matching the same scope as `isAvdumpFinished`.