### PR TITLE
Fix release workflow: target_commitish and previous_tag (#1335) [no ci]

### DIFF
--- a/.github/workflows/Release-Manual.yml
+++ b/.github/workflows/Release-Manual.yml
@@ -50,6 +50,10 @@ jobs:
           ref: ${{ github.event.inputs.ref }}
           fetch-depth: 0
 
+      - name: Get previous release tag
+        id: prev-tag
+        run: echo "tag=$(git describe --tags --abbrev=0)" >> $GITHUB_OUTPUT
+
       - name: Install pnpm
         uses: pnpm/action-setup@v4
         with:
@@ -89,9 +93,11 @@ jobs:
         with:
           files: ./build/Shoko-WebUI-v${{ github.event.inputs.version }}.zip
           tag_name: v${{ github.event.inputs.version }}
+          target_commitish: ${{ github.event.inputs.ref }}
           prerelease: ${{ github.event.inputs.prerelease }}
           fail_on_unmatched_files: true
           body_path: ./release-notes.txt
           generate_release_notes: true
+          previous_tag: ${{ steps.prev-tag.outputs.tag }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Problem

Two issues with the Release-Manual workflow:

1. **Tag created on master instead of the specified branch** — `target_commitish` was not passed to `softprops/action-gh-release`, so the GitHub API defaulted to creating the tag on the default branch (master), ignoring the checked-out ref.

2. **Auto-generated release notes compared against wrong previous tag** — `previous_tag` was not set, so GitHub auto-picked a tag from master (e.g. v2.5.3) instead of the latest tag reachable from the release branch (e.g. v2.5.4).

## Fix

- Added `target_commitish: ${{ github.event.inputs.ref }}` to the release step so the tag is created on the intended branch.
- Added a step to determine the previous tag via `git describe --tags --abbrev=0` and pass it as `previous_tag` so release notes compare against the correct base.