### PR TITLE
feat(settings): add plugin pages to settings sidebar with iframe embeds

### DIFF
--- a/src/core/react-query/plugin/queries.ts
+++ b/src/core/react-query/plugin/queries.ts
@@ -1,6 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 
 import { axios } from '@/core/axios';
+import { STALE_TIME } from '@/core/util';
 
 import type { PluginPageType, SharedPluginPageType } from '@/core/types/api/plugin';
 
@@ -8,13 +9,13 @@ export const usePluginPagesQuery = () =>
   useQuery<PluginPageType[]>({
     queryKey: ['plugin', 'pages'],
     queryFn: () => axios.get('Plugin/Pages'),
-    staleTime: 86400 * 100000,
+    staleTime: STALE_TIME,
   });
 
 export const usePluginPagesForPluginQuery = (pluginId: string, enabled = true) =>
   useQuery<SharedPluginPageType[]>({
     queryKey: ['plugin', 'pages', pluginId],
     queryFn: () => axios.get(`Plugin/${pluginId}/Pages`),
-    staleTime: 86400 * 100000,
+    staleTime: STALE_TIME,
     enabled,
   });

--- a/src/core/react-query/plugin/queries.ts
+++ b/src/core/react-query/plugin/queries.ts
@@ -2,7 +2,7 @@ import { useQuery } from '@tanstack/react-query';
 
 import { axios } from '@/core/axios';
 
-import type { PluginPageType } from '@/core/types/api/plugin';
+import type { PluginPageType, SharedPluginPageType } from '@/core/types/api/plugin';
 
 export const usePluginPagesQuery = () =>
   useQuery<PluginPageType[]>({
@@ -12,7 +12,7 @@ export const usePluginPagesQuery = () =>
   });
 
 export const usePluginPagesForPluginQuery = (pluginId: string, enabled = true) =>
-  useQuery<PluginPageType[]>({
+  useQuery<SharedPluginPageType[]>({
     queryKey: ['plugin', 'pages', pluginId],
     queryFn: () => axios.get(`Plugin/${pluginId}/Pages`),
     staleTime: 86400 * 100000,

--- a/src/core/react-query/plugin/queries.ts
+++ b/src/core/react-query/plugin/queries.ts
@@ -1,0 +1,18 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { axios } from '@/core/axios';
+
+import type { PluginPageType } from '@/core/types/api/plugin';
+
+export const usePluginPagesQuery = () =>
+  useQuery<PluginPageType[]>({
+    queryKey: ['plugin', 'pages'],
+    queryFn: () => axios.get('Plugin/Pages'),
+  });
+
+export const usePluginPagesForPluginQuery = (pluginId: string, enabled = true) =>
+  useQuery<PluginPageType[]>({
+    queryKey: ['plugin', 'pages', pluginId],
+    queryFn: () => axios.get(`Plugin/${pluginId}/Pages`),
+    enabled,
+  });

--- a/src/core/react-query/plugin/queries.ts
+++ b/src/core/react-query/plugin/queries.ts
@@ -8,11 +8,13 @@ export const usePluginPagesQuery = () =>
   useQuery<PluginPageType[]>({
     queryKey: ['plugin', 'pages'],
     queryFn: () => axios.get('Plugin/Pages'),
+    staleTime: 86400 * 100000,
   });
 
 export const usePluginPagesForPluginQuery = (pluginId: string, enabled = true) =>
   useQuery<PluginPageType[]>({
     queryKey: ['plugin', 'pages', pluginId],
     queryFn: () => axios.get(`Plugin/${pluginId}/Pages`),
+    staleTime: 86400 * 100000,
     enabled,
   });

--- a/src/core/react-query/plugin/queries.ts
+++ b/src/core/react-query/plugin/queries.ts
@@ -6,14 +6,14 @@ import { STALE_TIME } from '@/core/util';
 import type { PluginPageType, SharedPluginPageType } from '@/core/types/api/plugin';
 
 export const usePluginPagesQuery = () =>
-  useQuery<PluginPageType[]>({
+  useQuery<SharedPluginPageType[]>({
     queryKey: ['plugin', 'pages'],
     queryFn: () => axios.get('Plugin/Pages'),
     staleTime: STALE_TIME,
   });
 
 export const usePluginPagesForPluginQuery = (pluginId: string, enabled = true) =>
-  useQuery<SharedPluginPageType[]>({
+  useQuery<PluginPageType[]>({
     queryKey: ['plugin', 'pages', pluginId],
     queryFn: () => axios.get(`Plugin/${pluginId}/Pages`),
     staleTime: STALE_TIME,

--- a/src/core/router/index.tsx
+++ b/src/core/router/index.tsx
@@ -30,6 +30,7 @@ import LoginPage from '@/pages/login/LoginPage';
 import LogsPage from '@/pages/logs/LogsPage';
 import MainPage from '@/pages/main/MainPage';
 import SettingsPage from '@/pages/settings/SettingsPage';
+import PluginPageEmbed from '@/pages/settings/plugin/PluginPageEmbed';
 import AniDBSettings from '@/pages/settings/tabs/AniDBSettings';
 import ApiKeys from '@/pages/settings/tabs/ApiKeys';
 import CollectionSettings from '@/pages/settings/tabs/CollectionSettings';
@@ -125,6 +126,7 @@ const router = sentryCreateBrowserRouter(
             <Route path="integrations" element={<IntegrationsSettings />} />
             <Route path="user-management" element={<UserManagementSettings />} />
             <Route path="api-keys" element={<ApiKeys />} />
+            <Route path="plugin/:pluginId/:pageIndex" element={<PluginPageEmbed />} />
           </Route>
         </Route>
       </Route>

--- a/src/core/router/index.tsx
+++ b/src/core/router/index.tsx
@@ -126,7 +126,7 @@ const router = sentryCreateBrowserRouter(
             <Route path="integrations" element={<IntegrationsSettings />} />
             <Route path="user-management" element={<UserManagementSettings />} />
             <Route path="api-keys" element={<ApiKeys />} />
-            <Route path="plugin/:pluginId/:pageIndex" element={<PluginPageEmbed />} />
+            <Route path="plugin/:pluginId/:pageId" element={<PluginPageEmbed />} />
           </Route>
         </Route>
       </Route>

--- a/src/core/types/api/plugin.ts
+++ b/src/core/types/api/plugin.ts
@@ -36,6 +36,7 @@ export type PluginInfoType = {
 };
 
 export type PluginPageType = {
+  ID: string;
   Name: string;
   Url: string;
   CanEmbed: boolean;

--- a/src/core/types/api/plugin.ts
+++ b/src/core/types/api/plugin.ts
@@ -34,3 +34,10 @@ export type PluginInfoType = {
   ContainingDirectory?: string;
   DLLs: string[];
 };
+
+export type PluginPageType = {
+  Name: string;
+  Url: string;
+  CanEmbed: boolean;
+  PluginInfo?: PluginInfoType;
+};

--- a/src/core/types/api/plugin.ts
+++ b/src/core/types/api/plugin.ts
@@ -40,5 +40,8 @@ export type PluginPageType = {
   Name: string;
   Url: string;
   CanEmbed: boolean;
-  PluginInfo?: PluginInfoType;
+};
+
+export type SharedPluginPageType = PluginPageType & {
+  PluginInfo: PluginInfoType;
 };

--- a/src/core/util.ts
+++ b/src/core/util.ts
@@ -26,6 +26,9 @@ dayjs.extend(customParseFormatPlugin);
 
 export { default as dayjs } from 'dayjs';
 
+/** Shared stale time: ~100 days. Used for relatively static data that rarely changes server-side. */
+export const STALE_TIME = 86400 * 100000;
+
 // Enables immer plugin to support Map and Set
 enableMapSet();
 

--- a/src/pages/settings/SettingsPage.tsx
+++ b/src/pages/settings/SettingsPage.tsx
@@ -4,7 +4,7 @@ import { NavLink, Outlet, useLocation } from 'react-router';
 import useMeasure from 'react-use-measure';
 import { mdiLoading, mdiOpenInNew } from '@mdi/js';
 import { Icon } from '@mdi/react';
-import { isEqual } from 'lodash';
+import { groupBy, isEmpty, isEqual, map } from 'lodash';
 import { useDebounceValue } from 'usehooks-ts';
 
 import Button from '@/components/Input/Button';
@@ -15,7 +15,6 @@ import { useSettingsQuery } from '@/core/react-query/settings/queries';
 import { setItem as setMiscItem } from '@/core/slices/misc';
 import { useDispatch } from '@/core/store';
 
-import type { SharedPluginPageType } from '@/core/types/api/plugin';
 import type { PluginRenamerSettingsType } from '@/core/types/api/settings';
 
 const items = [
@@ -45,22 +44,7 @@ const SettingsPage = () => {
 
   const pluginPages = usePluginPagesQuery().data;
 
-  const pluginGroups = useMemo(() => {
-    if (!pluginPages) return [];
-    const groups: { id: string, name: string, pages: SharedPluginPageType[] }[] = [];
-    const seen = new Map<string, SharedPluginPageType[]>();
-    for (const page of pluginPages) {
-      const pluginId = page.PluginInfo.ID;
-      if (!seen.has(pluginId)) {
-        seen.set(pluginId, []);
-      }
-      seen.get(pluginId)!.push(page);
-    }
-    for (const [id, pages] of seen.entries()) {
-      groups.push({ id, name: pages[0].PluginInfo.Name, pages });
-    }
-    return groups;
-  }, [pluginPages]);
+  const pluginGroups = groupBy(pluginPages, page => page.PluginInfo.ID);
 
   const [newSettings, setNewSettings] = useState(settings);
 
@@ -193,19 +177,19 @@ const SettingsPage = () => {
                 {item.name}
               </NavLink>
             ))}
-            {pluginGroups.length > 0 && (
+            {!isEmpty(pluginGroups) && (
               <div className="mt-6 w-full border-t border-panel-border pt-6">
                 <div className="mb-4 text-center text-lg">Plugins</div>
-                {pluginGroups.map(group => (
-                  <div className="mb-4 flex flex-col gap-y-2" key={group.id}>
+                {map(pluginGroups, (group, groupId) => (
+                  <div className="mb-4 flex flex-col gap-y-2" key={groupId}>
                     <div className="px-2 text-center text-sm text-panel-text-primary opacity-60">
-                      {group.name}
+                      {group[0].Name}
                     </div>
-                    {group.pages.map(page => (
+                    {group.map(page => (
                       page.CanEmbed
                         ? (
                           <NavLink
-                            to={`plugin/${group.id}/${page.ID}`}
+                            to={`plugin/${groupId}/${page.ID}`}
                             className={({ isActive }) => (isActive
                               ? 'relative w-full text-center bg-panel-menu-item-background py-2 px-10 rounded-lg text-panel-menu-item-text'
                               : 'relative w-full text-center py-2 px-10 rounded-lg hover:bg-panel-menu-item-background-hover transition-colors')}

--- a/src/pages/settings/SettingsPage.tsx
+++ b/src/pages/settings/SettingsPage.tsx
@@ -43,7 +43,7 @@ const SettingsPage = () => {
   const settings = settingsQuery.data;
   const { isPending: settingsPatchPending, mutate: patchSettings } = usePatchSettingsMutation();
 
-  const { data: pluginPages } = usePluginPagesQuery();
+  const pluginPages = usePluginPagesQuery().data;
 
   const pluginGroups = useMemo(() => {
     if (!pluginPages) return [];

--- a/src/pages/settings/SettingsPage.tsx
+++ b/src/pages/settings/SettingsPage.tsx
@@ -198,7 +198,7 @@ const SettingsPage = () => {
                 <div className="mb-4 text-center text-lg">Plugins</div>
                 {pluginGroups.map(group => (
                   <div className="mb-4 flex flex-col gap-y-2" key={group.id}>
-                    <div className="px-2 text-sm text-panel-text-primary opacity-60">
+                    <div className="px-2 text-center text-sm text-panel-text-primary opacity-60">
                       {group.name}
                     </div>
                     {group.pages.map(page => (
@@ -213,7 +213,6 @@ const SettingsPage = () => {
                           >
                             <span>{page.Name}</span>
                             <a
-                              role="button"
                               href={page.Url}
                               target="_blank"
                               rel="noopener noreferrer"
@@ -222,7 +221,7 @@ const SettingsPage = () => {
                               data-tooltip-content={`Open ${page.Name} in new tab`}
                               title={`Open ${page.Name} in new tab`}
                               onClick={event => event.stopPropagation()}
-                              className="absolute top-1/2 right-2 flex -translate-y-1/2 cursor-pointer items-center justify-center rounded-md p-1 opacity-60 transition-opacity hover:opacity-100"
+                              className="absolute top-1/2 right-2 flex -translate-y-1/2 items-center justify-center rounded-md p-1 text-panel-text-primary opacity-60 transition-opacity hover:opacity-100"
                             >
                               <Icon path={mdiOpenInNew} size={0.7} />
                             </a>

--- a/src/pages/settings/SettingsPage.tsx
+++ b/src/pages/settings/SettingsPage.tsx
@@ -2,13 +2,14 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { NavLink, Outlet, useLocation } from 'react-router';
 import useMeasure from 'react-use-measure';
-import { mdiLoading } from '@mdi/js';
+import { mdiLoading, mdiOpenInNew } from '@mdi/js';
 import { Icon } from '@mdi/react';
 import { isEqual } from 'lodash';
 import { useDebounceValue } from 'usehooks-ts';
 
 import Button from '@/components/Input/Button';
 import toast from '@/components/Toast';
+import { usePluginPagesQuery } from '@/core/react-query/plugin/queries';
 import { usePatchSettingsMutation } from '@/core/react-query/settings/mutations';
 import { useSettingsQuery } from '@/core/react-query/settings/queries';
 import { setItem as setMiscItem } from '@/core/slices/misc';
@@ -41,6 +42,25 @@ const SettingsPage = () => {
   const settings = settingsQuery.data;
   const { isPending: settingsPatchPending, mutate: patchSettings } = usePatchSettingsMutation();
 
+  const { data: pluginPages } = usePluginPagesQuery();
+
+  const pluginGroups = useMemo(() => {
+    if (!pluginPages) return [];
+    const groups: { id: string, name: string, pages: typeof pluginPages }[] = [];
+    const seen = new Map<string, typeof pluginPages>();
+    for (const page of pluginPages) {
+      const pluginId = page.PluginInfo?.ID ?? '_unknown';
+      if (!seen.has(pluginId)) {
+        seen.set(pluginId, []);
+      }
+      seen.get(pluginId)!.push(page);
+    }
+    for (const [id, pages] of seen.entries()) {
+      groups.push({ id, name: pages[0].PluginInfo?.Name ?? id, pages });
+    }
+    return groups;
+  }, [pluginPages]);
+
   const [newSettings, setNewSettings] = useState(settings);
 
   useEffect(() => {
@@ -61,7 +81,7 @@ const SettingsPage = () => {
   const isSpecialPage = useMemo(() => {
     const path = pathname.split('/').pop();
     if (!path) return false;
-    if (pathname.includes('settings/dynamic/')) return true;
+    if (pathname.includes('settings/dynamic/') || pathname.includes('settings/plugin')) return true;
     return ['user-management', 'api-keys', 'hashing-release', 'dynamic'].includes(path);
   }, [pathname]);
 
@@ -172,6 +192,44 @@ const SettingsPage = () => {
                 {item.name}
               </NavLink>
             ))}
+            {pluginGroups.length > 0 && (
+              <div className="mt-6 w-full border-t border-panel-border pt-6">
+                <div className="mb-4 text-center text-lg">Plugins</div>
+                {pluginGroups.map(group => (
+                  <div className="mb-4 flex flex-col gap-y-2" key={group.id}>
+                    <div className="px-2 text-sm text-panel-text-primary opacity-60">
+                      {group.name}
+                    </div>
+                    {group.pages.map((page, pageIdx) => (
+                      page.CanEmbed
+                        ? (
+                          <NavLink
+                            to={`plugin/${group.id}/${pageIdx}`}
+                            className={({ isActive }) => (isActive
+                              ? 'w-full text-center bg-panel-menu-item-background py-2 px-2 rounded-lg text-panel-menu-item-text'
+                              : 'w-full text-center py-2 px-2 rounded-lg hover:bg-panel-menu-item-background-hover transition-colors')}
+                            key={page.Name}
+                          >
+                            {page.Name}
+                          </NavLink>
+                        )
+                        : (
+                          <a
+                            href={page.Url}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="flex w-full items-center justify-center gap-x-2 rounded-lg p-2 transition-colors hover:bg-panel-menu-item-background-hover"
+                            key={page.Name}
+                          >
+                            {page.Name}
+                            <Icon path={mdiOpenInNew} size={0.7} />
+                          </a>
+                        )
+                    ))}
+                  </div>
+                ))}
+              </div>
+            )}
           </div>
         </div>
       </div>

--- a/src/pages/settings/SettingsPage.tsx
+++ b/src/pages/settings/SettingsPage.tsx
@@ -219,7 +219,6 @@ const SettingsPage = () => {
                               tabIndex={-1}
                               data-tooltip-id="tooltip"
                               data-tooltip-content={`Open ${page.Name} in new tab`}
-                              title={`Open ${page.Name} in new tab`}
                               onClick={event => event.stopPropagation()}
                               className="absolute top-1/2 right-2 flex -translate-y-1/2 items-center justify-center rounded-md p-1 text-panel-text-primary opacity-60 transition-opacity hover:opacity-100"
                             >

--- a/src/pages/settings/SettingsPage.tsx
+++ b/src/pages/settings/SettingsPage.tsx
@@ -15,6 +15,7 @@ import { useSettingsQuery } from '@/core/react-query/settings/queries';
 import { setItem as setMiscItem } from '@/core/slices/misc';
 import { useDispatch } from '@/core/store';
 
+import type { SharedPluginPageType } from '@/core/types/api/plugin';
 import type { PluginRenamerSettingsType } from '@/core/types/api/settings';
 
 const items = [
@@ -46,17 +47,20 @@ const SettingsPage = () => {
 
   const pluginGroups = useMemo(() => {
     if (!pluginPages) return [];
-    const groups: { id: string, name: string, pages: typeof pluginPages }[] = [];
-    const seen = new Map<string, typeof pluginPages>();
-    for (const page of pluginPages) {
-      const pluginId = page.PluginInfo!.ID;
+    const sharedPages = pluginPages.filter(
+      (page): page is SharedPluginPageType => 'PluginInfo' in page,
+    );
+    const groups: { id: string, name: string, pages: SharedPluginPageType[] }[] = [];
+    const seen = new Map<string, SharedPluginPageType[]>();
+    for (const page of sharedPages) {
+      const pluginId = page.PluginInfo.ID;
       if (!seen.has(pluginId)) {
         seen.set(pluginId, []);
       }
       seen.get(pluginId)!.push(page);
     }
     for (const [id, pages] of seen.entries()) {
-      groups.push({ id, name: pages[0].PluginInfo!.Name, pages });
+      groups.push({ id, name: pages[0].PluginInfo.Name, pages });
     }
     return groups;
   }, [pluginPages]);
@@ -81,7 +85,7 @@ const SettingsPage = () => {
   const isSpecialPage = useMemo(() => {
     const path = pathname.split('/').pop();
     if (!path) return false;
-    if (pathname.includes('settings/dynamic/') || pathname.includes('settings/plugin')) return true;
+    if (pathname.includes('settings/dynamic/') || pathname.includes('settings/plugin/')) return true;
     return ['user-management', 'api-keys', 'hashing-release', 'dynamic'].includes(path);
   }, [pathname]);
 
@@ -208,7 +212,7 @@ const SettingsPage = () => {
                             className={({ isActive }) => (isActive
                               ? 'w-full text-center bg-panel-menu-item-background py-2 px-2 rounded-lg text-panel-menu-item-text'
                               : 'w-full text-center py-2 px-2 rounded-lg hover:bg-panel-menu-item-background-hover transition-colors')}
-                            key={page.Name}
+                            key={page.ID}
                           >
                             {page.Name}
                           </NavLink>
@@ -219,7 +223,7 @@ const SettingsPage = () => {
                             target="_blank"
                             rel="noopener noreferrer"
                             className="flex w-full items-center justify-center gap-x-2 rounded-lg p-2 transition-colors hover:bg-panel-menu-item-background-hover"
-                            key={page.Name}
+                            key={page.ID}
                           >
                             {page.Name}
                             <Icon path={mdiOpenInNew} size={0.7} />

--- a/src/pages/settings/SettingsPage.tsx
+++ b/src/pages/settings/SettingsPage.tsx
@@ -47,12 +47,9 @@ const SettingsPage = () => {
 
   const pluginGroups = useMemo(() => {
     if (!pluginPages) return [];
-    const sharedPages = pluginPages.filter(
-      (page): page is SharedPluginPageType => 'PluginInfo' in page,
-    );
     const groups: { id: string, name: string, pages: SharedPluginPageType[] }[] = [];
     const seen = new Map<string, SharedPluginPageType[]>();
-    for (const page of sharedPages) {
+    for (const page of pluginPages) {
       const pluginId = page.PluginInfo.ID;
       if (!seen.has(pluginId)) {
         seen.set(pluginId, []);

--- a/src/pages/settings/SettingsPage.tsx
+++ b/src/pages/settings/SettingsPage.tsx
@@ -183,7 +183,7 @@ const SettingsPage = () => {
                 {map(pluginGroups, (group, groupId) => (
                   <div className="mb-4 flex flex-col gap-y-2" key={groupId}>
                     <div className="px-2 text-center text-sm text-panel-text-primary opacity-60">
-                      {group[0].Name}
+                      {group[0].PluginInfo.Name}
                     </div>
                     {group.map(page => (
                       page.CanEmbed

--- a/src/pages/settings/SettingsPage.tsx
+++ b/src/pages/settings/SettingsPage.tsx
@@ -207,11 +207,25 @@ const SettingsPage = () => {
                           <NavLink
                             to={`plugin/${group.id}/${page.ID}`}
                             className={({ isActive }) => (isActive
-                              ? 'w-full text-center bg-panel-menu-item-background py-2 px-2 rounded-lg text-panel-menu-item-text'
-                              : 'w-full text-center py-2 px-2 rounded-lg hover:bg-panel-menu-item-background-hover transition-colors')}
+                              ? 'relative w-full text-center bg-panel-menu-item-background py-2 px-10 rounded-lg text-panel-menu-item-text'
+                              : 'relative w-full text-center py-2 px-10 rounded-lg hover:bg-panel-menu-item-background-hover transition-colors')}
                             key={page.ID}
                           >
-                            {page.Name}
+                            <span>{page.Name}</span>
+                            <a
+                              role="button"
+                              href={page.Url}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              tabIndex={-1}
+                              data-tooltip-id="tooltip"
+                              data-tooltip-content={`Open ${page.Name} in new tab`}
+                              title={`Open ${page.Name} in new tab`}
+                              onClick={event => event.stopPropagation()}
+                              className="absolute top-1/2 right-2 flex -translate-y-1/2 cursor-pointer items-center justify-center rounded-md p-1 opacity-60 transition-opacity hover:opacity-100"
+                            >
+                              <Icon path={mdiOpenInNew} size={0.7} />
+                            </a>
                           </NavLink>
                         )
                         : (

--- a/src/pages/settings/SettingsPage.tsx
+++ b/src/pages/settings/SettingsPage.tsx
@@ -49,14 +49,14 @@ const SettingsPage = () => {
     const groups: { id: string, name: string, pages: typeof pluginPages }[] = [];
     const seen = new Map<string, typeof pluginPages>();
     for (const page of pluginPages) {
-      const pluginId = page.PluginInfo?.ID ?? '_unknown';
+      const pluginId = page.PluginInfo!.ID;
       if (!seen.has(pluginId)) {
         seen.set(pluginId, []);
       }
       seen.get(pluginId)!.push(page);
     }
     for (const [id, pages] of seen.entries()) {
-      groups.push({ id, name: pages[0].PluginInfo?.Name ?? id, pages });
+      groups.push({ id, name: pages[0].PluginInfo!.Name, pages });
     }
     return groups;
   }, [pluginPages]);
@@ -200,11 +200,11 @@ const SettingsPage = () => {
                     <div className="px-2 text-sm text-panel-text-primary opacity-60">
                       {group.name}
                     </div>
-                    {group.pages.map((page, pageIdx) => (
+                    {group.pages.map(page => (
                       page.CanEmbed
                         ? (
                           <NavLink
-                            to={`plugin/${group.id}/${pageIdx}`}
+                            to={`plugin/${group.id}/${page.ID}`}
                             className={({ isActive }) => (isActive
                               ? 'w-full text-center bg-panel-menu-item-background py-2 px-2 rounded-lg text-panel-menu-item-text'
                               : 'w-full text-center py-2 px-2 rounded-lg hover:bg-panel-menu-item-background-hover transition-colors')}

--- a/src/pages/settings/plugin/PluginPageEmbed.tsx
+++ b/src/pages/settings/plugin/PluginPageEmbed.tsx
@@ -126,7 +126,7 @@ const PluginPageEmbed = () => {
         ref={iframeRef}
         src={page.Url}
         title={page.Name}
-        sandbox="allow-scripts allow-forms allow-same-origin"
+        sandbox="allow-scripts allow-forms allow-popups allow-same-origin"
         className="w-full rounded-lg"
         style={{ height: iframeHeight ?? undefined }}
       />

--- a/src/pages/settings/plugin/PluginPageEmbed.tsx
+++ b/src/pages/settings/plugin/PluginPageEmbed.tsx
@@ -6,10 +6,11 @@ import { Icon } from '@mdi/react';
 import { usePluginPagesForPluginQuery } from '@/core/react-query/plugin/queries';
 
 const PluginPageEmbed = () => {
-  const { pageIndex: pageIndexStr = '0', pluginId = '' } = useParams();
-  const pageIndex = Number(pageIndexStr);
+  const { pageId = '', pluginId = '' } = useParams();
 
   const { data: pages, isPending } = usePluginPagesForPluginQuery(pluginId);
+
+  const page = pages?.find(pgEntry => pgEntry.ID === pageId);
 
   const iframeRef = useRef<HTMLIFrameElement>(null);
   const [iframeHeight, setIframeHeight] = useState<number | null>(null);
@@ -17,7 +18,7 @@ const PluginPageEmbed = () => {
   // Reset height when navigating to a different page
   useEffect(() => {
     setIframeHeight(null);
-  }, [pluginId, pageIndex]);
+  }, [pluginId, pageId]);
 
   // Same-origin: track content height via ResizeObserver on the iframe document.
   // Cross-origin iframes throw on contentDocument access — caught silently.
@@ -56,7 +57,7 @@ const PluginPageEmbed = () => {
       iframe.removeEventListener('load', setupObserver);
       resizeObserver?.disconnect();
     };
-  }, [pluginId, pageIndex, pages]);
+  }, [pluginId, pageId, pages]);
 
   // Cross-origin: listen for postMessage from cooperating plugin pages.
   // Plugin pages send: { type: 'shoko-plugin-resize', height: <number> }
@@ -85,8 +86,6 @@ const PluginPageEmbed = () => {
       </div>
     );
   }
-
-  const page = pages?.[pageIndex];
 
   if (!page) {
     return (

--- a/src/pages/settings/plugin/PluginPageEmbed.tsx
+++ b/src/pages/settings/plugin/PluginPageEmbed.tsx
@@ -8,7 +8,7 @@ import { usePluginPagesForPluginQuery } from '@/core/react-query/plugin/queries'
 const PluginPageEmbed = () => {
   const { pageId = '', pluginId = '' } = useParams();
 
-  const { data: pages, isPending } = usePluginPagesForPluginQuery(pluginId);
+  const { data: pages, isPending } = usePluginPagesForPluginQuery(pluginId, pluginId !== '');
 
   const page = pages?.find(pgEntry => pgEntry.ID === pageId);
 
@@ -34,7 +34,12 @@ const PluginPageEmbed = () => {
         if (!doc?.body) return;
 
         const updateHeight = () => {
-          const height = doc.body.scrollHeight + 48; // We have a 3rem margin we need to negate.
+          // The settings content container has 1.5rem padding on each side.
+          // The wrapper div applies `-m-6` (1.5rem per side) to cancel that
+          // padding so the iframe sits flush against the container edges. The
+          // iframe still measures from the content area, so we add 48px
+          // (3rem = 2× the padding) to restore the full visual height.
+          const height = doc.body.scrollHeight + 48;
           if (height > 0) setIframeHeight(height);
         };
 
@@ -57,7 +62,7 @@ const PluginPageEmbed = () => {
       iframe.removeEventListener('load', setupObserver);
       resizeObserver?.disconnect();
     };
-  }, [pluginId, pageId, pages]);
+  }, [pluginId, pageId]);
 
   // Cross-origin: listen for postMessage from cooperating plugin pages.
   // Plugin pages send: { type: 'shoko-plugin-resize', height: <number> }
@@ -74,6 +79,7 @@ const PluginPageEmbed = () => {
 
     const handler = (event: MessageEvent) => {
       if (event.origin !== expectedOrigin) return;
+      if (event.source !== iframeRef.current?.contentWindow) return;
 
       const data: unknown = event.data;
       if (
@@ -84,7 +90,10 @@ const PluginPageEmbed = () => {
         && 'height' in data
         && typeof data.height === 'number'
       ) {
-        setIframeHeight(data.height);
+        // The +48 offset mirrors the same-origin logic above — see the
+        // updateHeight comment in the ResizeObserver effect for details.
+        const safeHeight = Math.max(50, Math.min(data.height, 8000)) + 48;
+        setIframeHeight(safeHeight);
       }
     };
     globalThis.addEventListener('message', handler);
@@ -113,6 +122,7 @@ const PluginPageEmbed = () => {
         ref={iframeRef}
         src={page.Url}
         title={page.Name}
+        sandbox="allow-scripts allow-forms allow-same-origin"
         className="w-full rounded-lg"
         style={{ height: iframeHeight ?? undefined }}
       />

--- a/src/pages/settings/plugin/PluginPageEmbed.tsx
+++ b/src/pages/settings/plugin/PluginPageEmbed.tsx
@@ -18,7 +18,11 @@ const PluginPageEmbed = () => {
   // Reset height when navigating to a different page
   useEffect(() => {
     setIframeHeight(null);
-  }, [pluginId, pageId]);
+  // `pages` is a dependency because the iframe is only rendered once data
+  // loads (see the isPending early return below). Without it, the effect
+  // would fire on mount when the iframe doesn't exist yet, and then never
+  // re-run when pages arrive and the iframe enters the DOM.
+  }, [pluginId, pageId, pages]);
 
   // Same-origin: track content height via ResizeObserver on the iframe document.
   // Cross-origin iframes throw on contentDocument access — caught silently.
@@ -62,7 +66,7 @@ const PluginPageEmbed = () => {
       iframe.removeEventListener('load', setupObserver);
       resizeObserver?.disconnect();
     };
-  }, [pluginId, pageId]);
+  }, [pluginId, pageId, pages]);
 
   // Cross-origin: listen for postMessage from cooperating plugin pages.
   // Plugin pages send: { type: 'shoko-plugin-resize', height: <number> }

--- a/src/pages/settings/plugin/PluginPageEmbed.tsx
+++ b/src/pages/settings/plugin/PluginPageEmbed.tsx
@@ -61,8 +61,20 @@ const PluginPageEmbed = () => {
 
   // Cross-origin: listen for postMessage from cooperating plugin pages.
   // Plugin pages send: { type: 'shoko-plugin-resize', height: <number> }
+  // We only accept messages from the origin of the currently embedded page.
   useEffect(() => {
+    if (!page?.Url) return undefined;
+
+    let expectedOrigin: string;
+    try {
+      expectedOrigin = new URL(page.Url).origin;
+    } catch {
+      return undefined;
+    }
+
     const handler = (event: MessageEvent) => {
+      if (event.origin !== expectedOrigin) return;
+
       const data: unknown = event.data;
       if (
         typeof data === 'object'
@@ -77,7 +89,7 @@ const PluginPageEmbed = () => {
     };
     globalThis.addEventListener('message', handler);
     return () => globalThis.removeEventListener('message', handler);
-  }, []);
+  }, [page]);
 
   if (isPending) {
     return (

--- a/src/pages/settings/plugin/PluginPageEmbed.tsx
+++ b/src/pages/settings/plugin/PluginPageEmbed.tsx
@@ -121,7 +121,7 @@ const PluginPageEmbed = () => {
   }
 
   return (
-    <div className="flex grow -m-6 w-[calc(100%+3rem)] rounded-lg">
+    <div className="-m-6 flex w-[calc(100%+3rem)] grow rounded-lg">
       <iframe
         ref={iframeRef}
         src={page.Url}

--- a/src/pages/settings/plugin/PluginPageEmbed.tsx
+++ b/src/pages/settings/plugin/PluginPageEmbed.tsx
@@ -1,0 +1,112 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { useParams } from 'react-router';
+import { mdiLoading } from '@mdi/js';
+import { Icon } from '@mdi/react';
+
+import { usePluginPagesForPluginQuery } from '@/core/react-query/plugin/queries';
+
+const PluginPageEmbed = () => {
+  const { pageIndex: pageIndexStr = '0', pluginId = '' } = useParams();
+  const pageIndex = Number(pageIndexStr);
+
+  const { data: pages, isPending } = usePluginPagesForPluginQuery(pluginId);
+
+  const iframeRef = useRef<HTMLIFrameElement>(null);
+  const [iframeHeight, setIframeHeight] = useState<number | null>(null);
+
+  // Reset height when navigating to a different page
+  useEffect(() => {
+    setIframeHeight(null);
+  }, [pluginId, pageIndex]);
+
+  // Same-origin: track content height via ResizeObserver on the iframe document.
+  // Cross-origin iframes throw on contentDocument access — caught silently.
+  useEffect(() => {
+    const iframe = iframeRef.current;
+    if (!iframe) return undefined;
+
+    let resizeObserver: ResizeObserver | undefined;
+
+    const setupObserver = () => {
+      try {
+        const doc = iframe.contentDocument ?? iframe.contentWindow?.document;
+        if (!doc?.body) return;
+
+        const updateHeight = () => {
+          const height = doc.body.scrollHeight + 48; // We have a 3rem margin we need to negate.
+          if (height > 0) setIframeHeight(height);
+        };
+
+        resizeObserver?.disconnect();
+        resizeObserver = new ResizeObserver(updateHeight);
+        resizeObserver.observe(doc.body);
+        updateHeight();
+      } catch {
+        // Cross-origin — contentDocument inaccessible, rely on postMessage
+      }
+    };
+
+    // Try immediately — catches the case where the iframe already loaded
+    // before this effect ran (race: commit DOM → browser loads → effect runs).
+    setupObserver();
+
+    // Also listen for load — fires when the iframe finishes loading.
+    iframe.addEventListener('load', setupObserver);
+    return () => {
+      iframe.removeEventListener('load', setupObserver);
+      resizeObserver?.disconnect();
+    };
+  }, [pluginId, pageIndex, pages]);
+
+  // Cross-origin: listen for postMessage from cooperating plugin pages.
+  // Plugin pages send: { type: 'shoko-plugin-resize', height: <number> }
+  useEffect(() => {
+    const handler = (event: MessageEvent) => {
+      const data: unknown = event.data;
+      if (
+        typeof data === 'object'
+        && data !== null
+        && 'type' in data
+        && data.type === 'shoko-plugin-resize'
+        && 'height' in data
+        && typeof data.height === 'number'
+      ) {
+        setIframeHeight(data.height);
+      }
+    };
+    globalThis.addEventListener('message', handler);
+    return () => globalThis.removeEventListener('message', handler);
+  }, []);
+
+  if (isPending) {
+    return (
+      <div className="flex grow items-center justify-center text-panel-text-primary">
+        <Icon path={mdiLoading} spin size={5} />
+      </div>
+    );
+  }
+
+  const page = pages?.[pageIndex];
+
+  if (!page) {
+    return (
+      <div className="flex grow items-center justify-center text-panel-text-primary">
+        Plugin page not found.
+      </div>
+    );
+  }
+
+  return (
+    <div className="-m-6 w-[calc(100%+3rem)] rounded-lg">
+      <iframe
+        ref={iframeRef}
+        src={page.Url}
+        title={page.Name}
+        className="w-full rounded-lg"
+        style={{ height: iframeHeight ?? undefined }}
+      />
+    </div>
+  );
+};
+
+export default PluginPageEmbed;

--- a/src/pages/settings/plugin/PluginPageEmbed.tsx
+++ b/src/pages/settings/plugin/PluginPageEmbed.tsx
@@ -18,10 +18,10 @@ const PluginPageEmbed = () => {
   // Reset height when navigating to a different page
   useEffect(() => {
     setIframeHeight(null);
-  // `pages` is a dependency because the iframe is only rendered once data
-  // loads (see the isPending early return below). Without it, the effect
-  // would fire on mount when the iframe doesn't exist yet, and then never
-  // re-run when pages arrive and the iframe enters the DOM.
+    // `pages` is a dependency because the iframe is only rendered once data
+    // loads (see the isPending early return below). Without it, the effect
+    // would fire on mount when the iframe doesn't exist yet, and then never
+    // re-run when pages arrive and the iframe enters the DOM.
   }, [pluginId, pageId, pages]);
 
   // Same-origin: track content height via ResizeObserver on the iframe document.

--- a/src/pages/settings/plugin/PluginPageEmbed.tsx
+++ b/src/pages/settings/plugin/PluginPageEmbed.tsx
@@ -117,7 +117,7 @@ const PluginPageEmbed = () => {
   }
 
   return (
-    <div className="-m-6 w-[calc(100%+3rem)] rounded-lg">
+    <div className="flex grow -m-6 w-[calc(100%+3rem)] rounded-lg">
       <iframe
         ref={iframeRef}
         src={page.Url}


### PR DESCRIPTION
Plugin pages are listed in the settings sidebar, grouped by plugin, with embeddable pages opening in an `<iframe/>` via the new new `/settings/plugin/:id/:index` route, and external pages opening in a new tab. External pages have an external link icon attched to them. Everything tested locally.

Example plugin page;
<img width="1312" height="2810" alt="image" src="https://github.com/user-attachments/assets/045e8773-57dd-4c77-aac5-4408ccb0119a" />
