### PR TITLE
remove: ReleaseInfo parallel mode and settings endpoint

### DIFF
--- a/src/components/Settings/HashingAndReleaseSettings/ReleaseSettings.tsx
+++ b/src/components/Settings/HashingAndReleaseSettings/ReleaseSettings.tsx
@@ -5,9 +5,9 @@ import { Icon } from '@mdi/react';
 import DnDList from '@/components/DnDList/DnDList';
 import Button from '@/components/Input/Button';
 import Checkbox from '@/components/Input/Checkbox';
-import { useReleaseInfoProvidersQuery, useReleaseInfoSummaryQuery } from '@/core/react-query/release-info/queries';
+import { useReleaseInfoProvidersQuery } from '@/core/react-query/release-info/queries';
 import { showProviderInfo } from '@/core/slices/modals/providerInfo';
-import { reorderProvider, setReleaseInfoSettings, toggleProvider } from '@/core/slices/settings/release';
+import { reorderProvider, toggleProvider } from '@/core/slices/settings/release';
 import { useDispatch, useSelector } from '@/core/store';
 
 import type { DropResult } from '@hello-pangea/dnd';
@@ -15,17 +15,9 @@ import type { DropResult } from '@hello-pangea/dnd';
 const ReleaseSettings = () => {
   const dispatch = useDispatch();
 
-  const { providers, releaseInfoSettings, webuiProviders } = useSelector(state => state.settings.release);
+  const { providers, webuiProviders } = useSelector(state => state.settings.release);
 
   const releaseProvidersQuery = useReleaseInfoProvidersQuery();
-  const releaseProviderSummaryQuery = useReleaseInfoSummaryQuery();
-
-  const handleToggleParallelMode = () => {
-    dispatch(setReleaseInfoSettings({
-      ParallelMode: !releaseInfoSettings.ParallelMode,
-    }));
-  };
-
   const handleProviderReorder = (result: DropResult, type: 'server' | 'webui') => {
     if (!result.destination || result.destination.index === result.source.index) {
       return;
@@ -45,29 +37,13 @@ const ReleaseSettings = () => {
     dispatch(toggleProvider({ checked, id, type }));
   };
 
-  if (!releaseProvidersQuery.isSuccess || !releaseProviderSummaryQuery.isSuccess) {
+  if (!releaseProvidersQuery.isSuccess) {
     return <Icon path={mdiLoading} size={4} spin className="m-auto text-panel-text-primary" />;
   }
 
   return (
     <div className="flex flex-col gap-y-6">
       <div className="flex items-center font-semibold">Release Provider Options</div>
-
-      <div className="flex flex-col">
-        <Checkbox
-          id="release-provider-parallel-mode"
-          isChecked={!!releaseInfoSettings.ParallelMode}
-          onChange={handleToggleParallelMode}
-          label="Parallel Mode"
-          justify
-        />
-
-        <div className="w-[95%] text-xs opacity-65">
-          {releaseInfoSettings.ParallelMode
-            ? 'Run all enabled providers in parallel, and wait for the highest priority valid result.'
-            : 'Run each provider in sequential order defined by the priority below until a valid result is found.'}
-        </div>
-      </div>
 
       <div className="flex flex-col gap-y-2">
         <div className="flex items-center">

--- a/src/core/react-query/release-info/mutations.ts
+++ b/src/core/react-query/release-info/mutations.ts
@@ -3,14 +3,8 @@ import { useMutation } from '@tanstack/react-query';
 import { axios } from '@/core/axios';
 import queryClient, { invalidateQueries } from '@/core/react-query/queryClient';
 
-import type { ReleaseInfoSettingsType, UpdateReleaseInfoProvidersType } from '@/core/react-query/release-info/types';
+import type { UpdateReleaseInfoProvidersType } from '@/core/react-query/release-info/types';
 import type { ReleaseInfoType } from '@/core/types/api/file';
-
-export const useUpdateReleaseInfoSettingsMutation = () =>
-  useMutation({
-    mutationFn: (settings: ReleaseInfoSettingsType) => axios.post('ReleaseInfo/Settings', settings),
-    onSuccess: () => invalidateQueries(['release-info', 'summary']),
-  });
 
 export const useUpdateReleaseInfoProvidersMutation = () =>
   useMutation({

--- a/src/core/react-query/release-info/queries.ts
+++ b/src/core/react-query/release-info/queries.ts
@@ -2,13 +2,7 @@ import { useQuery } from '@tanstack/react-query';
 
 import { axios } from '@/core/axios';
 
-import type { ReleaseInfoSettingsType, ReleaseProviderInfoType } from '@/core/react-query/release-info/types';
-
-export const useReleaseInfoSummaryQuery = () =>
-  useQuery<ReleaseInfoSettingsType>({
-    queryKey: ['release-info', 'summary'],
-    queryFn: () => axios.get('ReleaseInfo/Summary'),
-  });
+import type { ReleaseProviderInfoType } from '@/core/react-query/release-info/types';
 
 export const useReleaseInfoProvidersQuery = (noStale = false) =>
   useQuery<ReleaseProviderInfoType[]>({

--- a/src/core/react-query/release-info/types.ts
+++ b/src/core/react-query/release-info/types.ts
@@ -1,9 +1,5 @@
 import type { PluginInfoType } from '@/core/types/api/plugin';
 
-export type ReleaseInfoSettingsType = {
-  ParallelMode?: boolean;
-};
-
 export type UpdateReleaseInfoProvidersType = {
   ID: string;
   Priority?: number;

--- a/src/core/slices/settings/release.ts
+++ b/src/core/slices/settings/release.ts
@@ -1,13 +1,12 @@
 import { createSlice } from '@reduxjs/toolkit';
 import { forEach } from 'lodash';
 
-import type { ReleaseInfoSettingsType, ReleaseProviderInfoType } from '@/core/react-query/release-info/types';
+import type { ReleaseProviderInfoType } from '@/core/react-query/release-info/types';
 import type { PayloadAction } from '@reduxjs/toolkit';
 
 type State = {
   initialized: boolean;
   providers: ReleaseProviderInfoType[];
-  releaseInfoSettings: ReleaseInfoSettingsType;
   webuiProviders: ReleaseProviderInfoType[];
 };
 
@@ -31,7 +30,6 @@ type ToggleProviderActionType = {
 const initialState: State = {
   initialized: false,
   providers: [],
-  releaseInfoSettings: { ParallelMode: false },
   webuiProviders: [],
 };
 
@@ -46,9 +44,6 @@ const release = createSlice({
       sliceState.providers = action.payload.providers;
       sliceState.webuiProviders = action.payload.webuiProviders;
       sliceState.initialized = true;
-    },
-    setReleaseInfoSettings(sliceState, action: PayloadAction<ReleaseInfoSettingsType>) {
-      sliceState.releaseInfoSettings = action.payload;
     },
     reorderProvider(sliceState, action: PayloadAction<ReorderProviderActionType>) {
       const { destinationIndex, sourceIndex, type } = action.payload;
@@ -74,7 +69,6 @@ export const {
   clearReleaseSettings,
   reorderProvider,
   setProviders,
-  setReleaseInfoSettings,
   toggleProvider,
 } = release.actions;
 

--- a/src/pages/settings/tabs/HashingAndReleaseSettings.tsx
+++ b/src/pages/settings/tabs/HashingAndReleaseSettings.tsx
@@ -13,15 +13,12 @@ import ReleaseSettings from '@/components/Settings/HashingAndReleaseSettings/Rel
 import toast from '@/components/Toast';
 import { useUpdateHashingSettingsMutation } from '@/core/react-query/hashing/mutations';
 import { useHashingProvidersQuery, useHashingSummaryQuery } from '@/core/react-query/hashing/queries';
-import {
-  useUpdateReleaseInfoProvidersMutation,
-  useUpdateReleaseInfoSettingsMutation,
-} from '@/core/react-query/release-info/mutations';
-import { useReleaseInfoProvidersQuery, useReleaseInfoSummaryQuery } from '@/core/react-query/release-info/queries';
+import { useUpdateReleaseInfoProvidersMutation } from '@/core/react-query/release-info/mutations';
+import { useReleaseInfoProvidersQuery } from '@/core/react-query/release-info/queries';
 import { usePatchSettingsMutation } from '@/core/react-query/settings/mutations';
 import { useSettingsQuery } from '@/core/react-query/settings/queries';
 import { hideProviderInfo, showProviderInfo } from '@/core/slices/modals/providerInfo';
-import { clearReleaseSettings, setProviders, setReleaseInfoSettings } from '@/core/slices/settings/release';
+import { clearReleaseSettings, setProviders } from '@/core/slices/settings/release';
 import { useDispatch, useSelector } from '@/core/store';
 import useToggleModalKeybinds from '@/hooks/useToggleModalKeybinds';
 
@@ -30,22 +27,15 @@ import type { ManualLinkProviderType } from '@/core/types/utilities/unrecognized
 
 const HashingAndReleaseSettings = () => {
   const dispatch = useDispatch();
-  const {
-    initialized,
-    providers,
-    releaseInfoSettings,
-    webuiProviders,
-  } = useSelector(state => state.settings.release);
+  const { initialized, providers, webuiProviders } = useSelector(state => state.settings.release);
   const { show: showProviderInfoModal } = useSelector(state => state.modals.providerInfo);
 
   const settings = useSettingsQuery().data;
   const releaseProvidersQuery = useReleaseInfoProvidersQuery();
-  const releaseProviderSummaryQuery = useReleaseInfoSummaryQuery();
   const hashingProvidersQuery = useHashingProvidersQuery();
   const hashingSummaryQuery = useHashingSummaryQuery();
 
   const { mutate: patchSettings } = usePatchSettingsMutation();
-  const { mutate: updateReleaseInfoSettings } = useUpdateReleaseInfoSettingsMutation();
   const { mutate: updateReleaseInfoProviders } = useUpdateReleaseInfoProvidersMutation();
   const { mutate: updateHashingSettings } = useUpdateHashingSettingsMutation();
 
@@ -58,12 +48,9 @@ const HashingAndReleaseSettings = () => {
 
   useEffect(() => {
     if (
-      !releaseProvidersQuery.data || !releaseProviderSummaryQuery.data || !hashingProvidersQuery.data
-      || !hashingSummaryQuery.data
+      !releaseProvidersQuery.data || !hashingProvidersQuery.data || !hashingSummaryQuery.data
     ) return;
     setHashingSettings(hashingSummaryQuery.data);
-
-    dispatch(setReleaseInfoSettings({ ParallelMode: releaseProviderSummaryQuery.data.ParallelMode ?? false }));
 
     const cleanWebuiProviders = settings.WebUI_Settings.releaseInfoProviders
       .map((webuiProvider) => {
@@ -83,7 +70,6 @@ const HashingAndReleaseSettings = () => {
   }, [
     hashingProvidersQuery.data,
     hashingSummaryQuery.data,
-    releaseProviderSummaryQuery.data,
     releaseProvidersQuery.data,
     settings,
     dispatch,
@@ -98,11 +84,9 @@ const HashingAndReleaseSettings = () => {
 
   const hashingSettingsChanged = hashingSummaryQuery.data?.ParallelMode !== hashingSettings.ParallelMode;
   const releaseProvidersChanged = !isEqual(releaseProvidersQuery.data, providers);
-  const releaseInfoSettingsChanged =
-    releaseProviderSummaryQuery.data?.ParallelMode !== releaseInfoSettings.ParallelMode;
   const webuiProvidersChanged = !isEqual(settings.WebUI_Settings.releaseInfoProviders, newWebuiProviderOrder);
   const unsavedChanges = initialized
-    && (hashingSettingsChanged || releaseProvidersChanged || releaseInfoSettingsChanged || webuiProvidersChanged);
+    && (hashingSettingsChanged || releaseProvidersChanged || webuiProvidersChanged);
   const [debouncedUnsavedChanges] = useDebounceValue(unsavedChanges, 100);
 
   // Use debounced value for unsaved changes to avoid flashing the toast for certain changes
@@ -135,10 +119,6 @@ const HashingAndReleaseSettings = () => {
 
     if (releaseProvidersChanged) {
       updateReleaseInfoProviders(providers);
-    }
-
-    if (releaseInfoSettingsChanged) {
-      updateReleaseInfoSettings({ ParallelMode: releaseInfoSettings.ParallelMode });
     }
 
     if (webuiProvidersChanged) {


### PR DESCRIPTION
Removes everything related to ReleaseInfo Parallel Mode and the `ReleaseInfo/Settings` endpoint, which have been removed from the backend.

## Changes

- **Types** — Remove `ReleaseInfoSettingsType` (only contained `ParallelMode`)
- **Queries** — Remove `useReleaseInfoSummaryQuery` (called `GET ReleaseInfo/Summary`)
- **Mutations** — Remove `useUpdateReleaseInfoSettingsMutation` (called `POST ReleaseInfo/Settings`)
- **Redux** — Remove `releaseInfoSettings` state property, `setReleaseInfoSettings` reducer and export
- **UI** — Remove Parallel Mode checkbox and description from `ReleaseSettings`; remove all `releaseInfoSettings`-related dispatch, change detection, and save logic from `HashingAndReleaseSettings`
