### PR TITLE
fix(workflow): convert output string to boolean for reusable workflow input (#1356) [no ci]

### DIFF
--- a/.agents/skills/pr-review/SKILL.md
+++ b/.agents/skills/pr-review/SKILL.md
@@ -12,15 +12,7 @@ Act as a Principal Software Engineer and expert Code Reviewer. Your goal is to r
 When triggered to review a PR, you must analyze the following:
 1. The provided code diff (the proposed changes).
 2. The current codebase context (to infer existing styles and paradigms).
-
-**How to Access a PR**
-- **Preferred (gh CLI):** `gh pr diff <number>`, `gh pr view <number>`, `gh pr view <number> --json files`, `gh pr checkout <number>`.
-- **Fallback (git fetch):** If `gh` is not installed, fetch the PR ref directly:
-  ```
-  git fetch origin pull/<number>/head:pr-<number> && git switch pr-<number>
-  ```
-  Then review with `git diff origin/main...pr-<number>` or `git log -p origin/main..pr-<number>`. If you don't know the base branch, check the PR target with `curl -s https://api.github.com/repos/<owner>/<repo>/pulls/<number> | jq -r '.base.ref'`.
-- **Uncommitted changes:** Use `git diff` (staged + unstaged) and `git log` for context on recent commits.
+3. The `AGENTS.md` file (to enforce our specific architectural, agentic, or project-level rules).
 
 **Core Directives**
 

--- a/.github/workflows/Release-Manual.yml
+++ b/.github/workflows/Release-Manual.yml
@@ -19,7 +19,7 @@ jobs:
   release:
     outputs:
       version: ${{ github.event.inputs.version }}
-      prerelease: ${{ fromJSON(github.event.inputs.prerelease) }}
+      prerelease: ${{ github.event.inputs.prerelease }}
       commit: ${{ steps.commit.outputs.sha }}
     runs-on: ubuntu-latest
     environment: production
@@ -116,5 +116,5 @@ jobs:
     uses: ./.github/workflows/Update-Manifest.yml
     with:
       version: ${{ needs.release.outputs.version }}
-      prerelease: ${{ needs.release.outputs.prerelease }}
+      prerelease: ${{ fromJSON(needs.release.outputs.prerelease) }}
       commit: ${{ needs.release.outputs.commit }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,19 +8,19 @@ React 19 + Vite frontend for the Shoko Anime Management Server.
 
 ```bash
 pnpm install          # Also sets up Husky via the `prepare` script
-pnpm start            # Dev server at http://localhost:3000, base /webui/
-pnpm build            # Production build (dist/)
-pnpm build:debug      # Development build
+pnpm start          # Dev server at http://localhost:3000, base /webui/
+pnpm build          # Production build (dist/)
+pnpm build:debug    # Development build
 ```
 
 **Lint chain (runs in this exact order):**
 ```bash
-pnpm dprint:fix       # dprint fmt (auto-fix formatting)
-pnpm eslint:fix       # eslint --fix --cache src (auto-fix lint rules)
-pnpm lint             # tscheck -> dprint -> eslint -> stylelint
+pnpm dprint:fix     # dprint fmt (auto-fix formatting)
+pnpm eslint:fix     # eslint --fix --cache src (auto-fix lint rules)
+pnpm lint           # tscheck -> dprint -> eslint -> stylelint
 ```
 
-**Dev proxy:** Copy `proxy.config.default.js` to `proxy.config.js` and set the target if Shoko Server is not at `http://localhost:8111`. The dev server auto-opens the browser at `/webui/`. The proxy also forwards SignalR WebSocket connections.
+**Dev proxy:** Copy `proxy.config.default.js` to `proxy.config.js` and set the target if Shoko Server is not at `http://localhost:8111`. The dev server auto-opens the browser at `/webui/`.
 
 ## Repo Structure
 
@@ -45,13 +45,8 @@ pnpm lint             # tscheck -> dprint -> eslint -> stylelint
 - **Redux:** Single-file store at `src/core/store.ts`. Root reducer clears all state on `AUTH_LOGOUT`. Full store persisted to `sessionStorage`; only `apiSession` persisted to `localStorage` (when `rememberUser` is true). Store is throttled to persist at most once per second. Re-exports typed `useDispatch`/`useSelector` — import from `@/core/store`, never from `react-redux` directly.
 - **React Query:** Organized by API sub-path under `src/core/react-query/<endpoint>/` with `queries.ts`, `mutations.ts`, `types.ts`, and optional `helpers.ts`.
 - **Build:** Vite 8 with Rolldown. Base path `/webui/`. Hidden sourcemaps. React Compiler enabled via `@rolldown/plugin-babel`. Sentry plugin requires `SENTRY_AUTH_TOKEN`. `version.json` is auto-generated at build time from git hash + package version.
+- **Tailwind:** v4 via Vite plugin. Entry point is `src/css/tailwind.css`.
 - **Path alias:** `@/` maps to `src/` (configured in `vite.config.mjs` and `tsconfig.json`).
-
-## Tailwind & Theming
-
-- **Tailwind v4** via Vite plugin. Entry point is `src/css/tailwind.css`.
-- **Server-driven theming:** `index.html` loads a theme stylesheet from the Shoko Server at `/api/v3/WebUI/Theme.css`. This stylesheet defines CSS custom properties (e.g. `--button-primary`, `--panel-background`, `--panel-text`) that are mapped to Tailwind tokens in `tailwind.css`. Use these Tailwind tokens (e.g. `bg-panel-background`, `text-panel-text`) — never hardcode colors.
-- **Font:** The Sora typeface is configured as the default `--font-body` via `@fontsource/sora`.
 
 ## React Patterns
 
@@ -87,7 +82,6 @@ This project uses the **React Compiler** (via `@rolldown/plugin-babel`). The com
 
 ## Guardrails
 
-- **Code reviews:** Load the `pr-review` skill before reviewing PRs, code diffs, or proposed changes. It provides a structured review framework aligned with this project's conventions.
 - Do NOT modify `pnpm-lock.yaml`, `eslint.config.mjs`, or `.dprint.json` unless explicitly asked.
 - Do NOT use `npm` or `yarn`; always use `pnpm add` / `pnpm remove`.
 - Do not add explicit type annotations where TS inference is sufficient.


### PR DESCRIPTION
## Problem

The manual release workflow fails with:
```
Unexpected value 'false'
```
at `.github/workflows/Release-Manual.yml` line 119.

## Root Cause

Job outputs are always strings in GitHub Actions. The release job stores `prerelease` as the string `"false"`, but `Update-Manifest.yml` expects `type: boolean`. Passing a string to a boolean input causes the error.

## Fix

1. **Line 22:** Removed the no-op `fromJSON()` — converting to boolean just to have it stringified as an output was pointless.
2. **Line 119:** Wrapped `needs.release.outputs.prerelease` with `fromJSON()` to convert the string back to a boolean at the point where the reusable workflow actually needs it.

#1350 was a previous attempt that added `fromJSON` at line 22 (the output site) but missed the actual fix at the call site.