### PR TITLE
chore: migrate pnpm config from package.json to pnpm-workspace.yaml

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shoko-webui",
-  "version": "2.6.0-dev",
+  "version": "2.6.0",
   "private": true,
   "sideEffects": false,
   "engines": {

--- a/package.json
+++ b/package.json
@@ -94,11 +94,6 @@
     "typescript-eslint": "8.60.1",
     "vite": "^8.0.16"
   },
-  "pnpm": {
-    "overrides": {
-      "dompurify": "^3.4.7"
-    }
-  },
   "scripts": {
     "eslint": "eslint src",
     "eslint:fix": "eslint --fix --cache src",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,1 +1,8 @@
 minimumReleaseAge: 1440
+overrides:
+  dompurify: ^3.4.7
+allowBuilds:
+  '@sentry/cli': true
+  dprint: true
+  esbuild: true
+  unrs-resolver: true


### PR DESCRIPTION
Move pnpm.overrides to pnpm-workspace.yaml and add allowBuilds for
build script dependencies as required by pnpm v11.x (required for `pnpm install` starting version 11)
    
Should still compatible with pnpm v10.x