### PR TITLE
Prepare for pnpm 11

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,11 +94,6 @@
     "typescript-eslint": "8.60.1",
     "vite": "^8.0.16"
   },
-  "pnpm": {
-    "overrides": {
-      "dompurify": "^3.4.7"
-    }
-  },
   "scripts": {
     "eslint": "eslint src",
     "eslint:fix": "eslint --fix --cache src",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,1 +1,8 @@
 minimumReleaseAge: 1440
+overrides:
+  dompurify: ^3.4.7
+allowBuilds:
+  '@sentry/cli': true
+  dprint: true
+  esbuild: true
+  unrs-resolver: true


### PR DESCRIPTION
- Migrate pnpm settings from `package.json` to `pnpm-workspace.yaml`. Both `overrides` and `allowBuilds` are supported in pnpm 10, making this change backward compatible while preparing for pnpm 11 where the `pnpm` field in `package.json` is no longer read.

- `allowBuilds` is required in pnpm 11 because build scripts for dependencies are no longer allowed by default — without it, `pnpm install` will fail with `ERR_PNPM_IGNORED_BUILDS`.