### PR TITLE
Add settings modal for plugin update preferences

### DIFF
--- a/src/components/Settings/PluginManagement/Dialogs/PluginUpdateSettingsModal.tsx
+++ b/src/components/Settings/PluginManagement/Dialogs/PluginUpdateSettingsModal.tsx
@@ -1,0 +1,157 @@
+import React, { useEffect, useState } from 'react';
+import { produce } from 'immer';
+import { isEqual, toNumber } from 'lodash';
+
+import Button from '@/components/Input/Button';
+import Checkbox from '@/components/Input/Checkbox';
+import SelectSmall from '@/components/Input/SelectSmall';
+import ModalPanel from '@/components/Panels/ModalPanel';
+import UpdateFrequencyValues from '@/components/Settings/UpdateFrequencyValues';
+import { useVersionQuery } from '@/core/react-query/init/queries';
+import { usePatchSettingsMutation } from '@/core/react-query/settings/mutations';
+import { useSettingsQuery } from '@/core/react-query/settings/queries';
+import { convertMsToTimeSpan, convertTimeSpanToMs, dayjs } from '@/core/util';
+
+import type { PluginUpdatesSettingsType, SettingsUpdateFrequencyType } from '@/core/types/api/settings';
+
+type Props = {
+  onClose: () => void;
+  show: boolean;
+};
+
+const PluginUpdateSettingsModal = ({ onClose, show }: Props) => {
+  const settings = useSettingsQuery().data;
+  const versionQuery = useVersionQuery();
+  const { isPending: isSavePending, mutate: patchSettings } = usePatchSettingsMutation();
+
+  const isDevChannel = versionQuery.data?.Server.ReleaseChannel !== 'Stable';
+
+  const [updatesSettings, setUpdatesSettings] = useState(settings.Plugins.Updates);
+
+  useEffect(() => {
+    setUpdatesSettings(settings.Plugins.Updates);
+  }, [settings.Plugins.Updates]);
+
+  const unsavedChanges = !isEqual(settings.Plugins.Updates, updatesSettings);
+
+  const {
+    AutoUpdateFrequency,
+    InactivePluginVersionRetention,
+    IsAutoSyncEnabled,
+    IsAutoUpgradeEnabled,
+  } = updatesSettings;
+
+  const updateUpdatesSetting = <Key extends keyof PluginUpdatesSettingsType>(
+    key: Key,
+    value: PluginUpdatesSettingsType[Key],
+  ) => {
+    setUpdatesSettings(produce(updatesSettings, (draft) => {
+      draft[key] = value;
+    }));
+  };
+
+  const handleCancel = () => {
+    setUpdatesSettings(settings.Plugins.Updates);
+    onClose();
+  };
+
+  const handleSave = () => {
+    patchSettings(
+      produce(settings, (draft) => {
+        draft.Plugins.Updates = updatesSettings;
+      }),
+      { onSuccess: () => onClose() },
+    );
+  };
+
+  return (
+    <ModalPanel
+      show={show}
+      onRequestClose={onClose}
+      header="Plugin Update Settings"
+      size="sm"
+      footer={
+        <div className="flex justify-end gap-x-3 font-semibold">
+          <Button onClick={handleCancel} buttonType="secondary" buttonSize="normal">
+            Cancel
+          </Button>
+          <Button
+            onClick={handleSave}
+            buttonType="primary"
+            buttonSize="normal"
+            loading={isSavePending}
+            disabled={!unsavedChanges}
+          >
+            Save
+          </Button>
+        </div>
+      }
+    >
+      <div className="flex flex-col gap-y-6">
+        {isDevChannel && (
+          <>
+            <div className="flex flex-col gap-y-1">
+              <div className="flex items-center justify-between">
+                <span>Update Frequency</span>
+                <SelectSmall
+                  id="auto-update-frequency"
+                  value={AutoUpdateFrequency}
+                  onChange={event =>
+                    updateUpdatesSetting(
+                      'AutoUpdateFrequency',
+                      toNumber(event.target.value) as SettingsUpdateFrequencyType,
+                    )}
+                >
+                  <UpdateFrequencyValues min24Hours />
+                </SelectSmall>
+              </div>
+            </div>
+
+            <div className="border-b border-panel-border" />
+          </>
+        )}
+
+        <div className="flex flex-col gap-y-6">
+          <div className="flex items-center font-semibold">Plugin Updates</div>
+          <div className="flex flex-col gap-y-1">
+            <Checkbox
+              justify
+              label="Automatically Sync Repositories"
+              id="is-auto-sync-enabled"
+              isChecked={IsAutoSyncEnabled}
+              onChange={event => updateUpdatesSetting('IsAutoSyncEnabled', event.target.checked)}
+            />
+            <Checkbox
+              justify
+              label="Automatically Upgrade Plugins"
+              id="is-auto-upgrade-enabled"
+              isChecked={IsAutoUpgradeEnabled}
+              onChange={event => updateUpdatesSetting('IsAutoUpgradeEnabled', event.target.checked)}
+            />
+            <div className="flex items-center justify-between">
+              <span>Inactive Version Retention</span>
+              <SelectSmall
+                id="inactive-plugin-version-retention"
+                value={Math.round(dayjs.duration(convertTimeSpanToMs(InactivePluginVersionRetention)).asDays())}
+                onChange={event =>
+                  updateUpdatesSetting(
+                    'InactivePluginVersionRetention',
+                    convertMsToTimeSpan(dayjs.duration(toNumber(event.target.value), 'days').asMilliseconds()),
+                  )}
+              >
+                <option value={7}>7 Days</option>
+                <option value={14}>14 Days</option>
+                <option value={30}>30 Days</option>
+                <option value={90}>90 Days</option>
+                <option value={180}>180 Days</option>
+                <option value={365}>1 Year</option>
+              </SelectSmall>
+            </div>
+          </div>
+        </div>
+      </div>
+    </ModalPanel>
+  );
+};
+
+export default PluginUpdateSettingsModal;

--- a/src/components/Settings/PluginManagement/Dialogs/PluginUpdateSettingsModal.tsx
+++ b/src/components/Settings/PluginManagement/Dialogs/PluginUpdateSettingsModal.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { produce } from 'immer';
 import { isEqual, toNumber } from 'lodash';
 
@@ -28,10 +28,6 @@ const PluginUpdateSettingsModal = ({ onClose, show }: Props) => {
 
   const [updatesSettings, setUpdatesSettings] = useState(settings.Plugins.Updates);
 
-  useEffect(() => {
-    setUpdatesSettings(settings.Plugins.Updates);
-  }, [settings.Plugins.Updates]);
-
   const unsavedChanges = !isEqual(settings.Plugins.Updates, updatesSettings);
 
   const {
@@ -56,12 +52,11 @@ const PluginUpdateSettingsModal = ({ onClose, show }: Props) => {
   };
 
   const handleSave = () => {
-    patchSettings(
-      produce(settings, (draft) => {
-        draft.Plugins.Updates = updatesSettings;
-      }),
-      { onSuccess: () => onClose() },
-    );
+    const newSettings = produce(settings, (draft) => {
+      draft.Plugins.Updates = updatesSettings;
+    });
+
+    patchSettings(newSettings, { onSuccess: () => onClose() });
   };
 
   return (
@@ -111,42 +106,40 @@ const PluginUpdateSettingsModal = ({ onClose, show }: Props) => {
           </>
         )}
 
-        <div className="flex flex-col gap-y-6">
-          <div className="flex items-center font-semibold">Plugin Updates</div>
-          <div className="flex flex-col gap-y-1">
-            <Checkbox
-              justify
-              label="Automatically Sync Repositories"
-              id="is-auto-sync-enabled"
-              isChecked={IsAutoSyncEnabled}
-              onChange={event => updateUpdatesSetting('IsAutoSyncEnabled', event.target.checked)}
-            />
-            <Checkbox
-              justify
-              label="Automatically Upgrade Plugins"
-              id="is-auto-upgrade-enabled"
-              isChecked={IsAutoUpgradeEnabled}
-              onChange={event => updateUpdatesSetting('IsAutoUpgradeEnabled', event.target.checked)}
-            />
-            <div className="flex items-center justify-between">
-              <span>Inactive Version Retention</span>
-              <SelectSmall
-                id="inactive-plugin-version-retention"
-                value={Math.round(dayjs.duration(convertTimeSpanToMs(InactivePluginVersionRetention)).asDays())}
-                onChange={event =>
-                  updateUpdatesSetting(
-                    'InactivePluginVersionRetention',
-                    convertMsToTimeSpan(dayjs.duration(toNumber(event.target.value), 'days').asMilliseconds()),
-                  )}
-              >
-                <option value={7}>7 Days</option>
-                <option value={14}>14 Days</option>
-                <option value={30}>30 Days</option>
-                <option value={90}>90 Days</option>
-                <option value={180}>180 Days</option>
-                <option value={365}>1 Year</option>
-              </SelectSmall>
-            </div>
+        <div className="flex items-center font-semibold">Plugin Updates</div>
+        <div className="flex flex-col gap-y-1">
+          <Checkbox
+            justify
+            label="Automatically Sync Repositories"
+            id="is-auto-sync-enabled"
+            isChecked={IsAutoSyncEnabled}
+            onChange={event => updateUpdatesSetting('IsAutoSyncEnabled', event.target.checked)}
+          />
+          <Checkbox
+            justify
+            label="Automatically Upgrade Plugins"
+            id="is-auto-upgrade-enabled"
+            isChecked={IsAutoUpgradeEnabled}
+            onChange={event => updateUpdatesSetting('IsAutoUpgradeEnabled', event.target.checked)}
+          />
+          <div className="flex items-center justify-between">
+            <span>Inactive Version Retention</span>
+            <SelectSmall
+              id="inactive-plugin-version-retention"
+              value={Math.round(dayjs.duration(convertTimeSpanToMs(InactivePluginVersionRetention)).asDays())}
+              onChange={event =>
+                updateUpdatesSetting(
+                  'InactivePluginVersionRetention',
+                  convertMsToTimeSpan(dayjs.duration(toNumber(event.target.value), 'days').asMilliseconds()),
+                )}
+            >
+              <option value={7}>7 Days</option>
+              <option value={14}>14 Days</option>
+              <option value={30}>30 Days</option>
+              <option value={90}>90 Days</option>
+              <option value={180}>180 Days</option>
+              <option value={365}>1 Year</option>
+            </SelectSmall>
           </div>
         </div>
       </div>

--- a/src/core/react-query/settings/helpers.ts
+++ b/src/core/react-query/settings/helpers.ts
@@ -414,6 +414,13 @@ export const initialSettings: SettingsType = {
       AllowRelocationInsideDestinationOnImport: true,
       DefaultRenamer: null,
     },
+    Updates: {
+      IsAutoSyncEnabled: false,
+      IsAutoUpgradeEnabled: false,
+      AutoUpdateFrequency: 4,
+      DefaultRepositoryStaleTime: '12:00:00',
+      InactivePluginVersionRetention: '30.00:00:00',
+    },
   },
 };
 

--- a/src/core/types/api/settings.ts
+++ b/src/core/types/api/settings.ts
@@ -331,10 +331,21 @@ export type PluginRenamerSettingsType = {
   DefaultRenamer: string | null;
 };
 
+export type PluginUpdatesSettingsType = {
+  IsAutoSyncEnabled: boolean;
+  IsAutoUpgradeEnabled: boolean;
+  AutoUpdateFrequency: SettingsUpdateFrequencyType;
+  // .NET TimeSpan string, e.g. "12:00:00" or "30.00:00:00".
+  DefaultRepositoryStaleTime: string;
+  // .NET TimeSpan string, e.g. "12:00:00" or "30.00:00:00".
+  InactivePluginVersionRetention: string;
+};
+
 export type PluginSettingsType = {
   EnabledPlugins: Record<string, boolean>;
   Priority: string[];
   Renamer: PluginRenamerSettingsType;
+  Updates: PluginUpdatesSettingsType;
 };
 
 export type SettingsServerType = {

--- a/src/core/util.ts
+++ b/src/core/util.ts
@@ -55,14 +55,25 @@ export const copyToClipboard = async (text: string, entityName?: string) => {
 };
 
 /**
- * To convert TimeSpan returned by ASP.NET for duration (eg. 00:24:02.2424) to milliseconds
+ * To convert a TimeSpan string returned by the API in the "[d.]hh:mm:ss[.fffffff]"
+ * format (eg. "00:24:02.2424" or "30.00:00:00") to milliseconds. The day-prefix is
+ * optional and only present on longer TimeSpan values, such as the plugin update settings.
  */
 export const convertTimeSpanToMs = (timeSpan: string) => {
-  const [duration, durationMs] = timeSpan.split('.');
-  const [hours, minutes, seconds] = duration.split(':');
-  return (((toNumber(hours) * 3600) + (toNumber(minutes) * 60) + toNumber(seconds)) * 1000)
-    + toNumber((durationMs ?? '0').slice(0, 3));
+  const [hourSegment, minutes, secondSegment] = timeSpan.split(':');
+  const [days, hours] = hourSegment.includes('.') ? hourSegment.split('.') : ['0', hourSegment];
+  const [seconds, durationMs] = secondSegment.includes('.') ? secondSegment.split('.') : [secondSegment, '0'];
+
+  return (toNumber(days) * 86400 * 1000)
+    + (((toNumber(hours) * 3600) + (toNumber(minutes) * 60) + toNumber(seconds)) * 1000)
+    + toNumber(durationMs.slice(0, 3));
 };
+
+/**
+ * To convert milliseconds to a TimeSpan string in the "d.hh:mm:ss" format
+ * expected by the API for the plugin update settings.
+ */
+export const convertMsToTimeSpan = (milliseconds: number) => dayjs.duration(milliseconds).format('D.HH:mm:ss');
 
 export const padNumber = (num: number | string, size = 2) => num.toString().padStart(size, '0');
 

--- a/src/pages/settings/SettingsPage.tsx
+++ b/src/pages/settings/SettingsPage.tsx
@@ -18,6 +18,14 @@ import { useDispatch } from '@/core/store';
 
 import type { PluginRenamerSettingsType } from '@/core/types/api/settings';
 
+type SettingValueType =
+  | string
+  | string[]
+  | number
+  | boolean
+  | PluginRenamerSettingsType
+  | undefined;
+
 const items = [
   { name: 'General', path: 'general' },
   { name: 'Import', path: 'import' },
@@ -99,13 +107,13 @@ const SettingsPage = () => {
   const updateSetting = (
     type: string,
     key: string,
-    value: string | string[] | number | boolean | PluginRenamerSettingsType | undefined,
+    value: SettingValueType,
   ) => {
     if (key === 'theme' && typeof value === 'string') {
       globalThis.localStorage.setItem('theme', value);
     }
 
-    const tempSettings: Record<string, string | string[] | number | boolean | PluginRenamerSettingsType | undefined> = {
+    const tempSettings: Record<string, SettingValueType> = {
       ...(newSettings[type] as Record<string, string | string[] | boolean>),
       [key]: value,
     };

--- a/src/pages/settings/tabs/PluginManagementSettings.tsx
+++ b/src/pages/settings/tabs/PluginManagementSettings.tsx
@@ -38,7 +38,7 @@ const PluginManagementSettings = () => {
   return (
     <>
       <title>Settings &gt; Plugin Management | Shoko</title>
-      <div className="flex flex-col gap-y-1 sm:gap-y-2">
+      <div className="flex flex-col gap-y-2">
         <div className="flex items-center justify-between">
           <div className="text-xl font-semibold">Plugin Management</div>
           <Button onClick={toggleSettingsModal} tooltip="Settings">

--- a/src/pages/settings/tabs/PluginManagementSettings.tsx
+++ b/src/pages/settings/tabs/PluginManagementSettings.tsx
@@ -1,10 +1,12 @@
 import React, { useState } from 'react';
 import { Navigate, useParams } from 'react-router';
-import { mdiMagnify } from '@mdi/js';
-import { useDebounceValue } from 'usehooks-ts';
+import { mdiCogOutline, mdiMagnify } from '@mdi/js';
+import { useDebounceValue, useToggle } from 'usehooks-ts';
 
+import IconButton from '@/components/Input/IconButton';
 import Input from '@/components/Input/Input';
 import MultiStateButton from '@/components/Input/MultiStateButton';
+import PluginUpdateSettingsModal from '@/components/Settings/PluginManagement/Dialogs/PluginUpdateSettingsModal';
 import BrowseSection from '@/components/Settings/PluginManagement/Sections/BrowseSection';
 import InstalledSection from '@/components/Settings/PluginManagement/Sections/InstalledSection';
 import RepositoriesSection from '@/components/Settings/PluginManagement/Sections/RepositoriesSection';
@@ -26,6 +28,7 @@ const PluginManagementSettings = () => {
   const { section } = useParams();
   const [query, setQuery] = useState('');
   const [debouncedQuery] = useDebounceValue(query?.toLowerCase().trim(), 300);
+  const [showSettingsModal, toggleSettingsModal] = useToggle(false);
 
   if (!isValidSection(section)) {
     return <Navigate replace to="../installed" />;
@@ -34,10 +37,21 @@ const PluginManagementSettings = () => {
   return (
     <>
       <title>Settings &gt; Plugin Management | Shoko</title>
-      <div className="flex flex-col gap-y-1 sm:gap-y-2">
-        <div className="text-xl font-semibold">Plugin Management</div>
-        <div className="max-w-3xl">
-          Manage plugin repositories, browse plugin packages, review installed plugins, and manually apply updates.
+      <div className="flex items-center justify-between">
+        <div className="flex flex-col gap-y-1 sm:gap-y-2">
+          <div className="text-xl font-semibold">Plugin Management</div>
+          <div className="max-w-3xl">
+            Manage plugin repositories, browse plugin packages, review installed plugins, and manually apply updates.
+          </div>
+        </div>
+        <div className="flex gap-x-2">
+          <IconButton
+            icon={mdiCogOutline}
+            buttonType="secondary"
+            buttonSize="normal"
+            onClick={toggleSettingsModal}
+            tooltip="Settings"
+          />
         </div>
       </div>
 
@@ -62,6 +76,8 @@ const PluginManagementSettings = () => {
       {section === 'browse' && <BrowseSection query={debouncedQuery} />}
       {section === 'updates' && <UpdatesSection query={debouncedQuery} />}
       {section === 'repositories' && <RepositoriesSection query={debouncedQuery} />}
+
+      <PluginUpdateSettingsModal show={showSettingsModal} onClose={toggleSettingsModal} />
     </>
   );
 };

--- a/src/pages/settings/tabs/PluginManagementSettings.tsx
+++ b/src/pages/settings/tabs/PluginManagementSettings.tsx
@@ -1,9 +1,10 @@
 import React, { useState } from 'react';
 import { Navigate, useParams } from 'react-router';
 import { mdiCogOutline, mdiMagnify } from '@mdi/js';
+import Icon from '@mdi/react';
 import { useDebounceValue, useToggle } from 'usehooks-ts';
 
-import IconButton from '@/components/Input/IconButton';
+import Button from '@/components/Input/Button';
 import Input from '@/components/Input/Input';
 import MultiStateButton from '@/components/Input/MultiStateButton';
 import PluginUpdateSettingsModal from '@/components/Settings/PluginManagement/Dialogs/PluginUpdateSettingsModal';
@@ -37,21 +38,15 @@ const PluginManagementSettings = () => {
   return (
     <>
       <title>Settings &gt; Plugin Management | Shoko</title>
-      <div className="flex items-center justify-between">
-        <div className="flex flex-col gap-y-1 sm:gap-y-2">
+      <div className="flex flex-col gap-y-1 sm:gap-y-2">
+        <div className="flex items-center justify-between">
           <div className="text-xl font-semibold">Plugin Management</div>
-          <div className="max-w-3xl">
-            Manage plugin repositories, browse plugin packages, review installed plugins, and manually apply updates.
-          </div>
+          <Button onClick={toggleSettingsModal} tooltip="Settings">
+            <Icon className="text-panel-icon-action" path={mdiCogOutline} size={1} />
+          </Button>
         </div>
-        <div className="flex gap-x-2">
-          <IconButton
-            icon={mdiCogOutline}
-            buttonType="secondary"
-            buttonSize="normal"
-            onClick={toggleSettingsModal}
-            tooltip="Settings"
-          />
+        <div>
+          Manage plugin repositories, browse plugin packages, review installed plugins, and manually apply updates.
         </div>
       </div>
 


### PR DESCRIPTION
Surfaces the `Plugins.Updates` server settings (auto-sync repositories, auto-upgrade plugins, update frequency, inactive version retention) through a new modal, opened via a cogwheel button on the Plugin Management page — mirroring the existing dashboard settings modal pattern.

Changes:
- New `PluginUpdateSettingsModal` with local draft state, save/cancel, and its own patch mutation (consistent with `DashboardSettingsModal`)
- Add `PluginUpdatesSettingsType` and `Plugins.Updates` initial defaults (verified against the swagger schema)
- Extend `convertTimeSpanToMs` in `core/util.ts` to handle the optional day-prefix present in longer TimeSpan values (e.g. `"30.00:00:00"`), and add `convertMsToTimeSpan` for the reverse conversion — both used to translate between milliseconds and the API's `"[d.]hh:mm:ss"` TimeSpan format
- Wire the cogwheel button + modal into `PluginManagementSettings`