### PR TITLE
Simplify ReleaseManagement cache invalidation

### DIFF
--- a/src/components/Utilities/ReleaseManagement/DuplicatesInfo.tsx
+++ b/src/components/Utilities/ReleaseManagement/DuplicatesInfo.tsx
@@ -2,67 +2,22 @@ import React, { useState } from 'react';
 import { mdiTrashCanOutline } from '@mdi/js';
 import Icon from '@mdi/react';
 import cx from 'classnames';
-import { produce } from 'immer';
-import { sortBy } from 'lodash';
 
 import ConfirmationPromptModal from '@/components/Dialogs/ConfirmationPromptModal';
 import Button from '@/components/Input/Button';
 import { useDeleteFileLocationMutation } from '@/core/react-query/file/mutations';
 import { useManagedFoldersQuery } from '@/core/react-query/managed-folder/queries';
-import queryClient from '@/core/react-query/queryClient';
+import { invalidateQueries } from '@/core/react-query/queryClient';
 import useToggleModalKeybinds from '@/hooks/useToggleModalKeybinds';
 
-import type { ListResultType } from '@/core/types/api';
-import type { EpisodeType } from '@/core/types/api/episode';
 import type { FileLocationType, FileType } from '@/core/types/api/file';
-import type { InfiniteData } from '@tanstack/react-query';
-
-const getFileForLocation = (
-  data: InfiniteData<ListResultType<EpisodeType>>,
-  locationId: number,
-) => {
-  for (const page of data.pages) {
-    for (const episode of page.List) {
-      for (const file of episode.Files ?? []) {
-        if (file?.Locations?.some(loc => loc.ID === locationId)) {
-          return file;
-        }
-      }
-    }
-  }
-  return undefined;
-};
-
-const handleSuccess = (locationId: number, seriesId: number) => {
-  queryClient.setQueriesData<InfiniteData<ListResultType<EpisodeType>>>(
-    { queryKey: ['release-management', 'series', 'episodes', 'DuplicateFiles', seriesId], type: 'active' },
-    prevData =>
-      produce(prevData, (draft) => {
-        if (!draft) return;
-        const file = getFileForLocation(draft, locationId);
-        if (!file) return;
-
-        const foundLocation = file.Locations.find(loc => loc.ID === locationId);
-        if (!foundLocation) return;
-
-        foundLocation.AbsolutePath = '';
-        file.Locations = sortBy(file.Locations, [
-          location => !location.AbsolutePath,
-        ]);
-      }),
-  );
-};
 
 type Props = {
   file: FileType;
-  handleEpisodeChange: (type: 'previous' | 'next') => void;
   location: FileLocationType;
-  seriesId: number;
 };
 
-const DuplicatesInfo = (props: Props) => {
-  const { file, handleEpisodeChange, location, seriesId } = props;
-
+const DuplicatesInfo = ({ file, location }: Props) => {
   const [confirmDelete, setConfirmDelete] = useState(false);
 
   const managedFoldersQuery = useManagedFoldersQuery();
@@ -72,13 +27,8 @@ const DuplicatesInfo = (props: Props) => {
   const handleDelete = async () => {
     if (!confirmDelete) return;
 
-    await deleteFileLocation({ locationId: location.ID })
-      .then(() => {
-        handleSuccess(location.ID, seriesId);
-        // We check for `=== 2` here since we are checking stale data
-        const oneLocationLeft = file.Locations.filter(fileLocation => !!fileLocation.AbsolutePath).length === 2;
-        if (oneLocationLeft) handleEpisodeChange('next');
-      });
+    await deleteFileLocation({ locationId: location.ID });
+    invalidateQueries(['release-management', 'series', 'episodes']);
   };
 
   // To re-enable the correct keybinds once the delete confirmation modal closes

--- a/src/components/Utilities/ReleaseManagement/MultipleReleasesInfo.tsx
+++ b/src/components/Utilities/ReleaseManagement/MultipleReleasesInfo.tsx
@@ -2,22 +2,18 @@ import React, { useState } from 'react';
 import { mdiFlagOffOutline, mdiFlagOutline, mdiOpenInNew, mdiTrashCanOutline } from '@mdi/js';
 import Icon from '@mdi/react';
 import cx from 'classnames';
-import { produce } from 'immer';
-import { map, sortBy } from 'lodash';
+import { map } from 'lodash';
 import prettyBytes from 'pretty-bytes';
 
 import ConfirmationPromptModal from '@/components/Dialogs/ConfirmationPromptModal';
 import Button from '@/components/Input/Button';
 import { useDeleteFileMutation, useMarkVariationMutation } from '@/core/react-query/file/mutations';
 import { useManagedFoldersQuery } from '@/core/react-query/managed-folder/queries';
-import queryClient from '@/core/react-query/queryClient';
+import { invalidateQueries } from '@/core/react-query/queryClient';
 import { dayjs } from '@/core/util';
 import useToggleModalKeybinds from '@/hooks/useToggleModalKeybinds';
 
-import type { ListResultType } from '@/core/types/api';
-import type { EpisodeType } from '@/core/types/api/episode';
 import type { FileType } from '@/core/types/api/file';
-import type { InfiniteData } from '@tanstack/react-query';
 
 const parseFlag = (flag?: boolean) => {
   if (flag == null) return 'N/A';
@@ -25,57 +21,11 @@ const parseFlag = (flag?: boolean) => {
   return 'No';
 };
 
-const getEpisodeForFile = (
-  data: InfiniteData<ListResultType<EpisodeType>>,
-  fileId: number,
-) => {
-  for (const page of data.pages) {
-    for (const episode of page.List) {
-      if (episode.Files?.some(file => file.ID === fileId)) {
-        return episode;
-      }
-    }
-  }
-  return undefined;
-};
-
-const handleSuccess = (fileId: number, seriesId: number, type: 'delete' | 'variation', variation?: boolean) => {
-  queryClient.setQueriesData<InfiniteData<ListResultType<EpisodeType>>>(
-    { queryKey: ['release-management', 'series', 'episodes', 'MultipleReleases', seriesId], type: 'active' },
-    prevData =>
-      produce(prevData, (draft) => {
-        if (!draft) return;
-        const episode = getEpisodeForFile(draft, fileId);
-        if (!episode) return;
-
-        const foundFile = episode.Files?.find(file => file.ID === fileId);
-        if (!foundFile) return;
-
-        if (type === 'delete') {
-          foundFile.Size = -1;
-        } else {
-          foundFile.IsVariation = !!variation;
-        }
-
-        episode.Files = sortBy(episode.Files, [
-          file => file.Size === -1,
-          // eslint-disable-next-line no-nested-ternary
-          file => (file.Size === -1 ? 0 : (file.IsVariation ? 1 : 0)),
-        ]);
-      }),
-  );
-};
-
 type Props = {
-  episode?: EpisodeType;
   file: FileType;
-  handleEpisodeChange: (type: 'previous' | 'next') => void;
-  seriesId: number;
 };
 
-const MultipleReleasesInfo = (props: Props) => {
-  const { episode, file, handleEpisodeChange, seriesId } = props;
-
+const MultipleReleasesInfo = ({ file }: Props) => {
   const [confirmDelete, setConfirmDelete] = useState(false);
 
   const managedFoldersQuery = useManagedFoldersQuery();
@@ -85,21 +35,15 @@ const MultipleReleasesInfo = (props: Props) => {
 
   const handleMarkVariation = (fileId: number, variation: boolean) => {
     markVariation({ fileId, variation }, {
-      onSuccess: () => handleSuccess(fileId, seriesId, 'variation', variation),
+      onSuccess: () => invalidateQueries(['release-management', 'series', 'episodes']),
     });
   };
 
   const handleDelete = async () => {
     if (!confirmDelete) return;
 
-    await deleteFile({ fileId: file.ID })
-      .then(() => {
-        handleSuccess(file.ID, seriesId, 'delete');
-        if (!episode?.Files) return;
-        // We check for `=== 2` here since we are checking stale data
-        const oneFileLeft = episode.Files.filter(episodeFile => episodeFile.Size > 0).length === 2;
-        if (oneFileLeft) handleEpisodeChange('next');
-      });
+    await deleteFile({ fileId: file.ID });
+    invalidateQueries(['release-management', 'series', 'episodes']);
   };
 
   // To re-enable the correct keybinds once the delete confirmation modal closes

--- a/src/components/Utilities/ReleaseManagement/ReleaseManagementModal.tsx
+++ b/src/components/Utilities/ReleaseManagement/ReleaseManagementModal.tsx
@@ -22,7 +22,6 @@ type Props = {
   handleEpisodeChange: (type: 'previous' | 'next') => void;
   isFetching: boolean;
   onClose: () => void;
-  seriesId: number;
   show: boolean;
   type: ReleaseManagementItemType;
 };
@@ -60,7 +59,7 @@ const EpisodeName = ({ episode }: { episode: EpisodeType }) => (
 );
 
 const ReleaseManagementModal = (props: Props) => {
-  const { episode, episodeCount, episodeIndex, handleEpisodeChange, isFetching, onClose, seriesId, show, type } = props;
+  const { episode, episodeCount, episodeIndex, handleEpisodeChange, isFetching, onClose, show, type } = props;
 
   useToggleModalKeybinds(show, 'modal');
   useToggleModalKeybinds(!show, 'primary');
@@ -97,10 +96,7 @@ const ReleaseManagementModal = (props: Props) => {
         {!isFetching && type === 'MultipleReleases' && map(episode.Files, file => (
           <MultipleReleasesInfo
             key={file.ID}
-            episode={episode}
             file={file}
-            handleEpisodeChange={handleEpisodeChange}
-            seriesId={seriesId}
           />
         ))}
 
@@ -109,9 +105,7 @@ const ReleaseManagementModal = (props: Props) => {
             <DuplicatesInfo
               key={location.ID}
               file={file}
-              handleEpisodeChange={handleEpisodeChange}
               location={location}
-              seriesId={seriesId}
             />
           )))}
       </div>

--- a/src/components/Utilities/ReleaseManagement/SeriesList.tsx
+++ b/src/components/Utilities/ReleaseManagement/SeriesList.tsx
@@ -325,7 +325,6 @@ const SeriesList = (
           }}
           episodeCount={episodeCount}
           episodeIndex={selectedEpisode}
-          seriesId={selectedSeries}
           isFetching={episodesQuery.isFetchingNextPage}
           type={type}
         />


### PR DESCRIPTION
Replace manual `queryClient.setQueriesData` cache manipulation with standard `invalidateQueries` calls in the Release Management components.

### Changes
- **DuplicatesInfo / MultipleReleasesInfo:** Replace manual cache patching (`immer.produce` + `lodash.sortBy`) with `invalidateQueries` after delete/delete-location/variation-toggle mutations
- **ReleaseManagementModal / SeriesList:** Drop `seriesId`, `handleEpisodeChange`, and `episode` props — only consumed by the old cache-manipulation helpers
- Remove now-dead helper functions: `getFileForLocation`, `getEpisodeForFile`, `handleSuccess`
- Remove unused imports (`produce`, `sortBy`, `ListResultType`, `EpisodeType`, `InfiniteData`)

Net: −113 lines, +11 lines. Cleaner components that follow the established `invalidateQueries` pattern used throughout the codebase.