### PR TITLE
Add install state badges to plugin browse and update sections

### DIFF
--- a/src/components/Settings/PluginManagement/Sections/BrowseSection.tsx
+++ b/src/components/Settings/PluginManagement/Sections/BrowseSection.tsx
@@ -1,10 +1,10 @@
-import React, { useMemo } from 'react';
+import React from 'react';
 import AnimateHeight from 'react-animate-height';
 import { mdiLoading } from '@mdi/js';
 import { Icon } from '@mdi/react';
 import cx from 'classnames';
 import dayjs from 'dayjs';
-import { map, some } from 'lodash';
+import { find, map, some } from 'lodash';
 import { useToggle } from 'usehooks-ts';
 
 import { Badge } from '@/components/Badge';
@@ -23,12 +23,6 @@ const Version = ({ manifest, version }: { manifest: PackageManifestInfoType, ver
 
   const isCompatible = some(version.Archives, archive => archive.IsCompatible);
 
-  const installTooltip = useMemo(() => {
-    if (!isCompatible) return 'Incompatible';
-    if (version.IsInstalled) return 'Already installed';
-    return '';
-  }, [isCompatible, version.IsInstalled]);
-
   const cannotInstall = version.IsInstalled || !isCompatible;
 
   return (
@@ -38,6 +32,11 @@ const Version = ({ manifest, version }: { manifest: PackageManifestInfoType, ver
           {version.Version}
           <span className="opacity-65">{version.Channel === 'Dev' && ' (Dev)'}</span>
           <span className="opacity-65">{!isCompatible && ' [Incompatible]'}</span>
+          {version.IsInstalled && (
+            <Badge className="ml-2 bg-panel-text-important text-button-primary-text">
+              Installed
+            </Badge>
+          )}
         </div>
 
         <div className="opacity-65">
@@ -50,7 +49,7 @@ const Version = ({ manifest, version }: { manifest: PackageManifestInfoType, ver
           buttonSize="small"
           onClick={toggleInstallModal}
           disabled={cannotInstall}
-          tooltip={installTooltip}
+          tooltip={!isCompatible ? 'Incompatible' : ''}
         >
           Install
         </Button>
@@ -75,6 +74,8 @@ const Package = ({ plugin }: { plugin: PackageManifestInfoType }) => {
   const thumbnailUrl = plugin.Thumbnail ? `/api/v3/Plugin/Package/${plugin.PackageID}/Thumbnail` : null;
   const [latestVersion, ...oldVersions] = plugin.Releases ?? [];
 
+  const installedVersion = find(plugin.Releases, release => release.IsInstalled)?.Version;
+
   return (
     <div className="flex flex-col gap-y-4 rounded-lg border border-panel-border bg-panel-input p-4">
       <div className="flex gap-x-4">
@@ -88,6 +89,11 @@ const Package = ({ plugin }: { plugin: PackageManifestInfoType }) => {
             <div className="text-lg font-semibold">
               {plugin.Name}
             </div>
+            {installedVersion && (
+              <Badge className="bg-panel-text-important text-button-primary-text">
+                {`Installed: ${installedVersion}`}
+              </Badge>
+            )}
           </div>
 
           <div className="text-sm opacity-65">

--- a/src/components/Settings/PluginManagement/Sections/UpdatesSection.tsx
+++ b/src/components/Settings/PluginManagement/Sections/UpdatesSection.tsx
@@ -4,6 +4,7 @@ import { Icon } from '@mdi/react';
 import { filter } from 'lodash';
 import { useToggle } from 'usehooks-ts';
 
+import { Badge } from '@/components/Badge';
 import Button from '@/components/Input/Button';
 import PluginInstallModal from '@/components/Settings/PluginManagement/Dialogs/PluginInstallModal';
 import toast from '@/components/Toast';
@@ -79,7 +80,14 @@ const UpdatesSection = ({ query }: Props) => {
               >
                 <div className="flex justify-between">
                   <div>
-                    <div className="font-semibold">{update.Name}</div>
+                    <div className="flex gap-x-2 font-semibold">
+                      {update.Name}
+                      {update.Latest.Release.IsInstalled && (
+                        <Badge className="bg-panel-text-warning text-button-primary-text">
+                          Restart required
+                        </Badge>
+                      )}
+                    </div>
                     <div className="text-sm opacity-65">
                       {update.Current.Release.Version}
                       &nbsp;→&nbsp;
@@ -87,12 +95,13 @@ const UpdatesSection = ({ query }: Props) => {
                     </div>
                   </div>
                   <Button
-                    buttonType="primary"
+                    buttonType={update.Latest.Release.IsInstalled ? 'secondary' : 'primary'}
                     buttonSize="small"
                     onClick={() => {
                       setSelectedPackage(update);
                       toggleUpdateModal();
                     }}
+                    disabled={update.Latest.Release.IsInstalled}
                   >
                     Upgrade
                   </Button>


### PR DESCRIPTION
Browse Section: Added Installed badge on version rows and package headers, removed redundant installTooltip useMemo. Updates Section: Added Restart required badge for already-installed updates, disabled Upgrade button with secondary styling, fixed import ordering.