### PR TITLE
fix: migrate two deprecated API v3 endpoints

### DIFF
--- a/src/core/react-query/init/mutations.ts
+++ b/src/core/react-query/init/mutations.ts
@@ -4,9 +4,9 @@ import { axios } from '@/core/axios';
 
 import type { UserRequestType } from '@/core/react-query/init/types';
 
-export const useStartServerMutation = () =>
+export const useCompleteSetupMutation = () =>
   useMutation({
-    mutationFn: () => axios.get('Init/StartServer'),
+    mutationFn: () => axios.post('Init/CompleteSetup'),
   });
 
 export const useSetDefaultUserMutation = () =>

--- a/src/core/react-query/series/queries.ts
+++ b/src/core/react-query/series/queries.ts
@@ -59,7 +59,7 @@ export const useSeriesAniDBEpisodesQuery = (anidbId: number, params: SeriesAniDB
 export const useSeriesAniDBSearchQuery = (query: string, enabled = true) =>
   useQuery<ListResultType<SeriesAniDBSearchResult>, unknown, SeriesAniDBSearchResult[]>({
     queryKey: ['series', 'anidb-search', query],
-    queryFn: () => axios.get(`Series/AniDB/Search/${encodeURIComponent(query)}`),
+    queryFn: () => axios.get('Series/AniDB/Search', { params: { query } }),
     select: transformListResultSimplified,
     enabled,
   });

--- a/src/pages/firstrun/StartServer.tsx
+++ b/src/pages/firstrun/StartServer.tsx
@@ -4,7 +4,7 @@ import { useOutletContext } from 'react-router';
 import Button from '@/components/Input/Button';
 import TransitionDiv from '@/components/TransitionDiv';
 import { useLoginMutation } from '@/core/react-query/auth/mutations';
-import { useStartServerMutation } from '@/core/react-query/init/mutations';
+import { useCompleteSetupMutation } from '@/core/react-query/init/mutations';
 import { useServerStatusQuery } from '@/core/react-query/init/queries';
 import { setSaved as setFirstRunSaved } from '@/core/slices/firstrun';
 import { useDispatch, useSelector } from '@/core/store';
@@ -23,7 +23,7 @@ const StartServer = () => {
   const [pollingInterval, setPollingInterval] = useState(0);
 
   const { setIsPersistent } = useOutletContext<OutletContextType>();
-  const { mutate: startServer } = useStartServerMutation();
+  const { mutate: completeSetup } = useCompleteSetupMutation();
   const { mutate: login } = useLoginMutation();
   const serverStatusQuery = useServerStatusQuery(pollingInterval);
 
@@ -47,7 +47,7 @@ const StartServer = () => {
 
   const handleStart = () => {
     setIsPersistent(true);
-    startServer();
+    completeSetup();
     setPollingInterval(500);
   };
 


### PR DESCRIPTION
## Summary

Migrates two deprecated API v3 endpoints to their non-deprecated replacements:

1. **`GET /Series/AniDB/Search/{query}` → `GET /Series/AniDB/Search?query=`**
   - Moves query from path parameter to query parameter

2. **`GET /Init/StartServer` → `POST /Init/CompleteSetup`**
   - Renames `useStartServerMutation` → `useCompleteSetupMutation`
   - Changes HTTP method and endpoint path
   - Updates `StartServer.tsx` callers accordingly