### PR TITLE
docs: add agent lint workflow to AGENTS.md (#1375) [no ci]

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,8 +79,10 @@ This project uses the **React Compiler** (via `@rolldown/plugin-babel`). The com
 - **No unit/integration tests** are configured. Verification is `pnpm lint`.
 - **Pre-commit:** Husky runs `lint-staged` (configured in `lint-staged.config.js`), which executes `tsc --noEmit` on all TS/TSX files (not just staged), plus `dprint fmt`, `eslint --cache`, and `stylelint` on staged files. `stylelint` only covers `src/css/*.css` (flat, not recursive).
 - **PR CI:** `.github/workflows/Lint-PR.yml` runs `pnpm lint --quiet`.
+- **Agent lint workflow:**
+  - After every file edit, run `./node_modules/.bin/dprint fmt <file>` to format just that file.
+  - After completing edits on a file, run `./node_modules/.bin/eslint --cache <file>` to catch lint errors early — fix them before moving on.
 - **Never skip pre-commit hooks.** Always let Husky run — do not use `--no-verify` or equivalent.
-- **Don't run the linter frequently during development.** Run it only at the end of completing a feature or when preparing a commit. Let pre-commit hooks handle the rest.
 
 ## Guardrails
 


### PR DESCRIPTION
Replaces the outdated 'don't run the linter frequently during development' guidance with a concrete per-file agent lint workflow:

- `./node_modules/.bin/dprint fmt <file>` — format after every file edit
- `./node_modules/.bin/eslint --cache <file>` — lint after completing file edits

Both commands verified to work correctly with the project's dprint and eslint configs.