### PR TITLE
fix(logs): fix level column overflow and adaptive width

### DIFF
--- a/src/pages/logs/LogsPage.tsx
+++ b/src/pages/logs/LogsPage.tsx
@@ -98,7 +98,7 @@ const LogsPage = () => {
                   style={{ height: rowVirtualizer.getTotalSize() }}
                 >
                   <div
-                    className="absolute top-0 left-4 w-[95%]"
+                    className="absolute inset-x-4 top-0"
                     style={{ transform: `translateY(${virtualItems[0]?.start ?? 0}px)` }}
                   >
                     {virtualItems.map((virtualRow) => {
@@ -111,7 +111,7 @@ const LogsPage = () => {
                           ref={rowVirtualizer.measureElement}
                         >
                           <div className="w-44 shrink-0 opacity-65">{row.TimeStamp}</div>
-                          <div className="w-[2.8rem] shrink-0">{row.Level}</div>
+                          <div className="w-32 shrink-0 overflow-hidden whitespace-nowrap">{row.Level}</div>
                           <div className="break-all">{row.Message}</div>
                         </div>
                       );


### PR DESCRIPTION
## Summary

- `w-[2.8rem]` on the log level column was too narrow for level strings like "Informational", causing text to wrap and push adjacent rows out of position in the virtualizer. Widened to `w-32` and added `overflow-hidden whitespace-nowrap` to guarantee single-line rendering.
- `left-4 w-[95%]` on the inner virtualizer wrapper used a hardcoded percentage that did not adapt correctly across resolutions. Replaced with `inset-x-4` so both edges track the container's 16px border inset.

## Changes

2 lines changed in `src/pages/logs/LogsPage.tsx`. All other virtualizer logic (scrollRect hack, measureElement, estimateSize, contain-strict) is untouched.