### PR TITLE
Fix live filter rebuild for tag and boolean criteria

### DIFF
--- a/src/components/Collection/Filter/FilterSidebar.tsx
+++ b/src/components/Collection/Filter/FilterSidebar.tsx
@@ -92,10 +92,6 @@ const FilterSidebar = () => {
   const isFilterValid = keys(selectedCriteria).length > 0
     && keys(selectedCriteria).length === keys(activeCriteriaWithValues).length;
 
-  // buildSidebarFilter reads filterConditions internally via store.getState(),
-  // which the React Compiler can't trace. Explicitly reading selectedConditions
-  // here teaches the compiler this expression depends on it. Also guards against
-  // building a filter when no conditions are set.
   const finalFilterExpression = isFilterValid
     ? buildSidebarFilter(
       Object.values(selectedCriteria),

--- a/src/components/Collection/Filter/FilterSidebar.tsx
+++ b/src/components/Collection/Filter/FilterSidebar.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { useParams } from 'react-router';
 import { mdiContentSaveOutline, mdiFilterPlusOutline } from '@mdi/js';
-import { keys, map, values } from 'lodash';
+import { keys, map } from 'lodash';
 
 import AddCriteriaModal from '@/components/Collection/Filter/AddCriteriaModal';
 import DefaultCriteria from '@/components/Collection/Filter/DefaultCriteria';
@@ -84,6 +84,9 @@ const FilterSidebar = () => {
   const dispatch = useDispatch();
   const selectedCriteria = useSelector(state => state.collection.filterCriteria);
   const selectedConditions = useSelector(state => state.collection.filterConditions);
+  const selectedMatch = useSelector(state => state.collection.filterMatch);
+  const selectedTags = useSelector(state => state.collection.filterTags);
+  const selectedValues = useSelector(state => state.collection.filterValues);
   const activeCriteriaWithValues = useSelector(selectActiveCriteriaWithValues);
 
   const isFilterValid = keys(selectedCriteria).length > 0
@@ -93,8 +96,16 @@ const FilterSidebar = () => {
   // which the React Compiler can't trace. Explicitly reading selectedConditions
   // here teaches the compiler this expression depends on it. Also guards against
   // building a filter when no conditions are set.
-  const finalFilterExpression = isFilterValid && values(selectedConditions).length > 0
-    ? buildSidebarFilter(values(selectedCriteria))
+  const finalFilterExpression = isFilterValid
+    ? buildSidebarFilter(
+      Object.values(selectedCriteria),
+      {
+        filterConditions: selectedConditions,
+        filterMatch: selectedMatch,
+        filterTags: selectedTags,
+        filterValues: selectedValues,
+      },
+    )
     : undefined;
 
   useEffect(() => {

--- a/src/core/utilities/filter.ts
+++ b/src/core/utilities/filter.ts
@@ -8,6 +8,13 @@ import store from '@/core/store';
 
 import type { ExpressionType, FilterCondition, FilterExpression, FilterTag } from '@/core/types/api/filter';
 
+type SidebarFilterState = {
+  filterConditions: Record<string, boolean>;
+  filterMatch: Record<string, 'Or' | 'And'>;
+  filterTags: Record<string, FilterTag[]>;
+  filterValues: Record<string, string[]>;
+};
+
 export const buildFilter = (filters: FilterCondition[]): FilterCondition => {
   if (filters.length > 1) {
     return {
@@ -65,39 +72,45 @@ const buildSidebarFilterConditionMultivaluePair = (
   return { Type: type, Parameter: conditionValues[0][0], SecondParameter: conditionValues[0][1] };
 };
 
-const buildSidebarFilterCondition = (currentFilter: FilterExpression): FilterCondition => {
+const buildSidebarFilterCondition = (
+  currentFilter: FilterExpression,
+  sidebarFilterState: SidebarFilterState,
+): FilterCondition => {
   if (currentFilter.Expression === 'HasCustomTag' || currentFilter.Expression === 'HasTag') {
-    const tagValues = store.getState().collection.filterTags[currentFilter.Expression];
+    const tagValues = sidebarFilterState.filterTags[currentFilter.Expression];
     return buildSidebarFilterConditionTag(tagValues, currentFilter.Expression);
   }
   if (currentFilter?.PossibleParameterPairs) {
     // TODO: Using ': ' as a delimiter, but this might need to be changed in the future.
     // Currently only In Season expression has possible parameter pairs.
-    const filterValues = store.getState().collection.filterValues[currentFilter.Expression].map(
+    const filterValues = sidebarFilterState.filterValues[currentFilter.Expression].map(
       value => value.split(': '),
     );
-    const filterMatch = store.getState().collection.filterMatch[currentFilter.Expression] ?? 'Or';
+    const filterMatch = sidebarFilterState.filterMatch[currentFilter.Expression] ?? 'Or';
     return buildSidebarFilterConditionMultivaluePair(filterValues, currentFilter.Expression, filterMatch);
   }
   if (currentFilter?.PossibleParameters ?? currentFilter?.Parameter === 'Number') {
-    const filterValues = store.getState().collection.filterValues[currentFilter.Expression];
-    const filterMatch = store.getState().collection.filterMatch[currentFilter.Expression] ?? 'Or';
+    const filterValues = sidebarFilterState.filterValues[currentFilter.Expression];
+    const filterMatch = sidebarFilterState.filterMatch[currentFilter.Expression] ?? 'Or';
     return buildSidebarFilterConditionMultivalue(filterValues, currentFilter.Expression, filterMatch);
   }
 
-  const value = store.getState().collection.filterConditions[currentFilter.Expression] ?? true;
+  const value = sidebarFilterState.filterConditions[currentFilter.Expression] ?? true;
   return value ? { Type: currentFilter.Expression } : { Type: 'Not', Left: { Type: currentFilter.Expression } };
 };
 
-export const buildSidebarFilter = (filters: FilterExpression[]): FilterCondition => {
+export const buildSidebarFilter = (
+  filters: FilterExpression[],
+  sidebarFilterState: SidebarFilterState,
+): FilterCondition => {
   if (filters.length > 1) {
     return {
       Type: 'And',
-      Left: buildSidebarFilterCondition(filters[0]),
-      Right: buildSidebarFilter(filters.slice(1)),
+      Left: buildSidebarFilterCondition(filters[0], sidebarFilterState),
+      Right: buildSidebarFilter(filters.slice(1), sidebarFilterState),
     };
   }
-  return buildSidebarFilterCondition(filters[0]);
+  return buildSidebarFilterCondition(filters[0], sidebarFilterState);
 };
 
 export const addFilterCriteriaToStore = async (newCriteria: string) => {


### PR DESCRIPTION
## Summary

This fixes the live filter regression introduced by https://github.com/ShokoAnime/Shoko-WebUI/commit/b50639d05cb54da52d9fe52293715fcbf288dab9, where updating tag or boolean criteria no longer reliably rebuilt the active filter.

The root cause was the shared sidebar filter builder reading Redux state internally through `store.getState()`. That made the dependency invisible to React, so live updates were not tracked correctly.

## What changed

- Made `buildSidebarFilter()` pure by passing the current sidebar filter slices in explicitly
- Updated `FilterSidebar` to provide:
  - `filterConditions`
  - `filterTags`
  - `filterValues`
  - `filterMatch`
- Removed the render-time workaround that only existed to force React to notice `filterConditions`

## Verification

Checked the live UI against the running app and confirmed:
- boolean criteria still rebuild the live preview
- tag criteria save and render correctly
- multivalue criteria save and render correctly

## Notes

This is a root-cause fix for the regression from https://github.com/ShokoAnime/Shoko-WebUI/commit/b50639d05cb54da52d9fe52293715fcbf288dab9, not a tag-only workaround.