### PR TITLE
fix: reset modal inputs on close

### DIFF
--- a/src/components/Utilities/Renamer/AddFilesModal.tsx
+++ b/src/components/Utilities/Renamer/AddFilesModal.tsx
@@ -98,10 +98,16 @@ const AddFilesModal = ({ onClose, show }: Props) => {
   );
   const [series, seriesCount] = useFlattenListResult(seriesQuery.data);
 
+  const handleCancel = () => {
+    setSearch('');
+    setPageSize(10);
+    onClose();
+  };
+
   return (
     <ModalPanel
       show={show}
-      onRequestClose={onClose}
+      onRequestClose={handleCancel}
       header="Add Files"
       size="sm"
       noGap

--- a/src/components/Utilities/Renamer/AddFilesModal.tsx
+++ b/src/components/Utilities/Renamer/AddFilesModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { mdiMagnify, mdiPlayCircleOutline } from '@mdi/js';
 import { Icon } from '@mdi/react';
 import { toNumber } from 'lodash';
@@ -98,16 +98,15 @@ const AddFilesModal = ({ onClose, show }: Props) => {
   );
   const [series, seriesCount] = useFlattenListResult(seriesQuery.data);
 
-  const handleCancel = () => {
+  useEffect(() => {
     setSearch('');
     setPageSize(10);
-    onClose();
-  };
+  }, [show]);
 
   return (
     <ModalPanel
       show={show}
-      onRequestClose={handleCancel}
+      onRequestClose={onClose}
       header="Add Files"
       size="sm"
       noGap

--- a/src/components/Utilities/SeriesWithoutFiles/AddSeriesModal.tsx
+++ b/src/components/Utilities/SeriesWithoutFiles/AddSeriesModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { mdiInformationOutline, mdiLoading, mdiMagnify, mdiOpenInNew } from '@mdi/js';
 import { Icon } from '@mdi/react';
 import cx from 'classnames';
@@ -24,10 +24,9 @@ const AddSeriesModal = ({ onClose, show }: Props) => {
 
   const searchQuery = useSeriesAniDBSearchQuery(debouncedSearch, !!debouncedSearch);
 
-  const handleCancel = () => {
+  useEffect(() => {
     setSearchText('');
-    onClose();
-  };
+  }, [show]);
 
   const {
     isPending: isRefreshPending,
@@ -40,7 +39,6 @@ const AddSeriesModal = ({ onClose, show }: Props) => {
       onSuccess: () => {
         toast.success('Series added successfully!');
         invalidateQueries(['series', 'without-files']);
-        setSearchText('');
         onClose();
       },
       onError: (error) => {
@@ -53,7 +51,7 @@ const AddSeriesModal = ({ onClose, show }: Props) => {
   return (
     <ModalPanel
       show={show}
-      onRequestClose={handleCancel}
+      onRequestClose={onClose}
       header="Add new series"
       size="sm"
       noPadding
@@ -124,7 +122,7 @@ const AddSeriesModal = ({ onClose, show }: Props) => {
             buttonType="secondary"
             buttonSize="normal"
             className="flex items-center justify-center"
-            onClick={handleCancel}
+            onClick={onClose}
           >
             Cancel
           </Button>

--- a/src/components/Utilities/SeriesWithoutFiles/AddSeriesModal.tsx
+++ b/src/components/Utilities/SeriesWithoutFiles/AddSeriesModal.tsx
@@ -24,6 +24,11 @@ const AddSeriesModal = ({ onClose, show }: Props) => {
 
   const searchQuery = useSeriesAniDBSearchQuery(debouncedSearch, !!debouncedSearch);
 
+  const handleCancel = () => {
+    setSearchText('');
+    onClose();
+  };
+
   const {
     isPending: isRefreshPending,
     mutate: refreshSeries,
@@ -35,6 +40,7 @@ const AddSeriesModal = ({ onClose, show }: Props) => {
       onSuccess: () => {
         toast.success('Series added successfully!');
         invalidateQueries(['series', 'without-files']);
+        setSearchText('');
         onClose();
       },
       onError: (error) => {
@@ -47,7 +53,7 @@ const AddSeriesModal = ({ onClose, show }: Props) => {
   return (
     <ModalPanel
       show={show}
-      onRequestClose={onClose}
+      onRequestClose={handleCancel}
       header="Add new series"
       size="sm"
       noPadding
@@ -118,7 +124,7 @@ const AddSeriesModal = ({ onClose, show }: Props) => {
             buttonType="secondary"
             buttonSize="normal"
             className="flex items-center justify-center"
-            onClick={onClose}
+            onClick={handleCancel}
           >
             Cancel
           </Button>


### PR DESCRIPTION
Resets the modal inputs when closed as otherwise the respective fields are filled with previous values when the modal is reopened again. This issue was found in two places:
* Series without files - Add series modal
* File renamer - Add files modal