### PR TITLE
Add Unrecognized tab to Duplicate Files utility, other minor tweaks

### DIFF
--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import type { PlacesType } from 'react-tooltip';
 import { Icon } from '@mdi/react';
 import cx from 'classnames';
@@ -30,9 +30,6 @@ type Props = {
   endIcons?: EndIcon[];
   startIcon?: string;
   inline?: boolean;
-  isOverlay?: boolean;
-  overlayClassName?: string;
-  onToggleOverlay?: (show: boolean) => void;
 };
 
 type TooltipAttributes = {
@@ -51,13 +48,10 @@ const Input = (props: Props) => {
     id,
     inline,
     inputClassName,
-    isOverlay,
     label,
     onChange,
     onKeyDown,
     onKeyUp,
-    onToggleOverlay,
-    overlayClassName,
     placeholder,
     startIcon,
     type,
@@ -66,33 +60,12 @@ const Input = (props: Props) => {
 
   const bodyVisible = useBodyVisibleContext();
   const inputRef = useAutoFocusRef(autoFocus && !disabled && bodyVisible);
-  const [isShow, setIsShow] = React.useState(false);
-
-  useEffect(() => {
-    if (isOverlay) return;
-    setIsShow(_ => false);
-    onToggleOverlay?.(false);
-  }, [isOverlay, onToggleOverlay]);
-
-  let inputContainerClassName = '';
-  if (isOverlay && inline) {
-    inputContainerClassName = isShow ? 'flex flex-row justify-center' : 'hidden 2xl:flex flex-row justify-center';
-  } else if (isOverlay && !inline) {
-    inputContainerClassName = isShow ? '' : 'hidden 2xl:inline';
-  } else if (!isOverlay && inline) {
-    inputContainerClassName = 'flex flex-row justify-center';
-  }
 
   return (
-    <div
-      className={cx([
-        className ?? '',
-        isOverlay && 'flex flex-row gap-x-2',
-      ])}
-    >
+    <div className={className}>
       <label
         htmlFor={id}
-        className={cx(isOverlay && overlayClassName, inputContainerClassName)}
+        className={cx(inline && 'flex flex-row justify-center')}
       >
         {label && (
           <div

--- a/src/components/Utilities/DuplicateFiles/DuplicateFilesModal.tsx
+++ b/src/components/Utilities/DuplicateFiles/DuplicateFilesModal.tsx
@@ -6,37 +6,37 @@ import { flatMap, map } from 'lodash';
 
 import Button from '@/components/Input/Button';
 import ModalPanel from '@/components/Panels/ModalPanel';
-import { getEpisodePrefix } from '@/core/utilities/getEpisodePrefix';
 import useToggleModalKeybinds from '@/hooks/useToggleModalKeybinds';
 
 import DuplicatesInfo from './DuplicatesInfo';
 
-import type { EpisodeType } from '@/core/types/api/episode';
+import type { FileType } from '@/core/types/api/file';
 
 type Props = {
-  episode?: EpisodeType;
-  episodeCount: number;
-  episodeIndex: number;
-  handleEpisodeChange: (type: 'previous' | 'next') => void;
-  isFetching: boolean;
   onClose: () => void;
   show: boolean;
+  count: number;
+  files: FileType[];
+  index: number;
+  isFetching: boolean;
+  onChange: (type: 'previous' | 'next') => void;
+  subheader?: string;
 };
 
-type FooterProps = Pick<Props, 'episodeCount' | 'episodeIndex' | 'handleEpisodeChange' | 'onClose'>;
+type FooterProps = Pick<Props, 'count' | 'index' | 'onChange' | 'onClose'>;
 
-const Footer = ({ episodeCount, episodeIndex, handleEpisodeChange, onClose }: FooterProps) => (
+const Footer = ({ count, index, onChange, onClose }: FooterProps) => (
   <div className="flex items-center justify-between">
     <div className="flex gap-x-2">
-      <Button onClick={() => handleEpisodeChange('previous')} disabled={episodeIndex === 0}>
+      <Button onClick={() => onChange('previous')} disabled={index === 0}>
         <Icon path={mdiChevronLeft} size={1.5} className="text-panel-icon-action" />
       </Button>
       <div className="flex items-center">
-        {episodeIndex + 1}
+        {index + 1}
         &nbsp;/&nbsp;
-        {episodeCount}
+        {count}
       </div>
-      <Button onClick={() => handleEpisodeChange('next')} disabled={episodeIndex === episodeCount - 1}>
+      <Button onClick={() => onChange('next')} disabled={index === count - 1}>
         <Icon path={mdiChevronRight} size={1.5} className="text-panel-icon-action" />
       </Button>
     </div>
@@ -46,25 +46,16 @@ const Footer = ({ episodeCount, episodeIndex, handleEpisodeChange, onClose }: Fo
   </div>
 );
 
-const EpisodeName = ({ episode }: { episode: EpisodeType }) => (
-  <div className="line-clamp-1 text-sm opacity-65">
-    {getEpisodePrefix(episode.AniDB?.Type)}
-    {episode.AniDB?.EpisodeNumber}
-    &nbsp;-&nbsp;
-    {episode.Name}
-  </div>
-);
-
 const DuplicateFilesModal = (props: Props) => {
-  const { episode, episodeCount, episodeIndex, handleEpisodeChange, isFetching, onClose, show } = props;
+  const { count, files, index, isFetching, onChange, onClose, show, subheader } = props;
 
   useToggleModalKeybinds(show, 'modal');
   useToggleModalKeybinds(!show, 'primary');
   useHotkeys('enter, escape', onClose, { scopes: 'modal' });
-  useHotkeys('left', () => handleEpisodeChange('previous'), { scopes: 'modal' });
-  useHotkeys('right', () => handleEpisodeChange('next'), { scopes: 'modal' });
+  useHotkeys('left', () => onChange('previous'), { scopes: 'modal' });
+  useHotkeys('right', () => onChange('next'), { scopes: 'modal' });
 
-  if (!episode) return null;
+  if (!show) return null;
 
   return (
     <ModalPanel
@@ -72,12 +63,12 @@ const DuplicateFilesModal = (props: Props) => {
       size="xl"
       onRequestClose={onClose}
       header="Duplicate Files"
-      subHeader={<EpisodeName episode={episode} />}
+      subHeader={subheader && <div className="text-sm opacity-65">{subheader}</div>}
       footer={
         <Footer
-          episodeCount={episodeCount}
-          episodeIndex={episodeIndex}
-          handleEpisodeChange={handleEpisodeChange}
+          count={count}
+          index={index}
+          onChange={onChange}
           onClose={onClose}
         />
       }
@@ -90,7 +81,7 @@ const DuplicateFilesModal = (props: Props) => {
           </div>
         )}
 
-        {!isFetching && flatMap(episode.Files, file =>
+        {!isFetching && flatMap(files, file =>
           map(file.Locations, location => (
             <DuplicatesInfo
               key={location.ID}

--- a/src/components/Utilities/DuplicateFiles/Title.tsx
+++ b/src/components/Utilities/DuplicateFiles/Title.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { NavLink } from 'react-router';
+import { mdiChevronRight } from '@mdi/js';
+import { Icon } from '@mdi/react';
+
+const TabButton = ({ id, name }: { id: string, name: string }) => (
+  <NavLink
+    to={`../duplicate-files/${id}`}
+    className={(
+      { isActive },
+    ) => (isActive ? 'text-panel-text-primary' : 'hover:text-panel-text-primary transition-colors')}
+  >
+    {name}
+  </NavLink>
+);
+
+const Title = () => (
+  <div className="flex items-center gap-x-2 font-semibold">
+    Duplicate Files
+    <Icon path={mdiChevronRight} size={1} />
+    <TabButton id="linked" name="Linked" />
+    <div>|</div>
+    <TabButton id="unrecognized" name="Unrecognized" />
+  </div>
+);
+
+export default Title;

--- a/src/components/Utilities/DuplicateFiles/Title.tsx
+++ b/src/components/Utilities/DuplicateFiles/Title.tsx
@@ -1,27 +1,12 @@
 import React from 'react';
-import { NavLink } from 'react-router';
-import { mdiChevronRight } from '@mdi/js';
-import { Icon } from '@mdi/react';
 
-const TabButton = ({ id, name }: { id: string, name: string }) => (
-  <NavLink
-    to={`../duplicate-files/${id}`}
-    className={(
-      { isActive },
-    ) => (isActive ? 'text-panel-text-primary' : 'hover:text-panel-text-primary transition-colors')}
-  >
-    {name}
-  </NavLink>
-);
+import TabTitle from '@/components/Utilities/TabTitle';
 
-const Title = () => (
-  <div className="flex items-center gap-x-2 font-semibold">
-    Duplicate Files
-    <Icon path={mdiChevronRight} size={1} />
-    <TabButton id="linked" name="Linked" />
-    <div>|</div>
-    <TabButton id="unrecognized" name="Unrecognized" />
-  </div>
-);
+const tabs = [
+  { id: 'linked', name: 'Linked' },
+  { id: 'unrecognized', name: 'Unrecognized' },
+];
+
+const Title = () => <TabTitle basePath="../duplicate-files" tabs={tabs} title="Duplicate Files" />;
 
 export default Title;

--- a/src/components/Utilities/TabTitle.tsx
+++ b/src/components/Utilities/TabTitle.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { NavLink } from 'react-router';
+import { mdiChevronRight } from '@mdi/js';
+import { Icon } from '@mdi/react';
+
+type Tab = { id: string, name: string };
+
+type Props = {
+  basePath: string;
+  tabs: Tab[];
+  title: string;
+};
+
+const TabButton = ({ basePath, tab }: { basePath: string, tab: Tab }) => (
+  <NavLink
+    to={`${basePath}/${tab.id}`}
+    className={(
+      { isActive },
+    ) => (isActive ? 'text-panel-text-primary' : 'hover:text-panel-text-primary transition-colors')}
+  >
+    {tab.name}
+  </NavLink>
+);
+
+const TabTitle = ({ basePath, tabs, title }: Props) => (
+  <div className="flex items-center gap-x-2 font-semibold">
+    {title}
+    <Icon path={mdiChevronRight} size={1} />
+    {tabs.map((tab, index) => (
+      <React.Fragment key={tab.id}>
+        <TabButton basePath={basePath} tab={tab} />
+        {index < tabs.length - 1 && <div>|</div>}
+      </React.Fragment>
+    ))}
+  </div>
+);
+
+export default TabTitle;

--- a/src/components/Utilities/Unrecognized/Title.tsx
+++ b/src/components/Utilities/Unrecognized/Title.tsx
@@ -1,29 +1,13 @@
 import React from 'react';
-import { NavLink } from 'react-router';
-import { mdiChevronRight } from '@mdi/js';
-import { Icon } from '@mdi/react';
 
-const TabButton = ({ id, name }: { id: string, name: string }) => (
-  <NavLink
-    to={`../unrecognized/${id}`}
-    className={(
-      { isActive },
-    ) => (isActive ? 'text-panel-text-primary' : 'hover:text-panel-text-primary transition-colors')}
-  >
-    {name}
-  </NavLink>
-);
+import TabTitle from '@/components/Utilities/TabTitle';
 
-const Title = () => (
-  <div className="flex items-center gap-x-2 font-semibold">
-    Unrecognized Files
-    <Icon path={mdiChevronRight} size={1} />
-    <TabButton id="files" name="Unrecognized" />
-    <div>|</div>
-    <TabButton id="manually-linked-files" name="Manually Linked" />
-    <div>|</div>
-    <TabButton id="ignored-files" name="Ignored" />
-  </div>
-);
+const tabs = [
+  { id: 'files', name: 'Unrecognized' },
+  { id: 'manually-linked-files', name: 'Manually Linked' },
+  { id: 'ignored-files', name: 'Ignored' },
+];
+
+const Title = () => <TabTitle basePath="../unrecognized" tabs={tabs} title="Unrecognized Files" />;
 
 export default Title;

--- a/src/components/Utilities/UtilitySeriesList.tsx
+++ b/src/components/Utilities/UtilitySeriesList.tsx
@@ -226,6 +226,11 @@ const UtilitySeriesList = (
       : duplicatesEpisodeFileCountColumn,
   ];
 
+  const episode = episodes[selectedEpisode];
+  const episodeName = episode?.Name
+    ? `${getEpisodePrefix(episode.AniDB?.Type)}${episode.AniDB?.EpisodeNumber} - ${episode.Name}`
+    : '';
+
   return (
     <>
       <div className="flex grow">
@@ -306,12 +311,13 @@ const UtilitySeriesList = (
         <DuplicateFilesModal
           onClose={toggleEpisodeModal}
           show={showEpisodeModal}
-          episode={episodes[selectedEpisode]}
-          handleEpisodeChange={(changeType) => {
+          files={episode?.Files ?? []}
+          subheader={episodeName}
+          count={episodeCount}
+          index={selectedEpisode}
+          onChange={(changeType) => {
             handleEpisodeChange(changeType).catch(console.error);
           }}
-          episodeCount={episodeCount}
-          episodeIndex={selectedEpisode}
           isFetching={episodesQuery.isFetchingNextPage}
         />
       )}

--- a/src/components/Utilities/constants.tsx
+++ b/src/components/Utilities/constants.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { find } from 'lodash';
 import prettyBytes from 'pretty-bytes';
 
 import { FileSortCriteriaEnum } from '@/core/types/api/file';
@@ -6,6 +7,7 @@ import { dayjs } from '@/core/util';
 
 import type { EpisodeType } from '@/core/types/api/episode';
 import type { FileType } from '@/core/types/api/file';
+import type { ManagedFolderType } from '@/core/types/api/managed-folder';
 import type { ReleaseManagementSeriesType, SeriesType } from '@/core/types/api/series';
 
 export type UtilityHeaderType<T extends EpisodeType | FileType | SeriesType | ReleaseManagementSeriesType> = {
@@ -14,8 +16,6 @@ export type UtilityHeaderType<T extends EpisodeType | FileType | SeriesType | Re
   className: string;
   item: (_: T) => React.ReactNode;
 };
-
-export type ReleaseManagementOptionsType = Record<number, 'keep' | 'variation' | 'delete'>;
 
 export const criteriaMap = {
   managedFolder: FileSortCriteriaEnum.ManagedFolderName,
@@ -26,32 +26,57 @@ export const criteriaMap = {
   status: null,
 };
 
-export const staticColumns: UtilityHeaderType<FileType>[] = [
-  {
-    id: 'filename',
-    name: 'Filename',
-    className: 'line-clamp-2 grow basis-0 overflow-hidden',
-    item: (file) => {
-      const path = file.Locations[0]?.RelativePath ?? '';
-      const match = /[/\\](?=[^/\\]*$)/g.exec(path);
-      const relativePath = match ? path?.substring(0, match.index) : 'Root Level';
-      return (
-        <div
-          className="flex flex-col"
-          data-tooltip-id="tooltip"
-          data-tooltip-content={path}
-          data-tooltip-delay-show={500}
-        >
-          <span className="line-clamp-1 text-sm font-semibold opacity-65">
-            {relativePath}
-          </span>
-          <span className="line-clamp-1">
-            {path?.split(/[/\\]/g).pop()}
-          </span>
-        </div>
-      );
-    },
+export const getManagedFolderColumn = (managedFolders: ManagedFolderType[]): UtilityHeaderType<FileType> => ({
+  id: 'managedFolder',
+  name: 'Managed Folder',
+  className: 'w-46',
+  item: (file) => {
+    const managedFolder = find(
+      managedFolders,
+      { ID: file?.Locations[0]?.ManagedFolderID ?? -1 },
+    )?.Name ?? '<Unknown>';
+
+    return (
+      <div
+        className="truncate"
+        data-tooltip-id="tooltip"
+        data-tooltip-content={managedFolder}
+        data-tooltip-delay-show={500}
+      >
+        {managedFolder}
+      </div>
+    );
   },
+});
+
+export const fileNameColumn: UtilityHeaderType<FileType> = {
+  id: 'filename',
+  name: 'Filename',
+  className: 'line-clamp-2 grow basis-0 overflow-hidden',
+  item: (file) => {
+    const path = file.Locations[0]?.RelativePath ?? '';
+    const match = /[/\\](?=[^/\\]*$)/g.exec(path);
+    const relativePath = match ? path?.substring(0, match.index) : 'Root Level';
+    return (
+      <div
+        className="flex flex-col"
+        data-tooltip-id="tooltip"
+        data-tooltip-content={path}
+        data-tooltip-delay-show={500}
+      >
+        <span className="line-clamp-1 text-sm font-semibold opacity-65">
+          {relativePath}
+        </span>
+        <span className="line-clamp-1">
+          {path?.split(/[/\\]/g).pop()}
+        </span>
+      </div>
+    );
+  },
+};
+
+export const staticColumns: UtilityHeaderType<FileType>[] = [
+  fileNameColumn,
   {
     id: 'crc32',
     name: 'CRC32',

--- a/src/core/router/index.tsx
+++ b/src/core/router/index.tsx
@@ -43,7 +43,8 @@ import PluginManagementSettings from '@/pages/settings/tabs/PluginManagementSett
 import TmdbSettings from '@/pages/settings/tabs/TmdbSettings';
 import UserManagementSettings from '@/pages/settings/tabs/UserManagementSettings';
 import UnsupportedPage from '@/pages/unsupported/UnsupportedPage';
-import DuplicateFiles from '@/pages/utilities/DuplicateFiles';
+import DuplicateFilesLinkedTab from '@/pages/utilities/DuplicateFilesTabs/DuplicateFilesLinkedTab';
+import DuplicateFilesUnrecognizedTab from '@/pages/utilities/DuplicateFilesTabs/DuplicateFilesUnrecognizedTab';
 import FileSearch from '@/pages/utilities/FileSearch';
 import MissingEpisodes from '@/pages/utilities/MissingEpisodes';
 import ReleaseManagement from '@/pages/utilities/ReleaseManagement';
@@ -97,7 +98,9 @@ const router = sentryCreateBrowserRouter(
             <Route path="unrecognized/ignored-files" element={<IgnoredFilesTab />} />
             <Route path="release-management/:seriesId" element={<ReleaseManagementSeriesDetail />} />
             <Route path="release-management" element={<ReleaseManagement />} />
-            <Route path="duplicate-files" element={<DuplicateFiles />} />
+            <Route path="duplicate-files" element={<Navigate to="linked" replace />} />
+            <Route path="duplicate-files/linked" element={<DuplicateFilesLinkedTab />} />
+            <Route path="duplicate-files/unrecognized" element={<DuplicateFilesUnrecognizedTab />} />
             <Route path="missing-episodes" element={<MissingEpisodes />} />
             <Route path="series-without-files" element={<SeriesWithoutFilesUtility />} />
             <Route path="file-search" element={<FileSearch />} />

--- a/src/pages/utilities/DuplicateFilesTabs/DuplicateFilesLinkedTab.tsx
+++ b/src/pages/utilities/DuplicateFilesTabs/DuplicateFilesLinkedTab.tsx
@@ -10,12 +10,13 @@ import Button from '@/components/Input/Button';
 import Checkbox from '@/components/Input/Checkbox';
 import ShokoPanel from '@/components/Panels/ShokoPanel';
 import DuplicateFilesQuickSelectModal from '@/components/Utilities/DuplicateFiles/DuplicateFilesQuickSelectModal';
+import Title from '@/components/Utilities/DuplicateFiles/Title';
 import ItemCount from '@/components/Utilities/ItemCount';
 import MenuButton from '@/components/Utilities/Unrecognized/MenuButton';
 import UtilitySeriesList from '@/components/Utilities/UtilitySeriesList';
 import { resetQueries } from '@/core/react-query/queryClient';
 
-const DuplicateFiles = () => {
+const DuplicateFilesLinkedTab = () => {
   const [searchParams, setSearchParams] = useSearchParams();
 
   const isSeriesQueryFetching = useIsFetching({ queryKey: ['release-management', 'series'] }) > 0;
@@ -46,7 +47,7 @@ const DuplicateFiles = () => {
     <>
       <title>Duplicate Files | Shoko</title>
       <div className="flex grow flex-col gap-y-6 overflow-y-auto">
-        <ShokoPanel title="Duplicate Files" options={<ItemCount count={seriesCount} suffix="Series" />}>
+        <ShokoPanel title={<Title />} options={<ItemCount count={seriesCount} suffix="Series" />}>
           <div className="flex items-center gap-x-3">
             <div className="relative box-border flex grow items-center gap-x-4 rounded-md border border-panel-border bg-panel-background-alt px-4 py-2">
               <MenuButton
@@ -92,4 +93,4 @@ const DuplicateFiles = () => {
   );
 };
 
-export default DuplicateFiles;
+export default DuplicateFilesLinkedTab;

--- a/src/pages/utilities/DuplicateFilesTabs/DuplicateFilesUnrecognizedTab.tsx
+++ b/src/pages/utilities/DuplicateFilesTabs/DuplicateFilesUnrecognizedTab.tsx
@@ -85,7 +85,7 @@ const DuplicateFilesUnrecognizedTab = () => {
       if (newIdx >= files.length && filesQuery.hasNextPage) {
         filesQuery.fetchNextPage().then(() => {
           setSelectedFile(newIdx);
-        }).catch(() => undefined);
+        }).catch(console.error);
         return prev;
       }
       if (newIdx < fileCount) return newIdx;

--- a/src/pages/utilities/DuplicateFilesTabs/DuplicateFilesUnrecognizedTab.tsx
+++ b/src/pages/utilities/DuplicateFilesTabs/DuplicateFilesUnrecognizedTab.tsx
@@ -1,0 +1,174 @@
+import React, { useState } from 'react';
+import { useHotkeys } from 'react-hotkeys-hook';
+import { mdiLoading, mdiMagnify, mdiRefresh } from '@mdi/js';
+import { Icon } from '@mdi/react';
+import { useToggle } from 'usehooks-ts';
+
+import Input from '@/components/Input/Input';
+import ShokoPanel from '@/components/Panels/ShokoPanel';
+import { fileNameColumn, getManagedFolderColumn } from '@/components/Utilities/constants';
+import DuplicateFilesModal from '@/components/Utilities/DuplicateFiles/DuplicateFilesModal';
+import Title from '@/components/Utilities/DuplicateFiles/Title';
+import ItemCount from '@/components/Utilities/ItemCount';
+import MenuButton from '@/components/Utilities/Unrecognized/MenuButton';
+import UtilitiesTable from '@/components/Utilities/UtilitiesTable';
+import { useFilesInfiniteQuery } from '@/core/react-query/file/queries';
+import { useManagedFoldersQuery } from '@/core/react-query/managed-folder/queries';
+import { resetQueries } from '@/core/react-query/queryClient';
+import { FileSortCriteriaEnum } from '@/core/types/api/file';
+import useFlattenListResult from '@/hooks/useFlattenListResult';
+import useTableSearchSortCriteria from '@/hooks/utilities/useTableSearchSortCriteria';
+
+import type { UtilityHeaderType } from '@/components/Utilities/constants';
+import type { FileType } from '@/core/types/api/file';
+
+const DuplicateFilesUnrecognizedTab = () => {
+  const [selectedFile, setSelectedFile] = useState(-1);
+  const [showModal, toggleModal, setShowModal] = useToggle(false);
+
+  const { debouncedSearch, search, setSearch, setSortCriteria, sortCriteria } = useTableSearchSortCriteria(
+    FileSortCriteriaEnum.DuplicateCount,
+  );
+
+  const managedFolderQuery = useManagedFoldersQuery();
+  const managedFolders = managedFolderQuery?.data ?? [];
+
+  let sortOrder: FileSortCriteriaEnum[] | undefined;
+  if (debouncedSearch && sortCriteria) {
+    sortOrder = [sortCriteria];
+  } else if (sortCriteria) {
+    sortOrder = [sortCriteria, FileSortCriteriaEnum.FileName, FileSortCriteriaEnum.RelativePath];
+  }
+
+  const filesQuery = useFilesInfiniteQuery(
+    {
+      pageSize: 100,
+      include: ['AbsolutePaths'],
+      include_only: ['Duplicates'],
+      sortOrder,
+    },
+    debouncedSearch,
+  );
+  const [files, fileCount] = useFlattenListResult(filesQuery.data);
+
+  const columns: UtilityHeaderType<FileType>[] = [
+    getManagedFolderColumn(managedFolders),
+    fileNameColumn,
+    {
+      id: 'duplicate-count',
+      name: 'Duplicate Count',
+      className: 'w-40',
+      item: (file) => {
+        const count = file.Locations.filter(loc => !!loc.AbsolutePath).length - 1;
+        return (
+          <>
+            <span className="text-panel-text-important">{count}</span>
+            {count === 1 ? ' Duplicate' : ' Duplicates'}
+          </>
+        );
+      },
+    },
+  ];
+
+  const handleRowSelect = (fileId: number) => {
+    const idx = files.findIndex(file => file.ID === fileId);
+    if (idx !== -1) {
+      setSelectedFile(idx);
+      setShowModal(true);
+    }
+  };
+
+  const handleFileChange = (type: 'previous' | 'next') => {
+    setSelectedFile((prev) => {
+      const newIdx = prev + (type === 'previous' ? -1 : 1);
+      if (newIdx < 0) return prev;
+      if (newIdx >= files.length && filesQuery.hasNextPage) {
+        filesQuery.fetchNextPage().then(() => {
+          setSelectedFile(newIdx);
+        }).catch(() => undefined);
+        return prev;
+      }
+      if (newIdx < fileCount) return newIdx;
+      return prev;
+    });
+  };
+
+  const file = files[selectedFile];
+
+  const handleRefresh = () => {
+    if (filesQuery.isFetching) return;
+    resetQueries(['files']);
+  };
+
+  useHotkeys('r', handleRefresh, { scopes: 'primary' });
+
+  return (
+    <>
+      <title>Duplicate Files | Shoko</title>
+      <div className="flex grow flex-col gap-y-6">
+        <ShokoPanel title={<Title />} options={<ItemCount count={fileCount} suffix="Files" />}>
+          <div className="flex items-center gap-x-3">
+            <Input
+              type="text"
+              placeholder="Search..."
+              startIcon={mdiMagnify}
+              id="search"
+              value={search}
+              onChange={setSearch}
+              inputClassName="px-4 py-3"
+            />
+            <div className="relative box-border flex grow items-center gap-x-4 rounded-md border border-panel-border bg-panel-background-alt px-4 py-3">
+              <MenuButton
+                onClick={handleRefresh}
+                icon={mdiRefresh}
+                name="Refresh"
+                loading={filesQuery.isFetching}
+                keybinding="R"
+              />
+            </div>
+          </div>
+        </ShokoPanel>
+
+        <div className="flex grow overflow-y-auto rounded-lg border border-panel-border bg-panel-background px-4 py-6">
+          {filesQuery.isPending && (
+            <div className="flex grow items-center justify-center text-panel-text-primary">
+              <Icon path={mdiLoading} size={4} spin />
+            </div>
+          )}
+
+          {!filesQuery.isPending && fileCount === 0 && (
+            <div className="flex grow items-center justify-center font-semibold">
+              No unrecognized duplicate file(s)!
+            </div>
+          )}
+
+          {filesQuery.isSuccess && fileCount > 0 && (
+            <UtilitiesTable
+              count={fileCount}
+              fetchNextPage={() => filesQuery.fetchNextPage()}
+              handleRowSelect={handleRowSelect}
+              columns={columns}
+              isFetchingNextPage={filesQuery.isFetchingNextPage}
+              rows={files}
+              setSortCriteria={setSortCriteria}
+              sortCriteria={sortCriteria}
+              rowSelection={{}}
+            />
+          )}
+        </div>
+      </div>
+
+      <DuplicateFilesModal
+        show={showModal}
+        onClose={toggleModal}
+        files={file ? [file] : []}
+        count={fileCount}
+        index={selectedFile}
+        onChange={handleFileChange}
+        isFetching={filesQuery.isFetchingNextPage}
+      />
+    </>
+  );
+};
+
+export default DuplicateFilesUnrecognizedTab;

--- a/src/pages/utilities/UnrecognizedUtilityTabs/IgnoredFilesTab.tsx
+++ b/src/pages/utilities/UnrecognizedUtilityTabs/IgnoredFilesTab.tsx
@@ -1,12 +1,12 @@
-import React, { useMemo } from 'react';
+import React from 'react';
 import { mdiCloseCircleOutline, mdiEyeOutline, mdiLoading, mdiMagnify, mdiRefresh } from '@mdi/js';
 import { Icon } from '@mdi/react';
-import { countBy, find } from 'lodash';
+import { countBy } from 'lodash';
 
 import Input from '@/components/Input/Input';
 import ShokoPanel from '@/components/Panels/ShokoPanel';
 import TransitionDiv from '@/components/TransitionDiv';
-import { staticColumns } from '@/components/Utilities/constants';
+import { getManagedFolderColumn, staticColumns } from '@/components/Utilities/constants';
 import ItemCount from '@/components/Utilities/ItemCount';
 import MenuButton from '@/components/Utilities/Unrecognized/MenuButton';
 import Title from '@/components/Utilities/Unrecognized/Title';
@@ -93,13 +93,14 @@ const IgnoredFilesTab = () => {
   } = useTableSearchSortCriteria(FileSortCriteriaEnum.ManagedFolderName);
 
   const managedFolderQuery = useManagedFoldersQuery();
-  const managedFolders = useMemo(() => managedFolderQuery?.data ?? [], [managedFolderQuery.data]);
+  const managedFolders = managedFolderQuery?.data ?? [];
 
-  const sortOrder = useMemo(() => {
-    if (!sortCriteria) return undefined;
-    if (debouncedSearch) return [sortCriteria];
-    return [sortCriteria, FileSortCriteriaEnum.FileName, FileSortCriteriaEnum.RelativePath];
-  }, [debouncedSearch, sortCriteria]);
+  let sortOrder: FileSortCriteriaEnum[] | undefined;
+  if (debouncedSearch && sortCriteria) {
+    sortOrder = [sortCriteria];
+  } else if (sortCriteria) {
+    sortOrder = [sortCriteria, FileSortCriteriaEnum.FileName, FileSortCriteriaEnum.RelativePath];
+  }
 
   const filesQuery = useFilesInfiniteQuery(
     {
@@ -111,22 +112,10 @@ const IgnoredFilesTab = () => {
   );
   const [files, fileCount] = useFlattenListResult(filesQuery.data);
 
-  const columns = useMemo<UtilityHeaderType<FileType>[]>(
-    () => [
-      {
-        id: 'managedFolder',
-        name: 'Managed Folder',
-        className: 'w-46',
-        item: file =>
-          find(
-            managedFolders,
-            { ID: file?.Locations[0]?.ManagedFolderID ?? -1 },
-          )?.Name ?? '<Unknown>',
-      },
-      ...staticColumns,
-    ],
-    [managedFolders],
-  );
+  const columns: UtilityHeaderType<FileType>[] = [
+    getManagedFolderColumn(managedFolders),
+    ...staticColumns,
+  ];
 
   const {
     handleRowSelect,

--- a/src/pages/utilities/UnrecognizedUtilityTabs/UnrecognizedTab.tsx
+++ b/src/pages/utilities/UnrecognizedUtilityTabs/UnrecognizedTab.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useState } from 'react';
-import useMeasure from 'react-use-measure';
 import {
   mdiBeta,
   mdiCloseCircleOutline,
@@ -322,26 +321,10 @@ const UnrecognizedTab = () => {
   const fileIds = selectedRows.map(file => file.ID);
   const links = selectedRows.map(file => getEd2kLink(file)).toSorted();
 
-  const [tabContainerRef, bounds] = useMeasure();
-  const isOverlay = bounds.width <= 1365 && bounds.width >= 1206 && selectedRows.length !== 0;
-
-  let searchClassName = '';
-  if (bounds.width < 1547 && selectedRows.length !== 0) {
-    if (isAvdumpFinished && !dumpInProgress) {
-      searchClassName = '!w-[calc(100vw-652px)]';
-    } else if (!isAvdumpFinished && dumpInProgress) {
-      searchClassName = '!w-[calc(100vw-656px)]';
-    } else if (!isAvdumpFinished && !dumpInProgress) {
-      searchClassName = '!w-[calc(100vw-640px)]';
-    }
-  } else if (isOverlay) {
-    searchClassName = '!w-[calc(100vw-38.4rem)]';
-  }
-
   return (
     <>
       <title>Unrecognized Files | Shoko</title>
-      <div className="flex grow flex-col gap-y-6" ref={tabContainerRef}>
+      <div className="flex grow flex-col gap-y-6">
         <div>
           <ShokoPanel title={<Title />} options={<ItemCount count={fileCount} selected={selectedRows?.length} />}>
             <div className="flex items-center gap-x-3">
@@ -352,7 +335,8 @@ const UnrecognizedTab = () => {
                 id="search"
                 value={search}
                 onChange={setSearch}
-                inputClassName={cx('px-4 py-3', searchClassName)}
+                className="grow 3xl:grow-0"
+                inputClassName="px-4 py-3"
               />
               <Menu
                 selectedRows={selectedRows}

--- a/src/pages/utilities/UnrecognizedUtilityTabs/UnrecognizedTab.tsx
+++ b/src/pages/utilities/UnrecognizedUtilityTabs/UnrecognizedTab.tsx
@@ -334,8 +334,7 @@ const UnrecognizedTab = () => {
     } else if (!isAvdumpFinished && !dumpInProgress) {
       searchClassName = '!w-[calc(100vw-640px)]';
     }
-  }
-  if (isOverlay) {
+  } else if (isOverlay) {
     searchClassName = '!w-[calc(100vw-38.4rem)]';
   }
 

--- a/src/pages/utilities/UnrecognizedUtilityTabs/UnrecognizedTab.tsx
+++ b/src/pages/utilities/UnrecognizedUtilityTabs/UnrecognizedTab.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import useMeasure from 'react-use-measure';
 import {
   mdiBeta,
@@ -86,10 +86,6 @@ const Menu = (
     invalidateQueries(['episode', 'anidb']);
   }, []);
 
-  const showDeleteConfirmation = useCallback(() => {
-    setShowConfirmModal(true);
-  }, []);
-
   const cancelDelete = () => {
     setShowConfirmModal(false);
   };
@@ -114,7 +110,7 @@ const Menu = (
     setSelectedRows([]);
   };
 
-  const ignoreFiles = useCallback(() => {
+  const ignoreFiles = () => {
     const promises = selectedRows.map(
       row => ignoreFile({ fileId: row.ID, ignore: true }),
     );
@@ -128,9 +124,9 @@ const Menu = (
         setSelectedRows([]);
       })
       .catch(console.error);
-  }, [ignoreFile, selectedRows, setSelectedRows]);
+  };
 
-  const rehashFiles = useCallback(() => {
+  const rehashFiles = () => {
     const promises = selectedRows.map(row => rehashFile(row.ID));
 
     Promise
@@ -142,9 +138,9 @@ const Menu = (
         setSelectedRows([]);
       })
       .catch(console.error);
-  }, [rehashFile, selectedRows, setSelectedRows]);
+  };
 
-  const rescanFiles = useCallback(() => {
+  const rescanFiles = () => {
     const promises = selectedRows.map(row => rescanFile(row.ID));
 
     Promise
@@ -156,12 +152,12 @@ const Menu = (
         setSelectedRows([]);
       })
       .catch(console.error);
-  }, [rescanFile, selectedRows, setSelectedRows]);
+  };
 
-  const handleRename = useCallback(() => {
+  const handleRename = () => {
     dispatch(addFiles(selectedRows));
     navigate('/webui/utilities/renamer');
-  }, [dispatch, navigate, selectedRows]);
+  };
 
   const renderSelectedRowActions = (
     <>
@@ -183,7 +179,7 @@ const Menu = (
       <MenuButton onClick={handleRename} icon={mdiFileDocumentEditOutline} name="Rename" />
       <MenuButton onClick={ignoreFiles} icon={mdiEyeOffOutline} name="Ignore" />
       <MenuButton
-        onClick={showDeleteConfirmation}
+        onClick={() => setShowConfirmModal(true)}
         icon={mdiMinusCircleOutline}
         name="Delete"
         highlightType="danger"

--- a/src/pages/utilities/UnrecognizedUtilityTabs/UnrecognizedTab.tsx
+++ b/src/pages/utilities/UnrecognizedUtilityTabs/UnrecognizedTab.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import useMeasure from 'react-use-measure';
 import {
   mdiBeta,
@@ -17,7 +17,7 @@ import {
 } from '@mdi/js';
 import { Icon } from '@mdi/react';
 import cx from 'classnames';
-import { countBy, every, find, some } from 'lodash';
+import { countBy, every, some } from 'lodash';
 
 import DeleteFilesModal from '@/components/Dialogs/DeleteFilesModal';
 import Button from '@/components/Input/Button';
@@ -25,7 +25,7 @@ import DropdownButton from '@/components/Input/DropdownButton';
 import Input from '@/components/Input/Input';
 import ShokoPanel from '@/components/Panels/ShokoPanel';
 import TransitionDiv from '@/components/TransitionDiv';
-import { staticColumns } from '@/components/Utilities/constants';
+import { getManagedFolderColumn, staticColumns } from '@/components/Utilities/constants';
 import ItemCount from '@/components/Utilities/ItemCount';
 import AVDumpFileIcon from '@/components/Utilities/Unrecognized/AvDumpFileIcon';
 import AvDumpSeriesSelectModal from '@/components/Utilities/Unrecognized/AvDumpSeriesSelectModal';
@@ -163,7 +163,7 @@ const Menu = (
     navigate('/webui/utilities/renamer');
   }, [dispatch, navigate, selectedRows]);
 
-  const renderSelectedRowActions = useMemo(() => (
+  const renderSelectedRowActions = (
     <>
       <div className="flex 2xl:hidden">
         {selectedRows.length !== 0
@@ -195,15 +195,7 @@ const Menu = (
         highlightType="primary"
       />
     </>
-  ), [
-    handleRename,
-    ignoreFiles,
-    rehashFiles,
-    rescanFiles,
-    setSelectedRows,
-    showDeleteConfirmation,
-    selectedRows,
-  ]);
+  );
 
   return (
     <>
@@ -261,13 +253,14 @@ const UnrecognizedTab = () => {
   const { mutateAsync: avdumpFiles } = useAvdumpFilesMutation();
 
   const managedFolderQuery = useManagedFoldersQuery();
-  const managedFolders = useMemo(() => managedFolderQuery?.data ?? [], [managedFolderQuery.data]);
+  const managedFolders = managedFolderQuery?.data ?? [];
 
-  const sortOrder = useMemo(() => {
-    if (!sortCriteria) return undefined;
-    if (debouncedSearch) return [sortCriteria];
-    return [sortCriteria, FileSortCriteriaEnum.FileName, FileSortCriteriaEnum.RelativePath];
-  }, [debouncedSearch, sortCriteria]);
+  let sortOrder: FileSortCriteriaEnum[] | undefined;
+  if (debouncedSearch && sortCriteria) {
+    sortOrder = [sortCriteria];
+  } else if (sortCriteria) {
+    sortOrder = [sortCriteria, FileSortCriteriaEnum.FileName, FileSortCriteriaEnum.RelativePath];
+  }
 
   const filesQuery = useFilesInfiniteQuery(
     {
@@ -280,40 +273,16 @@ const UnrecognizedTab = () => {
   );
   const [files, fileCount] = useFlattenListResult(filesQuery.data);
 
-  const columns = useMemo<UtilityHeaderType<FileType>[]>(
-    () => [
-      {
-        id: 'managedFolder',
-        name: 'Managed Folder',
-        className: 'w-46',
-        item: (file) => {
-          const managedFolder = find(
-            managedFolders,
-            { ID: file?.Locations[0]?.ManagedFolderID ?? -1 },
-          )?.Name ?? '<Unknown>';
-
-          return (
-            <div
-              className="truncate"
-              data-tooltip-id="tooltip"
-              data-tooltip-content={managedFolder}
-              data-tooltip-delay-show={500}
-            >
-              {managedFolder}
-            </div>
-          );
-        },
-      },
-      ...staticColumns,
-      {
-        id: 'status',
-        name: 'Status',
-        className: 'w-16',
-        item: file => <AVDumpFileIcon file={file} />,
-      },
-    ],
-    [managedFolders],
-  );
+  const columns: UtilityHeaderType<FileType>[] = [
+    getManagedFolderColumn(managedFolders),
+    ...staticColumns,
+    {
+      id: 'status',
+      name: 'Status',
+      className: 'w-16',
+      item: file => <AVDumpFileIcon file={file} />,
+    },
+  ];
 
   const avdumpList = useSelector(state => state.utilities.avdump);
 
@@ -324,15 +293,11 @@ const UnrecognizedTab = () => {
     setRowSelection,
   } = useRowSelection(files);
 
-  const isAvdumpFinished = useMemo(
-    () => (selectedRows.length > 0
-      ? every(
-        selectedRows,
-        row => avdumpList.sessions[avdumpList.sessionMap[row.ID]]?.status === 'Success' || row.AVDump.LastDumpedAt,
-      )
-      : false),
-    [selectedRows, avdumpList],
-  );
+  const isAvdumpFinished = selectedRows.length > 0
+    && every(
+      selectedRows,
+      row => avdumpList.sessions[avdumpList.sessionMap[row.ID]]?.status === 'Success' || row.AVDump.LastDumpedAt,
+    );
   const dumpInProgress = selectedRows.length > 0
     && some(
       selectedRows,
@@ -364,21 +329,19 @@ const UnrecognizedTab = () => {
   const [tabContainerRef, bounds] = useMeasure();
   const isOverlay = bounds.width <= 1365 && bounds.width >= 1206 && selectedRows.length !== 0;
 
-  const searchClassName = useMemo(() => {
-    if (bounds.width < 1547 && selectedRows.length !== 0) {
-      if (isAvdumpFinished && !dumpInProgress) {
-        return '!w-[calc(100vw-652px)]';
-      }
-      if (!isAvdumpFinished && dumpInProgress) {
-        return '!w-[calc(100vw-656px)]';
-      }
-      if (!isAvdumpFinished && !dumpInProgress) {
-        return '!w-[calc(100vw-640px)]';
-      }
+  let searchClassName = '';
+  if (bounds.width < 1547 && selectedRows.length !== 0) {
+    if (isAvdumpFinished && !dumpInProgress) {
+      searchClassName = '!w-[calc(100vw-652px)]';
+    } else if (!isAvdumpFinished && dumpInProgress) {
+      searchClassName = '!w-[calc(100vw-656px)]';
+    } else if (!isAvdumpFinished && !dumpInProgress) {
+      searchClassName = '!w-[calc(100vw-640px)]';
     }
-    if (isOverlay) return '!w-[calc(100vw-38.4rem)]';
-    return '';
-  }, [bounds.width, selectedRows.length, isOverlay, isAvdumpFinished, dumpInProgress]);
+  }
+  if (isOverlay) {
+    searchClassName = '!w-[calc(100vw-38.4rem)]';
+  }
 
   return (
     <>
@@ -447,7 +410,7 @@ const UnrecognizedTab = () => {
           </ShokoPanel>
         </div>
 
-        <div className="flex grow overflow-y-auto rounded-lg border border-panel-border bg-panel-background px-4 py-6">
+        <div className="flex grow overflow-y-auto rounded-lg border border-panel-border bg-panel-background p-6">
           {filesQuery.isPending && (
             <div className="flex grow items-center justify-center text-panel-text-primary">
               <Icon path={mdiLoading} size={4} spin />

--- a/src/pages/utilities/UnrecognizedUtilityTabs/UnrecognizedTab.tsx
+++ b/src/pages/utilities/UnrecognizedUtilityTabs/UnrecognizedTab.tsx
@@ -353,7 +353,6 @@ const UnrecognizedTab = () => {
                 value={search}
                 onChange={setSearch}
                 inputClassName={cx('px-4 py-3', searchClassName)}
-                overlayClassName="grow 2xl:w-auto 2xl:grow-0"
               />
               <Menu
                 selectedRows={selectedRows}


### PR DESCRIPTION
## Summary

Adds an "Unrecognized" tab to the Duplicate Files utility, showing duplicate files that are not linked to any episode or series. Previously, the utility only showed duplicates grouped by series/episode (the "Linked" view). This tab surfaces orphan duplicates that have no series association.

## Changes

### New files
- **`src/pages/utilities/DuplicateFilesTabs/DuplicateFilesUnrecognizedTab.tsx`** — Flat file list showing duplicate files with Managed Folder, Filename, and Duplicate Count columns. Uses `useFilesInfiniteQuery` with `include_only: ['Duplicates']`. Row click opens the duplicate files modal with file-level details and navigation carousel.
- **`src/components/Utilities/TabTitle.tsx`** — Shared tab navigation component (`TabButton` + `TabTitle`). Replaces duplicated tab bar logic across Unrecognized and Duplicate Files utilities.

### Refactored / moved
- **`src/components/Utilities/DuplicateFiles/Title.tsx`** and **`src/components/Utilities/Unrecognized/Title.tsx`** — Both refactored to thin wrappers around the shared `TabTitle` component, with tab definitions owned locally by each utility.
- **`src/pages/utilities/DuplicateFiles.tsx` → `DuplicateFilesTabs/DuplicateFilesLinkedTab.tsx`** — Original dual-pane page moved into a tab component with `<Title />` added to the panel header.
- **`src/components/Utilities/DuplicateFiles/DuplicateFilesModal.tsx`** — Refactored from episode-specific props to a generic `files: FileType[]` prop. The modal now handles the `{file, location}` mapping internally using lodash `flatMap`/`map` directly in JSX.
- **`src/core/router/index.tsx`** — Flattened duplicate-files routes (no unnecessary `<Outlet />` wrapper), matching the same flat route pattern used by the Unrecognized utility.

### Cleanup
- **`src/components/Utilities/constants.tsx`** — Extracted `fileNameColumn` as a named export and added `getManagedFolderColumn()` to be shared across `UnrecognizedTab`, `IgnoredFilesTab`, and `DuplicateFilesUnrecognizedTab`.
- Removed all `useMemo`/`useCallback` usage per the React Compiler convention across `UnrecognizedTab.tsx`, `IgnoredFilesTab.tsx`, and `UtilitySeriesList.tsx`.
- Replaced `useState(false)` modal toggle with `useToggle` from `usehooks-ts`.

<img width="1879" height="999" alt="image" src="https://github.com/user-attachments/assets/964d9c34-2ce3-4073-98c5-cfa671096f71" />
