### PR TITLE
fix: add force option to series TMDB refresh action

### DIFF
--- a/src/components/Collection/Series/EditSeriesTabs/UpdateActionsTab.tsx
+++ b/src/components/Collection/Series/EditSeriesTabs/UpdateActionsTab.tsx
@@ -26,6 +26,10 @@ const UpdateActionsTab = ({ seriesId }: Props) => {
     updateTmdbImagesMutation({ force: true });
   };
 
+  const triggerTmdbRefresh = (force: boolean) => {
+    refreshTmdb({ force });
+  };
+
   return (
     <div className="flex h-88 grow flex-col gap-y-4 overflow-y-auto">
       <Action
@@ -51,7 +55,12 @@ const UpdateActionsTab = ({ seriesId }: Props) => {
       <Action
         name="Update TMDB Info"
         description="Gets the latest series information from TMDB."
-        onClick={refreshTmdb}
+        onClick={() => triggerTmdbRefresh(false)}
+      />
+      <Action
+        name="Update TMDB Info - Force"
+        description="Forces a complete update from TMDB, bypassing usual checks."
+        onClick={() => triggerTmdbRefresh(true)}
       />
       <Action
         name="Update TMDB Images - Force"

--- a/src/core/react-query/series/mutations.ts
+++ b/src/core/react-query/series/mutations.ts
@@ -119,10 +119,10 @@ export const useAutoSearchTmdbMatchMutation = (seriesId: number) =>
 
 export const useRefreshSeriesTMDBInfoMutation = (seriesId: number) =>
   useMutation({
-    mutationFn: () =>
+    mutationFn: ({ force = false }: { force?: boolean } = {}) =>
       Promise.all([
-        axios.post(`Series/${seriesId}/TMDB/Show/Action/Refresh`, {}),
-        axios.post(`Series/${seriesId}/TMDB/Movie/Action/Refresh`, {}),
+        axios.post(`Series/${seriesId}/TMDB/Show/Action/Refresh`, { Force: force }),
+        axios.post(`Series/${seriesId}/TMDB/Movie/Action/Refresh`, { Force: force }),
       ]),
     onSuccess: () => toast.success('TMDB refresh queued!'),
   });


### PR DESCRIPTION
## Summary
- `useRefreshSeriesTMDBInfoMutation` posted an empty body to `Series/{id}/TMDB/Show|Movie/Action/Refresh`, so `Force` always defaulted to `false` server-side — the "Update TMDB Info" button in the series edit panel never actually forced a refresh (only reachable via Swagger).
- Added a `force` param threaded through to both `Action/Refresh` calls, and a second "Update TMDB Info - Force" button, mirroring the existing AniDB force-refresh pattern.

**Back to draft — reviewing scope.** Server-side investigation turned up that the need for a separate Force button may itself be a symptom: `UpdateShow`/`UpdateMovie` gate a full refresh behind a 14-day TMDB Changes-API cache that's proven unreliable for translation/title-only edits (the root cause of shows getting stuck with placeholder episode titles that never resolve on a normal refresh). Considering just removing that 14-day incremental-cache limit server-side instead of exposing a client-side Force escape hatch for it — TMDB has no strict rate limit that requires the optimization, and it's been causing more correctness issues than the API calls it was saving. If that lands, this PR's Force button may become unnecessary (a plain refresh would always be complete) and should be reconsidered before merging.

## Test plan
- [x] `dprint fmt` / `oxlint` clean on changed files
- [x] Manual verification against a running Shoko Server instance

cc @harshithmohan — would appreciate a review here.