### PR TITLE
Extract anidb.net urls into helpers

### DIFF
--- a/src/components/Collection/Episode/EpisodeDetails.tsx
+++ b/src/components/Collection/Episode/EpisodeDetails.tsx
@@ -3,7 +3,7 @@ import { mdiCalendarMonthOutline, mdiClipboardOutline, mdiClockOutline, mdiOpenI
 import { Icon } from '@mdi/react';
 import { toNumber } from 'lodash';
 
-import { convertTimeSpanToMs, copyToClipboard, dayjs } from '@/core/util';
+import { convertTimeSpanToMs, copyToClipboard, dayjs, getAnidbEpisodeLink } from '@/core/util';
 
 import type { EpisodeType } from '@/core/types/api/episode';
 
@@ -66,7 +66,7 @@ const EpisodeDetails = ({ episode }: { episode: EpisodeType }) => (
         Copy ShokoID
       </div>
       {episode.AniDB?.ID && (
-        <a href={`https://anidb.net/episode/${episode.AniDB?.ID}`} target="_blank" rel="noopener noreferrer">
+        <a href={getAnidbEpisodeLink(episode.AniDB.ID)} target="_blank" rel="noopener noreferrer">
           <div className="flex items-center gap-x-2 text-panel-text-primary">
             <div className="metadata-link-icon AniDB" />
             AniDB

--- a/src/components/Collection/Episode/EpisodeFiles.tsx
+++ b/src/components/Collection/Episode/EpisodeFiles.tsx
@@ -27,7 +27,7 @@ import {
 import { invalidateQueries } from '@/core/react-query/queryClient';
 import { useDeleteReleaseInfoForFileByIdMutation } from '@/core/react-query/release-info/mutations';
 import toast from '@/core/toast';
-import { copyToClipboard } from '@/core/util';
+import { copyToClipboard, getAnidbGroupLink, isAnidbFileUri } from '@/core/util';
 
 import type { FileType } from '@/core/types/api/file';
 
@@ -138,7 +138,7 @@ const EpisodeFiles = ({ anidbSeriesId, episodeFiles, episodeId, seriesId }: Prop
                   />
                   Copy ShokoID
                 </div>
-                {file.Release?.ReleaseURI?.startsWith('https://anidb.net/file/') && (
+                {isAnidbFileUri(file.Release?.ReleaseURI) && (
                   <a href={file.Release.ReleaseURI} target="_blank" rel="noopener noreferrer">
                     <div className="flex items-center gap-x-2 font-semibold text-panel-text-primary">
                       <div className="metadata-link-icon AniDB" />
@@ -149,7 +149,7 @@ const EpisodeFiles = ({ anidbSeriesId, episodeFiles, episodeId, seriesId }: Prop
                 )}
                 {releaseGroup?.Source === 'AniDB' && (
                   <a
-                    href={`https://anidb.net/group/${releaseGroup.ID}/anime/${anidbSeriesId}`}
+                    href={getAnidbGroupLink(releaseGroup.ID, anidbSeriesId)}
                     target="_blank"
                     rel="noopener noreferrer"
                   >

--- a/src/components/Collection/Files/FilesMissingEpisodes.tsx
+++ b/src/components/Collection/Files/FilesMissingEpisodes.tsx
@@ -3,7 +3,7 @@ import { mdiOpenInNew } from '@mdi/js';
 import { Icon } from '@mdi/react';
 import cx from 'classnames';
 
-import { dayjs, padNumber } from '@/core/util';
+import { dayjs, getAnidbEpisodeLink, padNumber } from '@/core/util';
 
 import type { WebuiSeriesFileSummaryMissingEpisodeType } from '@/core/types/api/webui';
 
@@ -28,7 +28,7 @@ const MissingEpisode = ({ episode, rowId }: FileMissingEpisodeProps) => (
       &nbsp;
       <a
         className="inline-flex items-center gap-0 text-panel-text-primary"
-        href={`https://anidb.net/episode/${episode.ID}`}
+        href={getAnidbEpisodeLink(episode.ID)}
         target="_blank"
         rel="noopener noreferrer"
       >

--- a/src/components/Collection/SeriesMetadata.tsx
+++ b/src/components/Collection/SeriesMetadata.tsx
@@ -5,6 +5,7 @@ import { Icon } from '@mdi/react';
 import Button from '@/components/Input/Button';
 import { invalidateQueries } from '@/core/react-query/queryClient';
 import { useDeleteTmdbLinkMutation } from '@/core/react-query/tmdb/mutations';
+import { getAnidbAnimeLink } from '@/core/util';
 import useNavigateVoid from '@/hooks/useNavigateVoid';
 
 type Props = {
@@ -22,7 +23,7 @@ const SeriesMetadata = ({ id, seriesId, site, type }: Props) => {
     if (!id) return '#';
     switch (site) {
       case 'AniDB':
-        return `https://anidb.net/anime/${id}`;
+        return getAnidbAnimeLink(id);
       case 'TMDB':
         return `https://www.themoviedb.org/${type === 'Show' ? 'tv' : 'movie'}/${id}`;
       default:

--- a/src/components/Collection/Tags/TagDetailsModal.tsx
+++ b/src/components/Collection/Tags/TagDetailsModal.tsx
@@ -9,6 +9,7 @@ import { debounce } from 'lodash';
 import CleanDescription from '@/components/Collection/CleanDescription';
 import ModalPanel from '@/components/Panels/ModalPanel';
 import { useFilteredSeriesInfiniteQuery } from '@/core/react-query/filter/queries';
+import { getAnidbTagLink } from '@/core/util';
 import useFlattenListResult from '@/hooks/useFlattenListResult';
 
 import type { SeriesType } from '@/core/types/api/series';
@@ -100,7 +101,7 @@ const TagDetailsModal = ({ onClose, show, tag }: { show: boolean, tag?: TagType,
       </div>
       {tag?.Source === 'AniDB' && (
         <a
-          href={`https://anidb.net/tag/${tag.ID}`}
+          href={getAnidbTagLink(tag.ID)}
           className="flex items-center gap-x-2 text-base text-panel-icon-action"
           rel="noopener noreferrer"
           target="_blank"

--- a/src/components/SeriesPoster.tsx
+++ b/src/components/SeriesPoster.tsx
@@ -9,6 +9,7 @@ import Button from '@/components/Input/Button';
 import { invalidateQueries } from '@/core/react-query/queryClient';
 import { useRefreshAniDBSeriesMutation } from '@/core/react-query/series/mutations';
 import toast from '@/core/toast';
+import { getAnidbAnimeLink, getAnidbEpisodeLink } from '@/core/util';
 
 import type { ImageType } from '@/core/types/api/common';
 
@@ -142,7 +143,7 @@ const SeriesPoster = (props: Props) => {
   if (anidbEpisodeId ?? anidbSeriesId) {
     return (
       <a
-        href={`https://anidb.net/${anidbEpisodeId ? `episode/${anidbEpisodeId}` : `anime/${anidbSeriesId}`}`}
+        href={anidbEpisodeId ? getAnidbEpisodeLink(anidbEpisodeId) : getAnidbAnimeLink(anidbSeriesId!)}
         className={cx(baseClassName, 'group')}
         target="_blank"
         rel="noopener noreferrer"

--- a/src/components/Utilities/ReleaseManagement/MultipleReleasesSeriesList.tsx
+++ b/src/components/Utilities/ReleaseManagement/MultipleReleasesSeriesList.tsx
@@ -9,7 +9,7 @@ import { debounce } from 'lodash';
 import { Badge } from '@/components/Badge';
 import ShokoIcon from '@/components/ShokoIcon';
 import { useMultipleReleaseSeriesQuery } from '@/core/react-query/release-management/queries';
-import { handleShiftSelect } from '@/core/util';
+import { getAnidbAnimeLink, handleShiftSelect } from '@/core/util';
 import useFlattenListResult from '@/hooks/useFlattenListResult';
 import useNavigateVoid from '@/hooks/useNavigateVoid';
 import useRowSelection from '@/hooks/useRowSelection';
@@ -59,7 +59,7 @@ const SeriesRow = ({
           </div>
 
           <a
-            href={`https://anidb.net/anime/${series.AnidbAnimeID}`}
+            href={getAnidbAnimeLink(series.AnidbAnimeID)}
             target="_blank"
             rel="noreferrer noopener"
             className="flex items-center gap-1 font-semibold text-panel-text-primary"

--- a/src/components/Utilities/ReleaseManagement/ReleaseManagementSeriesDetail.tsx
+++ b/src/components/Utilities/ReleaseManagement/ReleaseManagementSeriesDetail.tsx
@@ -15,6 +15,7 @@ import ShokoIcon from '@/components/ShokoIcon';
 import MultipleReleasesPreviewModal from '@/components/Utilities/ReleaseManagement/MultipleReleasesPreviewModal';
 import { useMultipleReleaseSeriesDetailQuery } from '@/core/react-query/release-management/queries';
 import toast from '@/core/toast';
+import { getAnidbAnimeLink } from '@/core/util';
 import useNavigateVoid from '@/hooks/useNavigateVoid';
 
 import CandidatesTab from './SeriesDetail/CandidatesTab';
@@ -49,7 +50,7 @@ const Title = (
 
       <div className="ml-auto flex items-center gap-x-4 text-sm">
         <a
-          href={`https://anidb.net/anime/${anidbId}`}
+          href={getAnidbAnimeLink(anidbId)}
           target="_blank"
           rel="noopener noreferrer"
           className="flex items-center gap-x-1 font-semibold text-panel-text-primary"

--- a/src/components/Utilities/SeriesWithoutFiles/AddSeriesModal.tsx
+++ b/src/components/Utilities/SeriesWithoutFiles/AddSeriesModal.tsx
@@ -12,6 +12,7 @@ import { invalidateQueries } from '@/core/react-query/queryClient';
 import { useRefreshAniDBSeriesMutation } from '@/core/react-query/series/mutations';
 import { useSeriesAniDBSearchQuery } from '@/core/react-query/series/queries';
 import toast from '@/core/toast';
+import { getAnidbAnimeLink } from '@/core/util';
 
 type Props = {
   show: boolean;
@@ -102,7 +103,7 @@ const AddSeriesModal = ({ onClose, show }: Props) => {
                         )
                         : (
                           <a
-                            href={`https://anidb.net/anime/${result.ID}`}
+                            href={getAnidbAnimeLink(result.ID)}
                             target="_blank"
                             rel="noopener noreferrer"
                             className="text-panel-text-primary"

--- a/src/components/Utilities/Unrecognized/AvDumpSeriesSelectModal.tsx
+++ b/src/components/Utilities/Unrecognized/AvDumpSeriesSelectModal.tsx
@@ -13,7 +13,7 @@ import { useRescanFileMutation } from '@/core/react-query/file/mutations';
 import { useSeriesAniDBSearchQuery } from '@/core/react-query/series/queries';
 import { useSelector } from '@/core/store';
 import toast from '@/core/toast';
-import { copyToClipboard, dayjs } from '@/core/util';
+import { copyToClipboard, dayjs, getAnidbAnimeLink } from '@/core/util';
 import { detectShow, findMostCommonShowName } from '@/core/utilities/auto-match-logic';
 
 type Props = {
@@ -230,7 +230,7 @@ const AvDumpSeriesSelectModal = ({ fileIds, links, onClose, show }: Props) => {
                       <div key={result.ID} className="flex justify-between">
                         <button
                           type="button"
-                          onClick={() => handleMassAddClick(`https://anidb.net/anime/${result.ID}/release/add`)}
+                          onClick={() => handleMassAddClick(`${getAnidbAnimeLink(result.ID)}/release/add`)}
                           data-tooltip-id="tooltip"
                           className="line-clamp-1 text-left transition-colors hover:text-panel-text-primary"
                           data-tooltip-content="Mass Add"
@@ -238,7 +238,7 @@ const AvDumpSeriesSelectModal = ({ fileIds, links, onClose, show }: Props) => {
                           {result.Title}
                         </button>
                         <a
-                          href={`https://anidb.net/anime/${result.ID}`}
+                          href={getAnidbAnimeLink(result.ID)}
                           aria-label="Check Series"
                           target="_blank"
                           rel="noopener noreferrer"

--- a/src/components/Utilities/Unrecognized/LinkFilesWithProvider/CrossReference.tsx
+++ b/src/components/Utilities/Unrecognized/LinkFilesWithProvider/CrossReference.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { useEpisodeAniDBQuery } from '@/core/react-query/episode/queries';
 import { useSeriesAniDBQuery } from '@/core/react-query/series/queries';
 import { EpisodeTypeEnum } from '@/core/types/api/episode';
+import { getAnidbAnimeLink, getAnidbEpisodeLink } from '@/core/util';
 import { getEpisodePrefix } from '@/core/utilities/getEpisodePrefix';
 
 import type { ReleaseCrossReferenceType } from '@/core/types/api/file';
@@ -56,7 +57,7 @@ const CrossReference = ({ xref }: { xref: ReleaseCrossReferenceType }) => {
       &nbsp;
       <a
         className="text-panel-text-primary"
-        href={`https://anidb.net/episode/${xref.AnidbEpisodeID}`}
+        href={getAnidbEpisodeLink(xref.AnidbEpisodeID)}
         onClick={stopPropagation}
         target="_blank"
         rel="noreferrer noopener"
@@ -96,7 +97,7 @@ const CrossReference = ({ xref }: { xref: ReleaseCrossReferenceType }) => {
           &nbsp;
           <a
             className="text-panel-text-primary"
-            href={`https://anidb.net/anime/${xref.AnidbAnimeID}`}
+            href={getAnidbAnimeLink(xref.AnidbAnimeID)}
             onClick={stopPropagation}
             target="_blank"
             rel="noreferrer noopener"

--- a/src/components/Utilities/UtilitySeriesList.tsx
+++ b/src/components/Utilities/UtilitySeriesList.tsx
@@ -12,6 +12,7 @@ import {
   useReleaseManagementSeries,
   useReleaseManagementSeriesEpisodes,
 } from '@/core/react-query/release-management/queries';
+import { getAnidbAnimeLink, getAnidbEpisodeLink } from '@/core/util';
 import { getEpisodePrefix } from '@/core/utilities/getEpisodePrefix';
 import useFlattenListResult from '@/hooks/useFlattenListResult';
 import useRowSelection from '@/hooks/useRowSelection';
@@ -32,7 +33,7 @@ const seriesColumns: UtilityHeaderType<ReleaseManagementSeriesType>[] = [
       <div className="flex items-center gap-x-1" data-tooltip-id="tooltip" data-tooltip-content={series.Name}>
         <span className="line-clamp-1">{series.Name}</span>
         <a
-          href={`https://anidb.net/anime/${series.IDs.AniDB}`}
+          href={getAnidbAnimeLink(series.IDs.AniDB)}
           target="_blank"
           rel="noreferrer noopener"
           className="cursor-pointer text-panel-text-primary"
@@ -90,7 +91,7 @@ const episodeNameColumn: UtilityHeaderType<EpisodeType> = {
         {episode.Name}
       </span>
       <a
-        href={`https://anidb.net/episode/${episode.IDs.AniDB}`}
+        href={getAnidbEpisodeLink(episode.IDs.AniDB)}
         target="_blank"
         rel="noreferrer noopener"
         className="cursor-pointer text-panel-text-primary"

--- a/src/core/anidbUtils.ts
+++ b/src/core/anidbUtils.ts
@@ -1,0 +1,9 @@
+const ANIDB_BASE_URL = 'https://anidb.net';
+
+export const getAnidbAnimeLink = (anidbId: number | string) => `${ANIDB_BASE_URL}/anime/${anidbId}`;
+export const getAnidbEpisodeLink = (anidbId: number | string) => `${ANIDB_BASE_URL}/episode/${anidbId}`;
+export const getAnidbGroupLink = (groupId: number | string, anidbAnimeId: number | string) =>
+  `${ANIDB_BASE_URL}/group/${groupId}/anime/${anidbAnimeId}`;
+export const getAnidbTagLink = (tagId: number | string) => `${ANIDB_BASE_URL}/tag/${tagId}`;
+export const isAnidbFileUri = (uri?: string | null): uri is string =>
+  uri?.startsWith(`${ANIDB_BASE_URL}/file/`) ?? false;

--- a/src/core/util.ts
+++ b/src/core/util.ts
@@ -28,6 +28,8 @@ dayjs.extend(customParseFormatPlugin);
 
 export { default as dayjs } from 'dayjs';
 
+export * from '@/core/anidbUtils';
+
 /** Shared stale time: ~100 days. Used for relatively static data that rarely changes server-side. */
 export const INFINITE_STALE_TIME = 86400 * 100000;
 
@@ -41,16 +43,6 @@ export const getMinimumServerVersion = () => VITE_MIN_SERVER_VERSION;
 export const getUiVersion = () => (DEV ? VITE_GITHASH : VITE_APPVERSION);
 
 export const formatThousand = (num: number) => formatThousands(num, ',');
-
-const ANIDB_BASE_URL = 'https://anidb.net';
-
-export const getAnidbAnimeLink = (anidbId: number | string) => `${ANIDB_BASE_URL}/anime/${anidbId}`;
-export const getAnidbEpisodeLink = (anidbId: number | string) => `${ANIDB_BASE_URL}/episode/${anidbId}`;
-export const getAnidbGroupLink = (groupId: number | string, anidbAnimeId: number | string) =>
-  `${ANIDB_BASE_URL}/group/${groupId}/anime/${anidbAnimeId}`;
-export const getAnidbTagLink = (tagId: number | string) => `${ANIDB_BASE_URL}/tag/${tagId}`;
-export const isAnidbFileUri = (uri?: string | null): uri is string =>
-  uri?.startsWith(`${ANIDB_BASE_URL}/file/`) ?? false;
 
 export const getMainPoster = (target: SeriesType | CollectionGroupType) =>
   target?.Images?.Posters?.find(poster => poster.Preferred) ?? target?.Images?.Posters?.[0];

--- a/src/core/util.ts
+++ b/src/core/util.ts
@@ -42,6 +42,16 @@ export const getUiVersion = () => (DEV ? VITE_GITHASH : VITE_APPVERSION);
 
 export const formatThousand = (num: number) => formatThousands(num, ',');
 
+const ANIDB_BASE_URL = 'https://anidb.net';
+
+export const getAnidbAnimeLink = (anidbId: number | string) => `${ANIDB_BASE_URL}/anime/${anidbId}`;
+export const getAnidbEpisodeLink = (anidbId: number | string) => `${ANIDB_BASE_URL}/episode/${anidbId}`;
+export const getAnidbGroupLink = (groupId: number | string, anidbAnimeId: number | string) =>
+  `${ANIDB_BASE_URL}/group/${groupId}/anime/${anidbAnimeId}`;
+export const getAnidbTagLink = (tagId: number | string) => `${ANIDB_BASE_URL}/tag/${tagId}`;
+export const isAnidbFileUri = (uri?: string | null): uri is string =>
+  uri?.startsWith(`${ANIDB_BASE_URL}/file/`) ?? false;
+
 export const getMainPoster = (target: SeriesType | CollectionGroupType) =>
   target?.Images?.Posters?.find(poster => poster.Preferred) ?? target?.Images?.Posters?.[0];
 

--- a/src/pages/collection/series/TmdbLinking.tsx
+++ b/src/pages/collection/series/TmdbLinking.tsx
@@ -31,6 +31,7 @@ import {
 } from '@/core/react-query/tmdb/queries';
 import toast from '@/core/toast';
 import { EpisodeTypeEnum, MatchRatingType } from '@/core/types/api/episode';
+import { getAnidbAnimeLink } from '@/core/util';
 import useFlattenListResult from '@/hooks/useFlattenListResult';
 import useNavigateVoid from '@/hooks/useNavigateVoid';
 
@@ -341,7 +342,7 @@ const TmdbLinking = () => {
               </div>
               <a
                 className="flex cursor-pointer font-semibold text-panel-text-primary"
-                href={`https://anidb.net/anime/${seriesQuery.data.IDs.AniDB}`}
+                href={getAnidbAnimeLink(seriesQuery.data.IDs.AniDB)}
                 target="_blank"
                 rel="noopener noreferrer"
                 data-tooltip-id="tooltip"

--- a/src/pages/utilities/FileSearch.tsx
+++ b/src/pages/utilities/FileSearch.tsx
@@ -42,7 +42,7 @@ import { addFiles } from '@/core/slices/utilities/renamer';
 import { useDispatch } from '@/core/store';
 import toast from '@/core/toast';
 import { FileSortCriteriaEnum } from '@/core/types/api/file';
-import { copyToClipboard } from '@/core/util';
+import { copyToClipboard, isAnidbFileUri } from '@/core/util';
 import getEd2kLink from '@/core/utilities/getEd2kLink';
 import useFlattenListResult from '@/hooks/useFlattenListResult';
 import useMediaInfo from '@/hooks/useMediaInfo';
@@ -290,7 +290,7 @@ const FileDetails = ({ fileId }: { fileId: number }) => {
       <div className="flex flex-col gap-y-1">
         <div className="flex justify-between">
           <span className="font-semibold">File Name</span>
-          {file.Release?.ReleaseURI?.startsWith('https://anidb.net/file/') && (
+          {isAnidbFileUri(file.Release?.ReleaseURI) && (
             <a href={file.Release.ReleaseURI} target="_blank" rel="noopener noreferrer">
               <div className="flex items-center gap-x-2 font-semibold text-panel-text-primary">
                 <div className="metadata-link-icon AniDB" />

--- a/src/pages/utilities/SeriesWithoutFilesUtility.tsx
+++ b/src/pages/utilities/SeriesWithoutFilesUtility.tsx
@@ -25,7 +25,7 @@ import { invalidateQueries } from '@/core/react-query/queryClient';
 import { useDeleteSeriesMutation } from '@/core/react-query/series/mutations';
 import { useSeriesWithoutFilesInfiniteQuery } from '@/core/react-query/series/queries';
 import toast from '@/core/toast';
-import { dayjs } from '@/core/util';
+import { dayjs, getAnidbAnimeLink } from '@/core/util';
 import useFlattenListResult from '@/hooks/useFlattenListResult';
 import useRowSelection from '@/hooks/useRowSelection';
 
@@ -56,7 +56,7 @@ const columns: UtilityHeaderType<SeriesType>[] = [
       <div className="line-clamp-2 flex gap-x-1" data-tooltip-id="tooltip" data-tooltip-content={series.Name}>
         {series.Name}
         <a
-          href={`https://anidb.net/anime/${series.IDs.AniDB}`}
+          href={getAnidbAnimeLink(series.IDs.AniDB)}
           target="_blank"
           rel="noreferrer noopener"
           className="flex gap-x-1 font-semibold"

--- a/src/pages/utilities/UnrecognizedUtilityTabs/LinkFilesTab.tsx
+++ b/src/pages/utilities/UnrecognizedUtilityTabs/LinkFilesTab.tsx
@@ -44,7 +44,7 @@ import {
 import toast from '@/core/toast';
 import { EpisodeTypeEnum } from '@/core/types/api/episode';
 import { SeriesTypeEnum } from '@/core/types/api/series';
-import { formatThousand } from '@/core/util';
+import { formatThousand, getAnidbAnimeLink } from '@/core/util';
 import { detectShow, findMostCommonShowName } from '@/core/utilities/auto-match-logic';
 import useNavigateVoid from '@/hooks/useNavigateVoid';
 
@@ -129,7 +129,7 @@ const AnimeResultRow = (
   >
     <a
       className="flex w-20 shrink-0 font-semibold text-panel-text-primary"
-      href={`https://anidb.net/anime/${data.ID}`}
+      href={getAnidbAnimeLink(data.ID)}
       target="_blank"
       rel="noopener noreferrer"
     >
@@ -720,7 +720,7 @@ const LinkFilesTab = () => {
                 </div>
                 <a
                   className="flex cursor-pointer font-semibold text-panel-text-primary"
-                  href={`https://anidb.net/anime/${selectedSeries.ID}`}
+                  href={getAnidbAnimeLink(selectedSeries.ID)}
                   target="_blank"
                   rel="noopener noreferrer"
                   data-tooltip-id="tooltip"

--- a/src/pages/utilities/UnrecognizedUtilityTabs/ManuallyLinkedTab.tsx
+++ b/src/pages/utilities/UnrecognizedUtilityTabs/ManuallyLinkedTab.tsx
@@ -29,6 +29,7 @@ import {
   useSeriesWithLinkedFilesInfiniteQuery,
 } from '@/core/react-query/series/queries';
 import toast from '@/core/toast';
+import { getAnidbAnimeLink, getAnidbEpisodeLink } from '@/core/util';
 import { getEpisodePrefix } from '@/core/utilities/getEpisodePrefix';
 import useFlattenListResult from '@/hooks/useFlattenListResult';
 import useRowSelection from '@/hooks/useRowSelection';
@@ -47,7 +48,7 @@ const seriesColumns: UtilityHeaderType<SeriesType>[] = [
       <div className="flex items-center gap-x-1" data-tooltip-id="tooltip" data-tooltip-content={series.Name}>
         <span className="line-clamp-1">{series.Name}</span>
         <a
-          href={`https://anidb.net/anime/${series.IDs.AniDB}`}
+          href={getAnidbAnimeLink(series.IDs.AniDB)}
           target="_blank"
           rel="noreferrer noopener"
           className="cursor-pointer text-panel-text-primary"
@@ -101,7 +102,7 @@ const episodeColumns: UtilityHeaderType<EpisodeType>[] = [
           {episode.Name}
         </span>
         <a
-          href={`https://anidb.net/episode/${episode.IDs.AniDB}`}
+          href={getAnidbEpisodeLink(episode.IDs.AniDB)}
           target="_blank"
           rel="noreferrer noopener"
           className="cursor-pointer text-panel-text-primary"


### PR DESCRIPTION
## Extract anidb.net URL builders into a shared helper

AniDB links were built as raw inline template literals scattered across 21 files (27 occurrences) — every component hand-rolled its own `` `https://anidb.net/anime/${id}` ``-style string, with no shared helper or constant anywhere in the codebase. This made the URL scheme hard to change and easy to typo.

Added `getAnidbAnimeLink`, `getAnidbEpisodeLink`, `getAnidbGroupLink`, `getAnidbTagLink`, and `isAnidbFileUri` to `src/core/util.ts` and replaced all inline occurrences across the 18 affected files. Left `wiki.anidb.net` links and the `api.anidb.net` placeholder text untouched — different subdomain/purpose, out of scope.
