### PR TITLE
Migrate to new image endpoints

### DIFF
--- a/src/components/BackgroundImagePlaceholderDiv.tsx
+++ b/src/components/BackgroundImagePlaceholderDiv.tsx
@@ -5,13 +5,13 @@ import cx from 'classnames';
 
 import { useSettingsQuery } from '@/core/react-query/settings/queries';
 
-import type { ImageType } from '@/core/types/api/common';
+import type { ImageLinkType } from '@/core/types/api/common';
 
 type Props = {
   children?: React.ReactNode;
   className?: string;
   contain?: boolean;
-  image?: ImageType;
+  image?: ImageLinkType;
   hidePlaceholderOnHover?: boolean;
   overlayOnHover?: boolean;
   zoomOnHover?: boolean;
@@ -42,7 +42,7 @@ const BackgroundImagePlaceholderDiv = (props: Props) => {
       return null;
     }
 
-    return `/api/v3/Image/${image.Source}/${image.Type}/${image.ID}`;
+    return `/api/v3/Image/${image.UID}`;
   }, [image, settings.LoadImageMetadata]);
 
   const [imageError, setImageError] = useState<string | null>(null);

--- a/src/components/Collection/Credits/CreditsStaffPanel.tsx
+++ b/src/components/Collection/Credits/CreditsStaffPanel.tsx
@@ -8,7 +8,7 @@ import type { CreditsModeType } from '@/pages/collection/series/SeriesCredits';
 const getThumbnailUrl = (item: SeriesCast, mode: CreditsModeType) => {
   const thumbnail = item[mode]?.Image ?? null;
   if (!thumbnail?.Available) return null;
-  return `/api/v3/Image/${thumbnail.Source}/${thumbnail.Type}/${thumbnail.ID}`;
+  return `/api/v3/Image/${thumbnail.UID}`;
 };
 
 const CreditsStaffPanel = ({ cast, mode }: { cast: SeriesCast, mode: CreditsModeType }) => (

--- a/src/components/Collection/SeriesTopPanel.tsx
+++ b/src/components/Collection/SeriesTopPanel.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useMemo, useState } from 'react';
 import { useParams } from 'react-router';
 import { mdiTagPlusOutline } from '@mdi/js';
 import Icon from '@mdi/react';
-import { toNumber } from 'lodash';
+import { flatMap, toNumber } from 'lodash';
 import { useToggle } from 'usehooks-ts';
 
 import BackgroundImagePlaceholderDiv from '@/components/BackgroundImagePlaceholderDiv';
@@ -13,11 +13,12 @@ import TagButton from '@/components/Collection/TagButton';
 import CustomTagModal from '@/components/Dialogs/CustomTagModal';
 import Button from '@/components/Input/Button';
 import ShokoPanel from '@/components/Panels/ShokoPanel';
-import { useSeriesImagesQuery, useSeriesTagsQuery } from '@/core/react-query/series/queries';
+import { useSeriesImageCrossReferencesQuery } from '@/core/react-query/image-management/queries';
+import { useSeriesTagsQuery } from '@/core/react-query/series/queries';
 import { useSettingsQuery } from '@/core/react-query/settings/queries';
 import { getMainPoster } from '@/core/util';
 
-import type { ImageType } from '@/core/types/api/common';
+import type { ImageLinkType } from '@/core/types/api/common';
 import type { SeriesType } from '@/core/types/api/series';
 
 const SeriesTopPanel = ({ series }: { series: SeriesType }) => {
@@ -27,10 +28,15 @@ const SeriesTopPanel = ({ series }: { series: SeriesType }) => {
   const tags = useMemo(() => tagsQuery?.data ?? [], [tagsQuery.data]);
 
   const { showRandomPoster } = useSettingsQuery().data.WebUI_Settings.collection.image;
-  const imagesQuery = useSeriesImagesQuery(toNumber(seriesId!), !!seriesId && showRandomPoster);
   const mainPoster = getMainPoster(series);
-  const [poster, setPoster] = useState<ImageType>();
+  const [poster, setPoster] = useState<ImageLinkType>();
   const [showTagModal, toggleTagModal] = useToggle(false);
+
+  const postersQuery = useSeriesImageCrossReferencesQuery(
+    toNumber(seriesId) ?? 0,
+    { imageType: 'Poster', isAvailable: true, pageSize: 30 },
+    !!seriesId && showRandomPoster,
+  );
 
   useEffect(() => {
     if (!showRandomPoster) {
@@ -38,11 +44,11 @@ const SeriesTopPanel = ({ series }: { series: SeriesType }) => {
       return;
     }
 
-    const allPosters = imagesQuery.data?.Posters ?? [];
+    const allPosters = flatMap(postersQuery.data?.pages, page => page.List)
+      .filter(xref => xref.Image?.Available);
     if (allPosters.length === 0) return;
-
-    setPoster(allPosters[Math.floor(Math.random() * allPosters.length)]);
-  }, [imagesQuery.data, mainPoster, showRandomPoster]);
+    setPoster(allPosters[Math.floor(Math.random() * allPosters.length)].Image);
+  }, [mainPoster, postersQuery.data, showRandomPoster]);
 
   // TODO: try to make this a grid for better responsiveness... but we'll have v3 soon so maybe not right now.
   return (

--- a/src/components/Collection/constants.ts
+++ b/src/components/Collection/constants.ts
@@ -1,6 +1,6 @@
 import type React from 'react';
 
-import type { ImageType } from '@/core/types/api/common';
+import type { ImageLinkType } from '@/core/types/api/common';
 import type { SeriesType } from '@/core/types/api/series';
 
 export const posterItemSize = {
@@ -17,7 +17,7 @@ export const listItemSize = {
 };
 
 export type SeriesContextType = {
-  backdrop?: ImageType;
+  backdrop?: ImageLinkType;
   scrollRef: React.RefObject<HTMLDivElement>;
   series: SeriesType;
 };

--- a/src/core/react-query/image-management/mutations.ts
+++ b/src/core/react-query/image-management/mutations.ts
@@ -1,0 +1,12 @@
+import { useMutation } from '@tanstack/react-query';
+
+import { axios } from '@/core/axios';
+import { invalidateQueries } from '@/core/react-query/queryClient';
+
+export const useSetPreferredImageMutation = () =>
+  useMutation({
+    mutationFn: (xrefId: number) => axios.put(`Image/Management/CrossReference/${xrefId}/Preferred`),
+    onSuccess: () => {
+      invalidateQueries(['image-management', 'cross-references']);
+    },
+  });

--- a/src/core/react-query/image-management/queries.ts
+++ b/src/core/react-query/image-management/queries.ts
@@ -1,0 +1,36 @@
+import { useInfiniteQuery } from '@tanstack/react-query';
+
+import { axios } from '@/core/axios';
+
+import type { SeriesImageCrossReferencesRequestType } from '@/core/react-query/image-management/types';
+import type { ListResultType } from '@/core/types/api';
+import type { ImageCrossReferenceType } from '@/core/types/api/image';
+
+/**
+ * Fetch image cross-references for a series, filtered by image type.
+ */
+export const useSeriesImageCrossReferencesQuery = (
+  seriesId: number,
+  params: SeriesImageCrossReferencesRequestType,
+  enabled: boolean,
+) =>
+  useInfiniteQuery<ListResultType<ImageCrossReferenceType>>({
+    queryKey: ['image-management', 'cross-references', seriesId, params],
+    queryFn: ({ pageParam }) =>
+      axios.get(
+        `Image/Management/CrossReference/Entity/Shoko/Series/${seriesId}`,
+        {
+          params: {
+            ...params,
+            includeImage: true,
+            page: pageParam as number,
+          },
+        },
+      ),
+    initialPageParam: 1,
+    getNextPageParam: (lastPage, _, lastPageParam) => {
+      if (!params.pageSize || lastPage.Total / params.pageSize <= (lastPageParam as number)) return undefined;
+      return (lastPageParam as number) + 1;
+    },
+    enabled: enabled && !!seriesId,
+  });

--- a/src/core/react-query/image-management/types.ts
+++ b/src/core/react-query/image-management/types.ts
@@ -1,0 +1,6 @@
+import type { PaginationType } from '@/core/types/api';
+
+export type SeriesImageCrossReferencesRequestType = {
+  imageType: string;
+  isAvailable?: boolean;
+} & PaginationType;

--- a/src/core/react-query/series/mutations.ts
+++ b/src/core/react-query/series/mutations.ts
@@ -10,25 +10,7 @@ import type {
   RefreshSeriesAniDBInfoRequestType,
   WatchSeriesEpisodesRequestType,
 } from '@/core/react-query/series/types';
-import type { ImageType } from '@/core/types/api/common';
 import type { SeriesAniDBSearchResult } from '@/core/types/api/series';
-
-export const useChangeSeriesImageMutation = (seriesId: number) =>
-  useMutation({
-    mutationFn: (image: ImageType) =>
-      axios.put(
-        `Series/${seriesId}/Images/${image.Type}`,
-        {
-          ID: image.ID,
-          Source: image.Source,
-        },
-      ),
-    onSuccess: (_, image) => {
-      toast.success(`Series ${image.Type} image has been changed.`);
-      invalidateQueries(['series', seriesId, 'data']);
-      invalidateQueries(['series', seriesId, 'images']);
-    },
-  });
 
 export const useDeleteSeriesMutation = () =>
   useMutation({

--- a/src/core/react-query/series/queries.ts
+++ b/src/core/react-query/series/queries.ts
@@ -15,7 +15,6 @@ import type {
 import type { DashboardRequestType, FileRequestType } from '@/core/react-query/types';
 import type { ListResultType } from '@/core/types/api';
 import type { CollectionGroupType } from '@/core/types/api/collection';
-import type { ImagesType } from '@/core/types/api/common';
 import type { AniDBEpisodeType, EpisodeType } from '@/core/types/api/episode';
 import type { FileType } from '@/core/types/api/file';
 import type {
@@ -113,13 +112,6 @@ export const useSeriesGroupQuery = (seriesId: number, topLevel: boolean) =>
   useQuery<CollectionGroupType>({
     queryKey: ['series', seriesId, 'group', topLevel],
     queryFn: () => axios.get(`Series/${seriesId}/Group`, { params: { topLevel } }),
-  });
-
-export const useSeriesImagesQuery = (seriesId: number, enabled = true) =>
-  useQuery<ImagesType>({
-    queryKey: ['series', seriesId, 'images'],
-    queryFn: () => axios.get(`Series/${seriesId}/Images`),
-    enabled,
   });
 
 export const useSeriesNextUpQuery = (seriesId: number, params: SeriesNextUpRequestType, enabled = true) =>

--- a/src/core/types/api/common.ts
+++ b/src/core/types/api/common.ts
@@ -1,20 +1,17 @@
-export type ImageType = {
+/** Minimal image reference used for passing images around without full metadata. */
+export type ImageLinkType = {
+  UID: string;
+  Available: boolean;
+};
+
+export type ImageType = ImageLinkType & {
   Source: ImageSourceEnum;
   Type: ImageTypeEnum;
   ID: number;
-  Available: boolean;
+  PrimaryUID: string;
   Preferred: boolean;
-  Width: null;
-  Height: null;
-  Disabled: boolean;
-} | {
-  Source: ImageSourceEnum;
-  Type: ImageTypeEnum;
-  ID: number;
-  Available: boolean;
-  Preferred: boolean;
-  Width: number;
-  Height: number;
+  Width?: number;
+  Height?: number;
   Disabled: boolean;
 };
 

--- a/src/core/types/api/image.ts
+++ b/src/core/types/api/image.ts
@@ -1,16 +1,63 @@
-import type { ImageTypeEnum } from '@/core/types/api/common';
+import type { ImageLinkType, ImageTypeEnum, RatingType } from './common';
 
 export type RandomImageMetadataResultType = {
   Source: string;
   Type: ImageTypeEnum;
   ID: string;
+  UID: string;
   Available: boolean;
   Preferred: boolean;
-  Width: number | null;
-  Height: number | null;
+  Width?: number;
+  Height?: number;
   Disabled: boolean;
   Series: {
     ID: number;
     Name: string;
   };
 };
+
+export type ImageSlimType = ImageLinkType & {
+  /** Primary image's UUID in the linked image list. */
+  PrimaryUID: string;
+  /** Extra image UUIDs in the linked image list, except the primary image. */
+  LinkedUIDs?: string[];
+  Source: string;
+  ResourceID: string;
+  ContentType: string;
+  Disabled: boolean;
+  LanguageCode?: string;
+  CountryCode?: string;
+  Width?: number;
+  Height?: number;
+};
+
+export type ImageCrossReferenceType = {
+  /** The cross-reference ID — used for set-preferred mutations. */
+  ID: number;
+  ImageID: string;
+  /** The primary image's UUID for the associated entity. */
+  PrimaryImageID: string;
+  ImageType: 'Primary' | 'Backdrop' | 'Banner' | 'Logo' | 'Disc';
+  ImageSource: string;
+  EntityID: string;
+  EntityType: string;
+  EntitySource: string;
+  EntitySeasonNumber?: number;
+  EntityEpisodeNumber?: number;
+  EntityReleasedAt?: string;
+  /** Ordering number — lower values appear first. */
+  Ordering: number;
+  IsEnabled: boolean;
+  /** Whether auto-download of the image is desired. */
+  IsDesired: boolean;
+  IsPreferred: boolean;
+  CommunityRating?: RatingType;
+  /** The source of the cross-reference (e.g. "User" for manual). */
+  Source: string;
+  CreatedAt: string;
+  LastUpdatedAt: string;
+  /** Included when ?includeImage=true. */
+  Image?: ImageSlimType;
+};
+
+export type ImageTabType = 'Posters' | 'Backdrops' | 'Logos';

--- a/src/core/util.ts
+++ b/src/core/util.ts
@@ -148,3 +148,6 @@ export const handleShiftSelect = (params: {
     console.error(error);
   }
 };
+
+/** Root font size in px, read once from the document. */
+export const pxPerRem = parseFloat(getComputedStyle(document.documentElement).fontSize);

--- a/src/hooks/useEpisodeThumbnail.ts
+++ b/src/hooks/useEpisodeThumbnail.ts
@@ -2,10 +2,10 @@ import { useMemo } from 'react';
 
 import { useSettingsQuery } from '@/core/react-query/settings/queries';
 
-import type { ImageType } from '@/core/types/api/common';
+import type { ImageLinkType } from '@/core/types/api/common';
 import type { EpisodeType } from '@/core/types/api/episode';
 
-const useEpisodeThumbnail = (episode: EpisodeType, backdrop?: ImageType) => {
+const useEpisodeThumbnail = (episode: EpisodeType, backdrop?: ImageLinkType) => {
   const { useThumbnailFallback } = useSettingsQuery().data.WebUI_Settings.collection.image;
   return useMemo(() => {
     if (episode.Images.Thumbnails?.length) {

--- a/src/pages/collection/Series.tsx
+++ b/src/pages/collection/Series.tsx
@@ -14,20 +14,21 @@ import {
 } from '@mdi/js';
 import { Icon } from '@mdi/react';
 import cx from 'classnames';
-import { toNumber } from 'lodash';
+import { flatMap, toNumber } from 'lodash';
 
 import EditSeriesModal from '@/components/Collection/Series/EditSeriesModal';
 import SeriesTopPanel from '@/components/Collection/SeriesTopPanel';
 import Button from '@/components/Input/Button';
 import { useGroupQuery } from '@/core/react-query/group/queries';
-import { useSeriesImagesQuery, useSeriesQuery } from '@/core/react-query/series/queries';
+import { useSeriesImageCrossReferencesQuery } from '@/core/react-query/image-management/queries';
+import { useSeriesQuery } from '@/core/react-query/series/queries';
 import { useSettingsQuery } from '@/core/react-query/settings/queries';
 import { setSeriesId } from '@/core/slices/modals/editSeries';
 import { useDispatch } from '@/core/store';
 import useNavigateVoid from '@/hooks/useNavigateVoid';
 
 import type { SeriesContextType } from '@/components/Collection/constants';
-import type { ImageType } from '@/core/types/api/common';
+import type { ImageLinkType } from '@/core/types/api/common';
 import type { SeriesType } from '@/core/types/api/series';
 
 const SeriesTab = ({ icon, text, to }: { icon: string, text: string, to: string }) => (
@@ -45,7 +46,7 @@ const SeriesTab = ({ icon, text, to }: { icon: string, text: string, to: string 
   </NavLink>
 );
 
-const getImagePath = ({ ID, Source, Type }: ImageType) => `/api/v3/Image/${Source}/${Type}/${ID}`;
+const getImagePath = (uid: string) => `/api/v3/Image/${uid}`;
 
 const languageMapping = { 'x-jat': 'ja', 'x-kot': 'ko', 'x-zht': 'zh-hans' };
 
@@ -79,19 +80,25 @@ const Series = () => {
   };
 
   const { showRandomBackdrop } = useSettingsQuery().data.WebUI_Settings.collection.image;
-  const imagesQuery = useSeriesImagesQuery(toNumber(seriesId!), !!seriesId && showRandomBackdrop);
-  const [backdrop, setBackdrop] = useState<ImageType>();
+
+  const backdropsQuery = useSeriesImageCrossReferencesQuery(
+    toNumber(seriesId) ?? 0,
+    { imageType: 'Backdrop', isAvailable: true, pageSize: 30 },
+    !!seriesId && showRandomBackdrop,
+  );
+
+  const [backdrop, setBackdrop] = useState<ImageLinkType>();
   useEffect(() => {
     if (!showRandomBackdrop) {
       setBackdrop(series.Images?.Backdrops?.[0]);
       return;
     }
 
-    const allBackdrops = imagesQuery.data?.Backdrops ?? [];
+    const allBackdrops = flatMap(backdropsQuery.data?.pages, page => page.List)
+      .filter(xref => xref.Image?.Available);
     if (allBackdrops.length === 0) return;
-
-    setBackdrop(allBackdrops[Math.floor(Math.random() * allBackdrops.length)]);
-  }, [imagesQuery.data, series, showRandomBackdrop]);
+    setBackdrop(allBackdrops[Math.floor(Math.random() * allBackdrops.length)].Image);
+  }, [backdropsQuery.data, series, showRandomBackdrop]);
 
   const [containerRef, containerBounds] = useMeasure();
 
@@ -164,7 +171,7 @@ const Series = () => {
         // If this height feels like a hack, you figure out how to fix it
         // 3rem accounts for the top and bottom padding of the container (1.5rem each side)
         style={{
-          backgroundImage: backdrop ? `url('${getImagePath(backdrop)}')` : undefined,
+          backgroundImage: backdrop ? `url('${getImagePath(backdrop.UID)}')` : undefined,
           height: `calc(${containerBounds.height}px + 3rem)`,
         }}
       />

--- a/src/pages/collection/series/SeriesImages.tsx
+++ b/src/pages/collection/series/SeriesImages.tsx
@@ -1,26 +1,37 @@
 import React, { useMemo, useState } from 'react';
 import { useOutletContext, useParams } from 'react-router';
-import { mdiStarCircleOutline } from '@mdi/js';
+import useMeasure from 'react-use-measure';
+import { mdiLoading, mdiStarCircleOutline } from '@mdi/js';
 import { Icon } from '@mdi/react';
+import { useVirtualizer } from '@tanstack/react-virtual';
 import cx from 'classnames';
-import { capitalize } from 'lodash';
+import { capitalize, debounce } from 'lodash';
 
 import BackgroundImagePlaceholderDiv from '@/components/BackgroundImagePlaceholderDiv';
 import Button from '@/components/Input/Button';
 import MultiStateButton from '@/components/Input/MultiStateButton';
 import ShokoPanel from '@/components/Panels/ShokoPanel';
-import { useChangeSeriesImageMutation } from '@/core/react-query/series/mutations';
-import { useSeriesImagesQuery } from '@/core/react-query/series/queries';
+import { useSetPreferredImageMutation } from '@/core/react-query/image-management/mutations';
+import { useSeriesImageCrossReferencesQuery } from '@/core/react-query/image-management/queries';
+import { invalidateQueries } from '@/core/react-query/queryClient';
+import toast from '@/core/toast';
+import { pxPerRem } from '@/core/util';
+import useFlattenListResult from '@/hooks/useFlattenListResult';
 import useNavigateVoid from '@/hooks/useNavigateVoid';
 
 import type { SeriesContextType } from '@/components/Collection/constants';
-import type { ImageType } from '@/core/types/api/common';
+import type { ImageCrossReferenceType, ImageTabType } from '@/core/types/api/image';
 
-type ImageTabType = 'Posters' | 'Backdrops' | 'Logos';
+const tabToImageTypeMap: Record<ImageTabType, string> = {
+  Posters: 'Primary',
+  Backdrops: 'Backdrop',
+  Logos: 'Logo',
+};
+
 const tabStates = [
-  { value: 'Posters' },
-  { value: 'Backdrops' },
-  { value: 'Logos' },
+  { value: 'Posters' as const },
+  { value: 'Backdrops' as const },
+  { value: 'Logos' as const },
 ];
 
 const InfoLine = ({ title, value }: { title: string, value: string }) => (
@@ -30,35 +41,45 @@ const InfoLine = ({ title, value }: { title: string, value: string }) => (
   </div>
 );
 
-const sizeMap = {
-  Posters: { image: 'h-[clamp(15rem,_16vw,_21rem)]', grid: 'grid-cols-6' },
-  Backdrops: { image: 'h-[clamp(11.5rem,_12vw,_16rem)]', grid: 'grid-cols-3' },
-  Logos: { image: 'h-[clamp(15rem,_16vw,_21rem)]', grid: 'grid-cols-4' },
+const imageItemSize: Record<ImageTabType, { height: number, width: number }> = {
+  Posters: { width: 13, height: 19.5 },
+  Backdrops: { width: 27, height: 16 },
+  Logos: { width: 15, height: 15 },
 };
+
+const itemGap = 1; // rem
 
 const SeriesImages = () => {
   const { imageType } = useParams();
-
-  const { series } = useOutletContext<SeriesContextType>();
-
+  const { scrollRef, series } = useOutletContext<SeriesContextType>();
   const navigate = useNavigateVoid();
 
-  const tabType = useMemo(() => {
-    if (!imageType) return 'Posters';
-    return capitalize(imageType) as ImageTabType;
-  }, [imageType]);
-  const [selectedImage, setSelectedImage] = useState<ImageType | null>(null);
-  const images = useSeriesImagesQuery(series.IDs.ID).data;
-  const { mutate: changeImage } = useChangeSeriesImageMutation(series.IDs.ID);
+  const tabType = (capitalize(imageType) ?? 'Posters') as ImageTabType;
 
-  const handleSelectionChange = (item: ImageType) => {
-    setSelectedImage(old => ((old === item) ? null : item));
+  const { fetchNextPage, isFetchingNextPage, ...crossReferencesQuery } = useSeriesImageCrossReferencesQuery(
+    series.IDs.ID,
+    { imageType: tabToImageTypeMap[tabType], isAvailable: true, pageSize: 30 },
+    !!series.IDs.ID,
+  );
+
+  const [images, imagesTotal] = useFlattenListResult(crossReferencesQuery.data);
+
+  const [selectedImage, setSelectedImage] = useState<ImageCrossReferenceType | null>(null);
+  const { mutate: setPreferred } = useSetPreferredImageMutation();
+
+  const handleSelectionChange = (item: ImageCrossReferenceType) => {
+    setSelectedImage(prev => (prev?.ID === item.ID ? null : item));
   };
 
   const handleSetPreferredImage = () => {
     if (!selectedImage) return;
-    changeImage(selectedImage, {
-      onSuccess: () => setSelectedImage(null),
+    setPreferred(selectedImage.ID, {
+      onSuccess: () => {
+        invalidateQueries(['series']);
+        toast.success(`Preferred ${tabType.slice(0, -1)} has been set.`);
+        setSelectedImage(null);
+      },
+      onError: () => toast.error(`Failed to set preferred ${tabType.slice(0, -1)}.`),
     });
   };
 
@@ -66,6 +87,32 @@ const SeriesImages = () => {
     setSelectedImage(null);
     navigate(`../images/${newType.toLowerCase()}`);
   };
+
+  const [gridContainerRef, gridContainerBounds] = useMeasure();
+
+  const { height: itemHeight, width: itemWidth } = imageItemSize[tabType];
+
+  const itemsPerRow = Math.max(
+    1,
+    Math.floor((gridContainerBounds.width / pxPerRem + itemGap) / (itemWidth + itemGap)),
+  );
+  const rowCount = Math.ceil(imagesTotal / itemsPerRow);
+
+  const virtualizer = useVirtualizer({
+    count: rowCount,
+    getScrollElement: () => scrollRef.current,
+    estimateSize: () => (itemHeight + itemGap) * pxPerRem,
+    overscan: 4,
+    gap: 24,
+  });
+
+  const fetchNextPageDebounced = useMemo(
+    () =>
+      debounce(() => {
+        fetchNextPage().catch(console.error);
+      }, 50),
+    [fetchNextPage],
+  );
 
   return (
     <>
@@ -79,17 +126,20 @@ const SeriesImages = () => {
             transparent
             sticky
           >
-            <InfoLine title="Source" value={selectedImage?.Source ?? '-'} />
+            <InfoLine
+              title="Source"
+              value={selectedImage?.Image?.Source ?? selectedImage?.ImageSource ?? '-'}
+            />
             <InfoLine
               title="Size"
-              value={selectedImage?.Width && selectedImage?.Height
-                ? `${selectedImage.Width} x ${selectedImage.Height}`
+              value={selectedImage?.Image?.Width && selectedImage?.Image?.Height
+                ? `${selectedImage.Image.Width} x ${selectedImage.Image.Height}`
                 : '-'}
             />
             <Button
               buttonType="primary"
               buttonSize="normal"
-              disabled={!selectedImage || selectedImage.Preferred}
+              disabled={!selectedImage || selectedImage.IsPreferred}
               onClick={handleSetPreferredImage}
             >
               {`Set As Preferred ${tabType.slice(0, -1)}`}
@@ -97,50 +147,90 @@ const SeriesImages = () => {
           </ShokoPanel>
         </div>
         <div className="flex grow flex-col gap-y-6">
-          <div className="flex h-24.5 items-center justify-between rounded-lg border border-panel-border bg-panel-background-transparent p-6">
+          <div className="flex h-24.5 shrink-0 items-center justify-between rounded-lg border border-panel-border bg-panel-background-transparent p-6">
             <div className="text-xl font-semibold">
               Images |&nbsp;
-              <span className="text-panel-text-important">{images?.[tabType]?.length ?? '-'}</span>
+              <span className="text-panel-text-important">{imagesTotal || '-'}</span>
               &nbsp;
               {tabType}
               &nbsp;Listed
             </div>
             <MultiStateButton activeState={tabType} onStateChange={handleTabChange} states={tabStates} />
           </div>
-          <div
-            className={cx(
-              sizeMap[tabType].grid,
-              'grid gap-6 rounded-lg border border-panel-border bg-panel-background-transparent p-6',
-            )}
-          >
-            {images?.[tabType].map(item => (
-              <div
-                onClick={() => handleSelectionChange(item)}
-                key={`${item.Source}-${item.Type}-${item.ID}`}
-                className="group flex cursor-pointer items-center justify-between"
-              >
-                <BackgroundImagePlaceholderDiv
-                  image={item}
-                  contain={tabType === 'Logos'}
-                  className={cx(
-                    'grow rounded-lg outline drop-shadow-md transition-transform',
-                    item === selectedImage
-                      ? 'outline-4 outline-panel-text-important'
-                      : 'outline-2 outline-panel-border',
-                    sizeMap[tabType].image,
-                  )}
-                  linkToImage
-                  zoomOnHover
+          <div className="rounded-lg border border-panel-border bg-panel-background-transparent p-6">
+            <div className="relative" style={{ height: virtualizer.getTotalSize() }} ref={gridContainerRef}>
+              {virtualizer.getVirtualItems().map(virtualRow => (
+                <div
+                  key={virtualRow.key}
+                  ref={virtualizer.measureElement}
+                  data-index={virtualRow.index}
+                  className="absolute top-0 left-0 flex w-full items-center justify-center gap-x-6"
+                  style={{ transform: `translateY(${virtualRow.start}px)` }}
                 >
-                  {item.Preferred && (
-                    <div className="absolute bottom-2 mx-[5%] flex w-[90%] justify-center gap-2.5 rounded-lg bg-panel-background-overlay py-2 text-sm font-semibold text-panel-text opacity-100 transition-opacity group-hover:opacity-0">
-                      <Icon path={mdiStarCircleOutline} size={1} />
-                      Preferred
-                    </div>
-                  )}
-                </BackgroundImagePlaceholderDiv>
-              </div>
-            ))}
+                  {Array.from({ length: itemsPerRow }).map((_, colIndex) => {
+                    const index = virtualRow.index * itemsPerRow + colIndex;
+                    const xref = images[index];
+                    const isPlaceholder = index >= imagesTotal;
+
+                    if (isPlaceholder) {
+                      return (
+                        <div
+                          key={`placeholder-${index}`}
+                          style={{ width: `${itemWidth}rem`, height: `${itemHeight}rem` }}
+                        />
+                      );
+                    }
+
+                    if (!xref) {
+                      if (!isFetchingNextPage) {
+                        fetchNextPageDebounced();
+                      }
+                      return (
+                        <div
+                          key={`loading-${index}`}
+                          className="flex shrink-0 items-center justify-center rounded-lg border border-panel-border text-panel-text-primary"
+                          style={{
+                            width: `${itemWidth}rem`,
+                            height: `${itemHeight}rem`,
+                          }}
+                        >
+                          <Icon path={mdiLoading} spin size={2} />
+                        </div>
+                      );
+                    }
+
+                    return (
+                      <div
+                        onClick={() => handleSelectionChange(xref)}
+                        key={xref.ID}
+                        className="group flex cursor-pointer items-center justify-between"
+                        style={{ width: `${itemWidth}rem`, height: `${itemHeight}rem` }}
+                      >
+                        <BackgroundImagePlaceholderDiv
+                          image={xref.Image}
+                          contain={tabType === 'Logos'}
+                          className={cx(
+                            'size-full rounded-lg drop-shadow-md',
+                            xref === selectedImage
+                              ? 'border-4 border-panel-text-important'
+                              : 'border-2 border-panel-border',
+                          )}
+                          linkToImage
+                          zoomOnHover
+                        >
+                          {xref.IsPreferred && (
+                            <div className="absolute bottom-2 mx-[5%] flex w-[90%] justify-center gap-2.5 rounded-lg bg-panel-background-overlay py-2 text-sm font-semibold text-panel-text opacity-100 transition-opacity group-hover:opacity-0">
+                              <Icon path={mdiStarCircleOutline} size={1} />
+                              Preferred
+                            </div>
+                          )}
+                        </BackgroundImagePlaceholderDiv>
+                      </div>
+                    );
+                  })}
+                </div>
+              ))}
+            </div>
           </div>
         </div>
       </div>

--- a/src/pages/collection/series/SeriesOverview.tsx
+++ b/src/pages/collection/series/SeriesOverview.tsx
@@ -53,7 +53,7 @@ const SeriesOverview = () => {
   const getThumbnailUrl = (item: SeriesCast, mode: string) => {
     const thumbnail = get<SeriesCast, string, ImageType | null>(item, `${mode}.Image`, null);
     if (thumbnail === null) return null;
-    return `/api/v3/Image/${thumbnail.Source}/${thumbnail.Type}/${thumbnail.ID}`;
+    return `/api/v3/Image/${thumbnail.UID}`;
   };
 
   return (

--- a/src/pages/login/LoginPage.tsx
+++ b/src/pages/login/LoginPage.tsx
@@ -53,13 +53,13 @@ const LoginPage = () => {
 
   useEffect(() => {
     if (imageMetadataQuery.isPending) return;
-    if (!imageMetadataQuery.isSuccess || !imageMetadataQuery.data.Type) {
+    if (!imageMetadataQuery.isSuccess || !imageMetadataQuery.data.UID) {
       setLoginImage({ imageUrl: 'default', seriesName: 'One Piece', seriesId: 0 });
       return;
     }
-    const { ID, Series, Source, Type } = imageMetadataQuery.data;
+    const { Series, UID } = imageMetadataQuery.data;
     setLoginImage({
-      imageUrl: `/api/v3/Image/${Source}/${Type}/${ID}`,
+      imageUrl: `/api/v3/Image/${UID}`,
       seriesName: Series?.Name ?? '',
       seriesId: Series?.ID ?? 0,
     });


### PR DESCRIPTION
## Summary

Migrates image handling from deprecated API endpoints to the new `ImageManagementController` endpoints with UUID-based image URLs.

### Key changes

**New API layer** (`src/core/react-query/image-management/`)
- `useSeriesImageCrossReferencesQuery` — paginated image cross-references with type filtering
- `useSetPreferredImageMutation` — set preferred image by cross-reference ID

**New types** (`src/core/types/api/`)
- `ImageLinkType` — minimal image reference (`UID`, `Available`)
- `ImageSlimType` — lightweight image metadata with `PrimaryUID` and linked UIDs
- `ImageCrossReferenceType` — cross-reference with source, ordering, preferred/desired flags
- `ImageTabType` — UI tab types (`Posters | Backdrops | Logos`)

**UUID-based URLs**
- All image components now use `/api/v3/Image/${UID}` instead of deprecated path-based URLs
- `BackgroundImagePlaceholderDiv` prop narrowed to `ImageLinkType`

**SeriesImages.tsx rewrite**
- Row-based virtualized grid with `@tanstack/react-virtual`
- Responsive column layout via `useMeasure`
- Tab navigation (Posters / Backdrops / Logos)
- Image info sidebar with set-as-preferred action
- Preferred image badge overlay
- Scroll container uses shared `scrollRef` from `SeriesContextType`

**Cleanup**
- Removed deprecated `useSeriesImagesQuery` and `useChangeSeriesImageMutation`
- Removed `Banners`/`Discs` from UI tabs (not applicable to series images)

**Utility**
- Added `pxPerRem` to `@/core/util` — reads root font size from the document for rem-based layout calculations