### PR TITLE
refactor: migrate to automatic JSX transform, remove explicit React imports

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -896,6 +896,7 @@
       }
     ],
     "react/only-export-components": "error",
+    "react/react-in-jsx-scope": "off",
     "react/rules-of-hooks": "error",
     "react/self-closing-comp": [
       "error",

--- a/src/components/BackgroundImagePlaceholderDiv.tsx
+++ b/src/components/BackgroundImagePlaceholderDiv.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
+import type { ReactNode } from 'react';
 import { mdiInformationOutline, mdiLoading, mdiOpenInNew } from '@mdi/js';
 import { Icon } from '@mdi/react';
 import cx from 'classnames';
@@ -8,7 +9,7 @@ import { useSettingsQuery } from '@/core/react-query/settings/queries';
 import type { ImageLinkType } from '@/core/types/api/common';
 
 type Props = {
-  children?: React.ReactNode;
+  children?: ReactNode;
   className?: string;
   contain?: boolean;
   image?: ImageLinkType;

--- a/src/components/Badge.tsx
+++ b/src/components/Badge.tsx
@@ -1,8 +1,8 @@
-import React from 'react';
+import type { ReactNode } from 'react';
 import cx from 'classnames';
 
 type Props = {
-  children: React.ReactNode;
+  children: ReactNode;
   className?: string;
 };
 

--- a/src/components/CharacterImage.tsx
+++ b/src/components/CharacterImage.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { mdiAccountTieOutline } from '@mdi/js';
 import { Icon } from '@mdi/react';
 import cx from 'classnames';

--- a/src/components/Collection/CleanDescription.tsx
+++ b/src/components/Collection/CleanDescription.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import { useMemo } from 'react';
 import cx from 'classnames';
 import { trim } from 'lodash';
 

--- a/src/components/Collection/CollectionTitle.tsx
+++ b/src/components/Collection/CollectionTitle.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Link, useParams } from 'react-router';
 import { mdiChevronRight } from '@mdi/js';
 import { Icon } from '@mdi/react';

--- a/src/components/Collection/CollectionView.tsx
+++ b/src/components/Collection/CollectionView.tsx
@@ -1,4 +1,5 @@
-import React, { useMemo } from 'react';
+import { useMemo } from 'react';
+import type { ReactNode, RefObject } from 'react';
 import { useOutletContext } from 'react-router';
 import useMeasure from 'react-use-measure';
 import { mdiLoading } from '@mdi/js';
@@ -49,7 +50,7 @@ const CollectionView = (props: Props) => {
     ];
   }, [isSidebarOpen, mode, isSeries]);
 
-  const { scrollRef } = useOutletContext<{ scrollRef: React.RefObject<HTMLDivElement> }>();
+  const { scrollRef } = useOutletContext<{ scrollRef: RefObject<HTMLDivElement> }>();
 
   const [gridContainerRef, gridContainerBounds] = useMeasure();
 
@@ -103,7 +104,7 @@ const CollectionView = (props: Props) => {
       <div className="relative w-full" style={{ height: virtualizer.getTotalSize() }} ref={gridContainerRef}>
         {/* Each row is considered a virtual item here instead of each group */}
         {virtualItems.map((virtualRow) => {
-          const children: React.ReactNode[] = [];
+          const children: ReactNode[] = [];
 
           // index of the first group in the current row
           // eg., row 2 (index = 1) at 1080p (itemsPerRow = 8)

--- a/src/components/Collection/Credits/CreditsSearchAndFilterPanel.tsx
+++ b/src/components/Collection/Credits/CreditsSearchAndFilterPanel.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import type { ChangeEvent } from 'react';
 import { mdiInformationOutline, mdiMagnify, mdiPlayCircleOutline } from '@mdi/js';
 import Icon from '@mdi/react';
 
@@ -9,9 +9,9 @@ import ShokoPanel from '@/components/Panels/ShokoPanel';
 type Props = {
   inputPlaceholder: string;
   search: string;
-  handleSearchChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  handleSearchChange: (event: ChangeEvent<HTMLInputElement>) => void;
   roleFilter: Set<string>;
-  handleFilterChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  handleFilterChange: (event: ChangeEvent<HTMLInputElement>) => void;
   uniqueRoles: string[];
   refreshAniDbAction: () => void;
   aniDbRefreshing: boolean;

--- a/src/components/Collection/Credits/CreditsStaffPanel.tsx
+++ b/src/components/Collection/Credits/CreditsStaffPanel.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import CharacterImage from '@/components/CharacterImage';
 
 import type { SeriesCast } from '@/core/types/api/series';

--- a/src/components/Collection/Credits/CreditsStaffVirtualizer.tsx
+++ b/src/components/Collection/Credits/CreditsStaffVirtualizer.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect, useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
+import type { RefObject } from 'react';
 import { useOutletContext } from 'react-router';
 import useMeasure from 'react-use-measure';
 import { useVirtualizer } from '@tanstack/react-virtual';
@@ -9,7 +10,7 @@ import type { SeriesCast } from '@/core/types/api/series';
 import type { CreditsModeType } from '@/pages/collection/series/SeriesCredits';
 
 const StaffPanelVirtualizer = ({ castArray, mode }: { castArray: SeriesCast[], mode: CreditsModeType }) => {
-  const { scrollRef } = useOutletContext<{ scrollRef: React.RefObject<HTMLDivElement> }>();
+  const { scrollRef } = useOutletContext<{ scrollRef: RefObject<HTMLDivElement> }>();
   const [containerRef, { width: containerWidth }] = useMeasure();
   const cardSize = useMemo(() => ({ x: 450, y: 174, gap: 24 }), []);
 

--- a/src/components/Collection/DisplaySettingsModal.tsx
+++ b/src/components/Collection/DisplaySettingsModal.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
+import type { ChangeEvent } from 'react';
 import { produce } from 'immer';
 
 import Button from '@/components/Input/Button';
@@ -32,7 +33,7 @@ const DisplaySettingsModal = ({ onClose, show }: Props) => {
     poster: posterSettings,
   } = newSettings.WebUI_Settings.collection;
 
-  const handleSettingChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+  const handleSettingChange = (event: ChangeEvent<HTMLInputElement>) => {
     const [type, key] = event.target.id.split('-') as [type: 'poster' | 'list' | 'image', key: string];
     const tempSettings = produce(newSettings, (draftState) => {
       draftState.WebUI_Settings.collection[type][key] = event.target.checked;

--- a/src/components/Collection/Episode/EpisodeDetails.tsx
+++ b/src/components/Collection/Episode/EpisodeDetails.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { mdiCalendarMonthOutline, mdiClipboardOutline, mdiClockOutline, mdiOpenInNew, mdiStarHalfFull } from '@mdi/js';
 import { Icon } from '@mdi/react';
 import { toNumber } from 'lodash';

--- a/src/components/Collection/Episode/EpisodeFiles.tsx
+++ b/src/components/Collection/Episode/EpisodeFiles.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 import { Menu, MenuButton, MenuItems } from '@headlessui/react';
 import {
   mdiClipboardOutline,

--- a/src/components/Collection/Episode/EpisodeSearchAndFilterPanel.tsx
+++ b/src/components/Collection/Episode/EpisodeSearchAndFilterPanel.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import type { ChangeEvent } from 'react';
 import { mdiInformationOutline, mdiMagnify } from '@mdi/js';
 import Icon from '@mdi/react';
 
@@ -15,7 +15,7 @@ type Props = {
   unaired: string;
   hasUnaired: boolean;
   hasMissing: boolean;
-  onFilterChange: (event: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => void;
+  onFilterChange: (event: ChangeEvent<HTMLInputElement | HTMLSelectElement>) => void;
 };
 
 const EpisodeSearchAndFilterPanel = (props: Props) => {

--- a/src/components/Collection/Episode/EpisodeSummary.tsx
+++ b/src/components/Collection/Episode/EpisodeSummary.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import AnimateHeight from 'react-animate-height';
 import { useOutletContext } from 'react-router';
 import {

--- a/src/components/Collection/Episode/EpisodeWatchModal.tsx
+++ b/src/components/Collection/Episode/EpisodeWatchModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import cx from 'classnames';
 import { map } from 'lodash';
 

--- a/src/components/Collection/Files/FilesMissingEpisodes.tsx
+++ b/src/components/Collection/Files/FilesMissingEpisodes.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { mdiOpenInNew } from '@mdi/js';
 import { Icon } from '@mdi/react';
 import cx from 'classnames';

--- a/src/components/Collection/Files/FilesOverview.tsx
+++ b/src/components/Collection/Files/FilesOverview.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import { Fragment, useMemo } from 'react';
 import prettyBytes from 'pretty-bytes';
 
 import ShokoPanel from '@/components/Panels/ShokoPanel';
@@ -30,10 +30,10 @@ const FileTypeSummary = ({ sources, type }: FileTypeSummaryProps) => {
       <span className="font-normal">
         {sourceMap.map((source, index) => (
           // oxlint-disable-next-line react/no-array-index-key -- will not change between renders
-          <React.Fragment key={index}>
+          <Fragment key={index}>
             {source}
             <br />
-          </React.Fragment>
+          </Fragment>
         ))}
       </span>
     </div>

--- a/src/components/Collection/Files/FilesSummaryGroup.tsx
+++ b/src/components/Collection/Files/FilesSummaryGroup.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import { useMemo } from 'react';
 import { forEach, map, omit } from 'lodash';
 import prettyBytes from 'pretty-bytes';
 

--- a/src/components/Collection/Filter/AddCriteriaModal.tsx
+++ b/src/components/Collection/Filter/AddCriteriaModal.tsx
@@ -1,4 +1,5 @@
-import React, { useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
+import type { ChangeEvent } from 'react';
 import { filter, map } from 'lodash';
 
 import Button from '@/components/Input/Button';
@@ -36,7 +37,7 @@ const AddCriteriaModal = ({ onClose, show }: Props) => {
     handleClose();
   };
 
-  const changeCriteria = (event: React.ChangeEvent<HTMLSelectElement>) => setNewCriteria(event.currentTarget.value);
+  const changeCriteria = (event: ChangeEvent<HTMLSelectElement>) => setNewCriteria(event.currentTarget.value);
 
   return (
     <ModalPanel show={show} onRequestClose={onClose} header="Add Condition" size="sm">

--- a/src/components/Collection/Filter/Criteria.tsx
+++ b/src/components/Collection/Filter/Criteria.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
+import type { ReactNode } from 'react';
 import { mdiCircleEditOutline, mdiMinusCircleOutline } from '@mdi/js';
 import { Icon } from '@mdi/react';
 
@@ -14,7 +15,7 @@ type ModalType = 'tag' | 'multivalue';
 type Props = {
   criteria: FilterExpression;
   parameterExists: boolean;
-  transformedParameter: React.ReactNode;
+  transformedParameter: ReactNode;
   type: ModalType;
 };
 

--- a/src/components/Collection/Filter/DefaultCriteria.tsx
+++ b/src/components/Collection/Filter/DefaultCriteria.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
+import type { ChangeEvent } from 'react';
 import { mdiMinusCircleOutline } from '@mdi/js';
 import { Icon } from '@mdi/react';
 
@@ -37,7 +38,7 @@ const DefaultCriteria = ({ criteria }: Props) => {
     }
   }, [criteria.Expression, dispatch, selectedCondition]);
 
-  const changeValue = (event: React.ChangeEvent<HTMLSelectElement>) => {
+  const changeValue = (event: ChangeEvent<HTMLSelectElement>) => {
     dispatch(addFilterCondition({ [criteria.Expression]: event.currentTarget.value === '1' }));
   };
 

--- a/src/components/Collection/Filter/FilterSidebar.tsx
+++ b/src/components/Collection/Filter/FilterSidebar.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
+import type { MouseEventHandler } from 'react';
 import { useParams } from 'react-router';
 import { mdiContentSaveOutline, mdiFilterPlusOutline } from '@mdi/js';
 import { keys, map } from 'lodash';
@@ -38,7 +39,7 @@ const OptionButton = (
     buttonType?: ButtonType;
     disabled?: boolean;
     icon: string;
-    onClick: React.MouseEventHandler<HTMLDivElement>;
+    onClick: MouseEventHandler<HTMLButtonElement>;
     tooltip?: string;
   },
 ) => (

--- a/src/components/Collection/Filter/MultiValueCriteria.tsx
+++ b/src/components/Collection/Filter/MultiValueCriteria.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import Criteria from '@/components/Collection/Filter/Criteria';
 import { selectFilterValues } from '@/core/slices/collection';
 import { useSelector } from '@/core/store';

--- a/src/components/Collection/Filter/MultiValueCriteriaModal.tsx
+++ b/src/components/Collection/Filter/MultiValueCriteriaModal.tsx
@@ -1,4 +1,5 @@
-import React, { useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
+import type { ChangeEvent } from 'react';
 import { filter, map, pull } from 'lodash';
 
 import Button from '@/components/Input/Button';
@@ -37,7 +38,7 @@ const MultiValueCriteriaModal = ({ criteria, onClose, removeCriteria, show }: Pr
   );
   const filterMatch = useSelector(state => selectFilterMatch(state, criteria.Expression));
 
-  const handleMatchChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
+  const handleMatchChange = (event: ChangeEvent<HTMLSelectElement>) => {
     dispatch(setFilterMatch({ [criteria.Expression]: event.target.value as 'Or' | 'And' }));
   };
 

--- a/src/components/Collection/Filter/SavePresetModal.tsx
+++ b/src/components/Collection/Filter/SavePresetModal.tsx
@@ -1,4 +1,4 @@
-import React, { useLayoutEffect, useState } from 'react';
+import { useLayoutEffect, useState } from 'react';
 import { toNumber } from 'lodash';
 
 import Button from '@/components/Input/Button';

--- a/src/components/Collection/Filter/TagCriteria.tsx
+++ b/src/components/Collection/Filter/TagCriteria.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import { useMemo } from 'react';
 import { forEach } from 'lodash';
 
 import Criteria from '@/components/Collection/Filter/Criteria';

--- a/src/components/Collection/Filter/TagCriteriaModal.tsx
+++ b/src/components/Collection/Filter/TagCriteriaModal.tsx
@@ -1,4 +1,5 @@
-import React, { useMemo, useRef, useState } from 'react';
+import { useMemo, useRef, useState } from 'react';
+import type { ChangeEvent } from 'react';
 import { mdiChevronRight, mdiMagnify, mdiMinusCircleOutline, mdiTagOffOutline, mdiTagOutline } from '@mdi/js';
 import { Icon } from '@mdi/react';
 import { useVirtualizer } from '@tanstack/react-virtual';
@@ -164,7 +165,7 @@ const TagCriteriaModal = ({ criteria, onClose, removeCriteria, show }: Props) =>
           type="text"
           placeholder="Search..."
           value={search}
-          onChange={(event: React.ChangeEvent<HTMLInputElement>) => setSearch(event.target.value)}
+          onChange={(event: ChangeEvent<HTMLInputElement>) => setSearch(event.target.value)}
         />
         <TagList unusedValues={unusedValues} selectTag={selectTag} />
       </div>

--- a/src/components/Collection/Group/EditGroupModal.tsx
+++ b/src/components/Collection/Group/EditGroupModal.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import cx from 'classnames';
 import { map } from 'lodash';
 

--- a/src/components/Collection/Group/EditGroupTabs/Action.tsx
+++ b/src/components/Collection/Group/EditGroupTabs/Action.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import cx from 'classnames';
 
 const Action = (

--- a/src/components/Collection/Group/EditGroupTabs/FileActionsTab.tsx
+++ b/src/components/Collection/Group/EditGroupTabs/FileActionsTab.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import Action from '@/components/Collection/Group/EditGroupTabs/Action';
 import { useRelocateGroupFilesMutation } from '@/core/react-query/group/mutations';
 

--- a/src/components/Collection/Group/EditGroupTabs/NameTab.tsx
+++ b/src/components/Collection/Group/EditGroupTabs/NameTab.tsx
@@ -1,4 +1,5 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import type { ChangeEvent } from 'react';
 import { mdiCheckUnderlineCircleOutline, mdiCloseCircleOutline, mdiPencilCircleOutline } from '@mdi/js';
 import cx from 'classnames';
 import { useToggle } from 'usehooks-ts';
@@ -49,7 +50,7 @@ const NameTab = ({ groupId }: Props) => {
     toggleNameEditable();
   }, [groupData?.Name, groupId, groupName, renameGroupMutation, toggleNameEditable]);
 
-  const updateName = (event: React.ChangeEvent<HTMLInputElement>) => {
+  const updateName = (event: ChangeEvent<HTMLInputElement>) => {
     setGroupName(event.target.value);
   };
 

--- a/src/components/Collection/Group/EditGroupTabs/SeriesTab.tsx
+++ b/src/components/Collection/Group/EditGroupTabs/SeriesTab.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import { useMemo } from 'react';
 import type { PlacesType } from 'react-tooltip';
 import { mdiArrowRightThinCircleOutline, mdiLoading, mdiStarCircleOutline } from '@mdi/js';
 import Icon from '@mdi/react';

--- a/src/components/Collection/ListViewItem.tsx
+++ b/src/components/Collection/ListViewItem.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import { useMemo } from 'react';
 import { Link } from 'react-router';
 import {
   mdiAlertCircleOutline,

--- a/src/components/Collection/PosterViewItem.tsx
+++ b/src/components/Collection/PosterViewItem.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Link } from 'react-router';
 import { mdiCheckboxMarkedCircleOutline, mdiFileDocumentRemoveOutline, mdiPencilCircleOutline } from '@mdi/js';
 import { Icon } from '@mdi/react';

--- a/src/components/Collection/Series/EditSeriesModal.tsx
+++ b/src/components/Collection/Series/EditSeriesModal.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import cx from 'classnames';
 import { map } from 'lodash';
 

--- a/src/components/Collection/Series/EditSeriesTabs/Action.tsx
+++ b/src/components/Collection/Series/EditSeriesTabs/Action.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import cx from 'classnames';
 
 const Action = (

--- a/src/components/Collection/Series/EditSeriesTabs/DeleteActionsTab.tsx
+++ b/src/components/Collection/Series/EditSeriesTabs/DeleteActionsTab.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 
 import Action from '@/components/Collection/Series/EditSeriesTabs/Action';
 import ConfirmationPromptModal from '@/components/Dialogs/ConfirmationPromptModal';

--- a/src/components/Collection/Series/EditSeriesTabs/FileActionsTab.tsx
+++ b/src/components/Collection/Series/EditSeriesTabs/FileActionsTab.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import Action from '@/components/Collection/Series/EditSeriesTabs/Action';
 import {
   useRehashSeriesFilesMutation,

--- a/src/components/Collection/Series/EditSeriesTabs/GroupTab.tsx
+++ b/src/components/Collection/Series/EditSeriesTabs/GroupTab.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
+import type { ChangeEvent, MouseEventHandler } from 'react';
 import {
   mdiArrowRightThinCircleOutline,
   mdiCheckUnderlineCircleOutline,
@@ -32,7 +33,7 @@ type Props = {
 type EndIcon = {
   icon: string;
   className?: string;
-  onClick?: React.MouseEventHandler<HTMLDivElement>;
+  onClick?: MouseEventHandler<HTMLDivElement>;
   tooltip?: string;
 };
 
@@ -90,7 +91,7 @@ const EditableNameComponent = (
       },
     ];
 
-  const updateInput = (event: React.ChangeEvent<HTMLInputElement>) => {
+  const updateInput = (event: ChangeEvent<HTMLInputElement>) => {
     setModifiableName(event.target.value);
   };
 
@@ -148,7 +149,7 @@ const GroupTab = ({ seriesId }: Props) => {
   const [search, setSearch] = useState('');
   const [debouncedSearch] = useDebounceValue(search, 200);
 
-  const updateSearch = (event: React.ChangeEvent<HTMLInputElement>) => setSearch(event.target.value);
+  const updateSearch = (event: ChangeEvent<HTMLInputElement>) => setSearch(event.target.value);
 
   const { data: seriesGroup, isFetching } = useSeriesGroupQuery(seriesId, false);
   const groupsQuery = useFilteredGroupsInfiniteQuery({

--- a/src/components/Collection/Series/EditSeriesTabs/NameTab.tsx
+++ b/src/components/Collection/Series/EditSeriesTabs/NameTab.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { mdiCheckUnderlineCircleOutline, mdiCloseCircleOutline, mdiPencilCircleOutline } from '@mdi/js';
 import cx from 'classnames';
 import { useToggle } from 'usehooks-ts';

--- a/src/components/Collection/Series/EditSeriesTabs/UpdateActionsTab.tsx
+++ b/src/components/Collection/Series/EditSeriesTabs/UpdateActionsTab.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import Action from '@/components/Collection/Series/EditSeriesTabs/Action';
 import {
   useAutoSearchTmdbMatchMutation,

--- a/src/components/Collection/Series/SeriesRating.tsx
+++ b/src/components/Collection/Series/SeriesRating.tsx
@@ -1,4 +1,5 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
+import type { MouseEvent } from 'react';
 import { mdiStar, mdiStarOutline } from '@mdi/js';
 import { Icon } from '@mdi/react';
 import { toNumber } from 'lodash';
@@ -13,8 +14,8 @@ type Props = {
 type StarIconProps = {
   hovered: boolean;
   index: string;
-  handleHover: (event: React.MouseEvent<HTMLDivElement>) => void;
-  handleVote: (event: React.MouseEvent<HTMLDivElement>) => void;
+  handleHover: (event: MouseEvent<HTMLDivElement>) => void;
+  handleVote: (event: MouseEvent<HTMLDivElement>) => void;
 };
 
 const StarIcon = ({ handleHover, handleVote, hovered, index }: StarIconProps) => (
@@ -33,7 +34,7 @@ const SeriesRating = ({ ratingValue, seriesId }: Props) => {
 
   const [hoveredStar, setHoveredStar] = useState(ratingValue - 1);
 
-  const handleVote = (event: React.MouseEvent<HTMLDivElement>) => {
+  const handleVote = (event: MouseEvent<HTMLDivElement>) => {
     voteSeries(toNumber(event.currentTarget.id) + 1);
   };
 
@@ -41,7 +42,7 @@ const SeriesRating = ({ ratingValue, seriesId }: Props) => {
     setHoveredStar(ratingValue - 1);
   };
 
-  const handleHover = (event: React.MouseEvent<HTMLDivElement>) => {
+  const handleHover = (event: MouseEvent<HTMLDivElement>) => {
     setHoveredStar(toNumber(event.currentTarget.id));
   };
 

--- a/src/components/Collection/SeriesInfo.tsx
+++ b/src/components/Collection/SeriesInfo.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import { useMemo } from 'react';
 import { useParams } from 'react-router';
 import cx from 'classnames';
 import { toNumber } from 'lodash';

--- a/src/components/Collection/SeriesMetadata.tsx
+++ b/src/components/Collection/SeriesMetadata.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import { useMemo } from 'react';
 import { mdiCloseCircleOutline, mdiOpenInNew, mdiPencilCircleOutline, mdiPlusCircleOutline } from '@mdi/js';
 import { Icon } from '@mdi/react';
 

--- a/src/components/Collection/SeriesTopPanel.tsx
+++ b/src/components/Collection/SeriesTopPanel.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useParams } from 'react-router';
 import { mdiTagPlusOutline } from '@mdi/js';
 import Icon from '@mdi/react';

--- a/src/components/Collection/SeriesUserStats.tsx
+++ b/src/components/Collection/SeriesUserStats.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Link } from 'react-router';
 
 import SeriesRating from '@/components/Collection/Series/SeriesRating';

--- a/src/components/Collection/TagButton.tsx
+++ b/src/components/Collection/TagButton.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { mdiTagTextOutline } from '@mdi/js';
 import { Icon } from '@mdi/react';
 import cx from 'classnames';

--- a/src/components/Collection/Tags/TagDetailsModal.tsx
+++ b/src/components/Collection/Tags/TagDetailsModal.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useRef } from 'react';
+import { useMemo, useRef } from 'react';
 import { Link } from 'react-router';
 import { mdiLoading, mdiOpenInNew } from '@mdi/js';
 import Icon from '@mdi/react';

--- a/src/components/Collection/Tags/TagsSearchAndFilterPanel.tsx
+++ b/src/components/Collection/Tags/TagsSearchAndFilterPanel.tsx
@@ -1,4 +1,5 @@
-import React, { useCallback, useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
+import type { ChangeEvent } from 'react';
 import { mdiMagnify, mdiPlayCircleOutline } from '@mdi/js';
 import Icon from '@mdi/react';
 
@@ -14,7 +15,7 @@ type Props = {
   tagSourceFilter: Set<string>;
   showSpoilers: boolean;
   seriesId: number;
-  handleInputChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  handleInputChange: (event: ChangeEvent<HTMLInputElement>) => void;
   toggleSort: () => void;
   sort: boolean;
 };

--- a/src/components/Collection/TimelineSidebar.tsx
+++ b/src/components/Collection/TimelineSidebar.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Link } from 'react-router';
 
 import BackgroundImagePlaceholderDiv from '@/components/BackgroundImagePlaceholderDiv';

--- a/src/components/Collection/TitleOptions.tsx
+++ b/src/components/Collection/TitleOptions.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import type { ChangeEvent, MouseEventHandler } from 'react';
 import {
   mdiCogOutline,
   mdiFilterMenuOutline,
@@ -25,7 +25,7 @@ type Props = {
   item: CollectionGroupType | SeriesType;
   mode: string;
   seriesSearch: string;
-  setSearch: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  setSearch: (event: ChangeEvent<HTMLInputElement>) => void;
   toggleFilterSidebar: () => void;
   toggleMode: () => void;
 };
@@ -33,7 +33,7 @@ type Props = {
 const OptionButton = (
   { icon, onClick, tooltip }: {
     icon: string;
-    onClick: React.MouseEventHandler<HTMLDivElement>;
+    onClick: MouseEventHandler<HTMLButtonElement>;
     tooltip?: string;
   },
 ) => (

--- a/src/components/Collection/Tmdb/AniDBEpisode.tsx
+++ b/src/components/Collection/Tmdb/AniDBEpisode.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { mdiMinus, mdiPlus } from '@mdi/js';
 import { Icon } from '@mdi/react';
 import cx from 'classnames';

--- a/src/components/Collection/Tmdb/EpisodeRow.tsx
+++ b/src/components/Collection/Tmdb/EpisodeRow.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import { useMemo } from 'react';
 import { useSearchParams } from 'react-router';
 import { mdiLoading } from '@mdi/js';
 import { Icon } from '@mdi/react';

--- a/src/components/Collection/Tmdb/EpisodeSelect.tsx
+++ b/src/components/Collection/Tmdb/EpisodeSelect.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useSearchParams } from 'react-router';
 import { Listbox, ListboxButton, ListboxOption, ListboxOptions, Transition } from '@headlessui/react';
 import { mdiChevronDown, mdiLoading, mdiMagnify } from '@mdi/js';

--- a/src/components/Collection/Tmdb/MatchRating.tsx
+++ b/src/components/Collection/Tmdb/MatchRating.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import cx from 'classnames';
 
 import { MatchRatingType } from '@/core/types/api/episode';

--- a/src/components/Collection/Tmdb/MovieRow.tsx
+++ b/src/components/Collection/Tmdb/MovieRow.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import { useMemo } from 'react';
 import { useSearchParams } from 'react-router';
 import { mdiLinkOff, mdiLinkPlus, mdiLoading } from '@mdi/js';
 import { Icon } from '@mdi/react';

--- a/src/components/Collection/Tmdb/TmdbLinkSelectPanel.tsx
+++ b/src/components/Collection/Tmdb/TmdbLinkSelectPanel.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useParams, useSearchParams } from 'react-router';
 import { mdiFilmstrip, mdiLoading, mdiMagnify, mdiOpenInNew, mdiTelevision } from '@mdi/js';
 import { Icon } from '@mdi/react';

--- a/src/components/Collection/Tmdb/TopPanel.tsx
+++ b/src/components/Collection/Tmdb/TopPanel.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import { useMemo } from 'react';
 import { mdiLinkPlus } from '@mdi/js';
 import { Icon } from '@mdi/react';
 import cx from 'classnames';

--- a/src/components/Collection/constants.ts
+++ b/src/components/Collection/constants.ts
@@ -1,4 +1,4 @@
-import type React from 'react';
+import type { RefObject } from 'react';
 
 import type { ImageLinkType } from '@/core/types/api/common';
 import type { SeriesType } from '@/core/types/api/series';
@@ -18,6 +18,6 @@ export const listItemSize = {
 
 export type SeriesContextType = {
   backdrop?: ImageLinkType;
-  scrollRef: React.RefObject<HTMLDivElement>;
+  scrollRef: RefObject<HTMLDivElement>;
   series: SeriesType;
 };

--- a/src/components/Dashboard/DashboardEpisode.tsx
+++ b/src/components/Dashboard/DashboardEpisode.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Link } from 'react-router';
 
 import BackgroundImagePlaceholderDiv from '@/components/BackgroundImagePlaceholderDiv';

--- a/src/components/Dashboard/DashboardSettingsModal.tsx
+++ b/src/components/Dashboard/DashboardSettingsModal.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
+import type { ChangeEvent } from 'react';
 import cx from 'classnames';
 import { produce } from 'immer';
 import { toNumber } from 'lodash';
@@ -90,7 +91,7 @@ const DashboardSettingsModal = ({ onClose, show }: Props) => {
     onClose();
   };
 
-  const handleUpdate = (event: React.ChangeEvent<HTMLInputElement>) => {
+  const handleUpdate = (event: ChangeEvent<HTMLInputElement>) => {
     updateSetting(
       event.target.id,
       event.target.type === 'checkbox' ? event.target.checked : Math.min(toNumber(event.target.value), 100),

--- a/src/components/Dashboard/ServerUpdateModal.tsx
+++ b/src/components/Dashboard/ServerUpdateModal.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import UpdateModal from '@/components/Dashboard/UpdateModal';
 import { useVersionQuery } from '@/core/react-query/init/queries';
 import { useSettingsQuery } from '@/core/react-query/settings/queries';

--- a/src/components/Dashboard/UpdateModal.tsx
+++ b/src/components/Dashboard/UpdateModal.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { mdiDownloadCircleOutline } from '@mdi/js';
 import { Icon } from '@mdi/react';
 

--- a/src/components/Dashboard/WebUIUpdateModal.tsx
+++ b/src/components/Dashboard/WebUIUpdateModal.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import UpdateModal from '@/components/Dashboard/UpdateModal';
 import Button from '@/components/Input/Button';
 import { useSettingsQuery } from '@/core/react-query/settings/queries';

--- a/src/components/Dialogs/ActionsModal.tsx
+++ b/src/components/Dialogs/ActionsModal.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 import cx from 'classnames';
 import { map } from 'lodash';
 

--- a/src/components/Dialogs/BrowseFolderModal.tsx
+++ b/src/components/Dialogs/BrowseFolderModal.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import Button from '@/components/Input/Button';
 import ModalPanel from '@/components/Panels/ModalPanel';
 import TreeView from '@/components/TreeView/TreeView';

--- a/src/components/Dialogs/ConfirmationPromptModal.tsx
+++ b/src/components/Dialogs/ConfirmationPromptModal.tsx
@@ -1,4 +1,5 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
+import type { ReactNode } from 'react';
 import { useHotkeys } from 'react-hotkeys-hook';
 
 import Button from '@/components/Input/Button';
@@ -8,7 +9,7 @@ import useToggleModalKeybinds from '@/hooks/useToggleModalKeybinds';
 import type { ButtonType } from '@/components/Input/Button.utils';
 
 type Props = {
-  children: React.ReactNode;
+  children: ReactNode;
   onConfirm: () => void | Promise<void>;
   onClose: () => void;
   show: boolean;

--- a/src/components/Dialogs/CustomTagModal.tsx
+++ b/src/components/Dialogs/CustomTagModal.tsx
@@ -1,4 +1,5 @@
-import React, { useCallback, useLayoutEffect, useMemo, useState } from 'react';
+import { useCallback, useLayoutEffect, useMemo, useState } from 'react';
+import type { ChangeEvent, MouseEvent } from 'react';
 import { mdiPencilCircleOutline, mdiPlusCircleOutline } from '@mdi/js';
 import Icon from '@mdi/react';
 import cx from 'classnames';
@@ -51,17 +52,17 @@ const CustomTagModal = ({ onClose, seriesId, show }: Props) => {
   if (mode === 'edit') subHeader = 'Edit Tags';
   if (mode === 'create') subHeader = 'Create Tag';
 
-  const handleTagNameChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+  const handleTagNameChange = (event: ChangeEvent<HTMLInputElement>) => {
     if (lockedControls) return;
     setTagName(event.target.value);
   };
 
-  const handleTagDescChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+  const handleTagDescChange = (event: ChangeEvent<HTMLInputElement>) => {
     if (lockedControls) return;
     setTagDescription(event.target.value);
   };
 
-  const handleTagClick = (event: React.MouseEvent<HTMLElement>) => {
+  const handleTagClick = (event: MouseEvent<HTMLDivElement>) => {
     if (lockedTag) return;
 
     const selectedTagId1 = parseInt(event.currentTarget.dataset.tagId ?? '0', 10);

--- a/src/components/Dialogs/DeleteFilesModal.tsx
+++ b/src/components/Dialogs/DeleteFilesModal.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
 import { mdiMinusCircleOutline } from '@mdi/js';
 import Icon from '@mdi/react';
 

--- a/src/components/Dialogs/FilterPresetsModal.tsx
+++ b/src/components/Dialogs/FilterPresetsModal.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { Link, useParams } from 'react-router';
 import { mdiLoading, mdiMagnify, mdiMinusCircleOutline } from '@mdi/js';
 import { Icon } from '@mdi/react';
@@ -163,7 +163,7 @@ const SidePanel = (
             startIcon={mdiMagnify}
             id="search"
             value={search}
-            onChange={(event: React.ChangeEvent<HTMLInputElement>) => setSearch(event.target.value)}
+            onChange={event => setSearch(event.target.value)}
             inputClassName="px-4 py-3"
           />
           <div className="flex grow overflow-y-auto rounded-lg border border-panel-border bg-panel-input p-4">

--- a/src/components/Dialogs/HashTypesModal.tsx
+++ b/src/components/Dialogs/HashTypesModal.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
+import type { ChangeEvent } from 'react';
 import { useHotkeys } from 'react-hotkeys-hook';
 import { useImmer } from 'use-immer';
 
@@ -33,7 +34,7 @@ const HashTypesModal = ({ onClose, provider, show }: HashTypesModalProps) => {
     });
   };
 
-  const handleToggle = (event: React.ChangeEvent<HTMLInputElement>) => {
+  const handleToggle = (event: ChangeEvent<HTMLInputElement>) => {
     const { checked, id } = event.target;
     if (checked) {
       setEnabledHashTypes(Array.from(new Set([...enabledHashTypes, id])));

--- a/src/components/Dialogs/LanguagesModal.tsx
+++ b/src/components/Dialogs/LanguagesModal.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
+import type { ChangeEvent } from 'react';
 import { mdiLoading } from '@mdi/js';
 import { Icon } from '@mdi/react';
 import { keys, map, remove } from 'lodash';
@@ -60,7 +61,7 @@ const LanguagesModal = ({ onClose, type }: Props) => {
     if (type !== null) setLanguages(LanguagePreference);
   }, [type, LanguagePreference]);
 
-  const handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+  const handleInputChange = (event: ChangeEvent<HTMLInputElement>) => {
     const { checked: value, id } = event.target;
 
     const newLanguages = languages.slice();

--- a/src/components/Dialogs/ManagedFolderModal.tsx
+++ b/src/components/Dialogs/ManagedFolderModal.tsx
@@ -1,4 +1,5 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
+import type { ChangeEvent } from 'react';
 import { mdiFolderOpen } from '@mdi/js';
 import { find } from 'lodash';
 
@@ -58,7 +59,7 @@ const ManagedFolderModal = () => {
     }
   };
 
-  const handleInputChange = (event: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
+  const handleInputChange = (event: ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
     const name = event.target.id;
     const value = name === 'WatchForNewFiles' ? event.target.value === '1' : event.target.value;
     setManagedFolder({ ...managedFolder, [name]: value });

--- a/src/components/Dialogs/ProviderInfoModal.tsx
+++ b/src/components/Dialogs/ProviderInfoModal.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { useHotkeys } from 'react-hotkeys-hook';
 
 import ModalPanel from '@/components/Panels/ModalPanel';

--- a/src/components/Dialogs/ReleaseManagementSettingsModal.tsx
+++ b/src/components/Dialogs/ReleaseManagementSettingsModal.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useHotkeys } from 'react-hotkeys-hook';
 import { produce } from 'immer';
 

--- a/src/components/Dialogs/TmdbShowSettingsModal.tsx
+++ b/src/components/Dialogs/TmdbShowSettingsModal.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { mdiLoading } from '@mdi/js';
 import { Icon } from '@mdi/react';
 import cx from 'classnames';

--- a/src/components/DnDList/DnDList.tsx
+++ b/src/components/DnDList/DnDList.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import type { ReactNode } from 'react';
 import { DragDropContext, Draggable, Droppable } from '@hello-pangea/dnd';
 
 import PortalAwareItem from './PortalAwareItem';
@@ -7,7 +7,7 @@ import type { DraggableProvided, DraggableStateSnapshot, DropResult, DroppablePr
 
 type Props = {
   onDragEnd: (result: DropResult) => void;
-  children: { key: string, item: React.ReactNode }[];
+  children: { key: string, item: ReactNode }[];
 };
 
 const DnDList = (props: Props) => {

--- a/src/components/DnDList/PortalAwareItem.tsx
+++ b/src/components/DnDList/PortalAwareItem.tsx
@@ -1,5 +1,4 @@
-import React from 'react';
-import type { JSX } from 'react';
+import type { ReactNode } from 'react';
 import ReactDOM from 'react-dom';
 
 import type { DraggableProvided, DraggableStateSnapshot } from '@hello-pangea/dnd';
@@ -10,7 +9,7 @@ document.body.appendChild(portal);
 type Props = {
   provided: DraggableProvided;
   snapshot: DraggableStateSnapshot;
-  children: React.ReactNode;
+  children: ReactNode;
 };
 
 const PortalAwareItem = (props: Props) => {
@@ -18,7 +17,7 @@ const PortalAwareItem = (props: Props) => {
 
   const usePortal: boolean = snapshot.isDragging;
 
-  const child: JSX.Element = (
+  const child: ReactNode = (
     <div
       ref={provided.innerRef}
       {...(provided.draggableProps)}

--- a/src/components/Dynamic/CodeEditor.tsx
+++ b/src/components/Dynamic/CodeEditor.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Editor } from '@monaco-editor/react';
 
 // To import custom monaco config

--- a/src/components/Dynamic/DynamicField.tsx
+++ b/src/components/Dynamic/DynamicField.tsx
@@ -1,4 +1,4 @@
-import React, { Suspense, lazy } from 'react';
+import { Suspense, lazy } from 'react';
 import { mdiLoading } from '@mdi/js';
 import { Icon } from '@mdi/react';
 

--- a/src/components/Dynamic/DynamicForm.tsx
+++ b/src/components/Dynamic/DynamicForm.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { mdiLoading } from '@mdi/js';
 import { Icon } from '@mdi/react';
 

--- a/src/components/Dynamic/DynamicSection.tsx
+++ b/src/components/Dynamic/DynamicSection.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import DynamicField from '@/components/Dynamic/DynamicField';
 
 import type { FormSchemaType } from '@/core/types/api/configuration';

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { useRouteError } from 'react-router';
 
 import ShokoMascot from '@/../images/shoko_mascot.png';

--- a/src/components/FileInfo.tsx
+++ b/src/components/FileInfo.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import type { MouseEvent } from 'react';
 import { mdiClipboardOutline } from '@mdi/js';
 import Icon from '@mdi/react';
 import prettyBytes from 'pretty-bytes';
@@ -13,7 +13,7 @@ const FileInfo = ({ compact, file }: { compact?: boolean, file: FileType }) => {
   const mediaInfo = useMediaInfo(file);
 
   const hash = getEd2kLink(file);
-  const handleCopy = (event: React.MouseEvent) => {
+  const handleCopy = (event: MouseEvent<HTMLDivElement>) => {
     event.stopPropagation();
     copyToClipboard(hash, 'ED2K hash').catch(console.error);
   };

--- a/src/components/Input/Button.tsx
+++ b/src/components/Input/Button.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import type { MouseEventHandler, ReactNode } from 'react';
 import type { PlacesType } from 'react-tooltip';
 import { mdiLoading } from '@mdi/js';
 import { Icon } from '@mdi/react';
@@ -13,11 +13,11 @@ type Props = {
   buttonType?: ButtonType;
   buttonSize?: SizeType;
   className?: string;
-  children: React.ReactNode;
+  children: ReactNode;
   disabled?: boolean;
   loading?: boolean;
   loadingSize?: number;
-  onClick?: React.MouseEventHandler<HTMLButtonElement>;
+  onClick?: MouseEventHandler<HTMLButtonElement>;
   submit?: boolean;
   tooltip?: string;
   tooltipPlace?: PlacesType;

--- a/src/components/Input/Checkbox.tsx
+++ b/src/components/Input/Checkbox.tsx
@@ -1,4 +1,5 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
+import type { ChangeEventHandler, ReactNode } from 'react';
 import { mdiCheckboxBlankCircleOutline, mdiCheckboxMarkedCircleOutline } from '@mdi/js';
 import { Icon } from '@mdi/react';
 import cx from 'classnames';
@@ -9,7 +10,7 @@ import useBodyVisibleContext from '@/hooks/useBodyVisibleContext';
 
 type Props = {
   id: string;
-  label?: React.ReactNode;
+  label?: ReactNode;
   labelClassName?: string;
   isChecked: boolean;
   disabled?: boolean;
@@ -17,7 +18,7 @@ type Props = {
   className?: string;
   labelRight?: boolean;
   justify?: boolean;
-  onChange: React.ChangeEventHandler<HTMLInputElement>;
+  onChange: ChangeEventHandler<HTMLInputElement>;
 };
 
 const Checkbox = (props: Props) => {

--- a/src/components/Input/DropdownButton.tsx
+++ b/src/components/Input/DropdownButton.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
+import type { ReactNode } from 'react';
 import useMeasure from 'react-use-measure';
 import { mdiChevronDown, mdiLoading } from '@mdi/js';
 import Icon from '@mdi/react';
@@ -7,8 +8,8 @@ import cx from 'classnames';
 type Props = {
   buttonType?: 'primary' | 'secondary' | 'danger';
   className?: string;
-  children: React.ReactNode;
-  content: React.ReactNode | string;
+  children: ReactNode;
+  content: ReactNode;
   disabled?: boolean;
   loading?: boolean;
   loadingSize?: number;

--- a/src/components/Input/DropdownMenuItem.tsx
+++ b/src/components/Input/DropdownMenuItem.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { MenuItem } from '@headlessui/react';
 import { mdiLoading } from '@mdi/js';
 import { Icon } from '@mdi/react';

--- a/src/components/Input/IconButton.tsx
+++ b/src/components/Input/IconButton.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import type { MouseEventHandler } from 'react';
 import { Icon } from '@mdi/react';
 import cx from 'classnames';
 
@@ -11,7 +11,7 @@ type IconButtonProps = {
   icon: string;
   className?: string;
   disabled?: boolean;
-  onClick: React.MouseEventHandler<HTMLDivElement | HTMLButtonElement>;
+  onClick: MouseEventHandler<HTMLButtonElement>;
   buttonType: ButtonType;
   buttonSize: SizeType;
   tooltip?: string;

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import type { ChangeEventHandler, HTMLInputTypeAttribute, KeyboardEventHandler, MouseEventHandler } from 'react';
 import type { PlacesType } from 'react-tooltip';
 import { Icon } from '@mdi/react';
 import cx from 'classnames';
@@ -9,19 +9,19 @@ import useBodyVisibleContext from '@/hooks/useBodyVisibleContext';
 type EndIcon = {
   icon: string;
   className?: string;
-  onClick?: React.MouseEventHandler<HTMLDivElement>;
+  onClick?: MouseEventHandler<HTMLDivElement>;
   tooltip?: string;
 };
 
 type Props = {
   id: string;
   label?: string;
-  type: React.HTMLInputTypeAttribute;
+  type: HTMLInputTypeAttribute;
   placeholder?: string;
   value: string | number;
-  onChange: React.ChangeEventHandler<HTMLInputElement>;
-  onKeyUp?: React.KeyboardEventHandler<HTMLInputElement>;
-  onKeyDown?: React.KeyboardEventHandler<HTMLInputElement>;
+  onChange: ChangeEventHandler<HTMLInputElement>;
+  onKeyUp?: KeyboardEventHandler<HTMLInputElement>;
+  onKeyDown?: KeyboardEventHandler<HTMLInputElement>;
   className?: string;
   inputClassName?: string;
   autoFocus?: boolean;

--- a/src/components/Input/InputSmall.tsx
+++ b/src/components/Input/InputSmall.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import type { ChangeEvent, ChangeEventHandler, KeyboardEventHandler, ReactNode } from 'react';
 
 import toast from '@/core/toast';
 
@@ -7,13 +7,13 @@ type Props = {
   type: string;
   placeholder?: string;
   value: string | number;
-  onChange: React.ChangeEventHandler<HTMLInputElement>;
-  onKeyUp?: React.KeyboardEventHandler<HTMLInputElement>;
+  onChange: ChangeEventHandler<HTMLInputElement>;
+  onKeyUp?: KeyboardEventHandler<HTMLInputElement>;
   className?: string;
   autoFocus?: boolean;
   disabled?: boolean;
   autoComplete?: string;
-  suffixes?: React.ReactNode;
+  suffixes?: ReactNode;
   min?: number;
   max?: number;
 };
@@ -35,7 +35,7 @@ const InputSmall = (props: Props) => {
     value,
   } = props;
 
-  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+  const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
     if (type === 'number' && max && event.target.valueAsNumber > max) {
       toast.info(`Value cannot be greater than ${max}!`);
 

--- a/src/components/Input/MultiStateButton.tsx
+++ b/src/components/Input/MultiStateButton.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import cx from 'classnames';
 
 import Button from './Button';

--- a/src/components/Input/Select.tsx
+++ b/src/components/Input/Select.tsx
@@ -1,15 +1,15 @@
-import React from 'react';
+import type { ChangeEventHandler, ReactNode } from 'react';
 import { mdiChevronDown } from '@mdi/js';
 import { Icon } from '@mdi/react';
 
 type Props = {
   id: string;
   value: string | number;
-  onChange: React.ChangeEventHandler<HTMLSelectElement>;
+  onChange: ChangeEventHandler<HTMLSelectElement>;
   className?: string;
-  children: React.ReactNode;
+  children: ReactNode;
   label?: string;
-  options?: React.ReactNode;
+  options?: ReactNode;
   disabled?: boolean;
 };
 

--- a/src/components/Input/SelectEpisodeList.tsx
+++ b/src/components/Input/SelectEpisodeList.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect, useState } from 'react';
+import { Fragment, useEffect, useState } from 'react';
+import type { ChangeEvent, KeyboardEvent } from 'react';
 import { Listbox, ListboxButton, ListboxOption, ListboxOptions, Transition } from '@headlessui/react';
 import { mdiChevronDown, mdiChevronUp, mdiMagnify } from '@mdi/js';
 import { Icon } from '@mdi/react';
@@ -79,10 +80,10 @@ const SelectEpisodeList = ({ disabled = false, onChange, options, rowIdx, value 
     setSelected(find(options, ['value', value]) ?? {} as Option);
   }, [value, options]);
 
-  const handleEpFilter = (event: React.ChangeEvent<HTMLInputElement>) => setEpFilter(event.target.value);
+  const handleEpFilter = (event: ChangeEvent<HTMLInputElement>) => setEpFilter(event.target.value);
 
   // Headless UI throws errors if keypresses bubble sepcifically space is treated as select item and causes errors if list is filtered to empty
-  const suppressKeydown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+  const suppressKeydown = (event: KeyboardEvent<HTMLInputElement>) => {
     event.stopPropagation();
   };
 
@@ -135,7 +136,7 @@ const SelectEpisodeList = ({ disabled = false, onChange, options, rowIdx, value 
               {/* 4rem below is to account for height of the input component */}
               <div className="mt-1 h-[calc(var(--anchor-max-height)-4rem)] overflow-y-auto rounded-lg border border-panel-border bg-panel-input p-4">
                 {options.map((item, idx) => (
-                  <React.Fragment key={`listbox-item-${item.value}`}>
+                  <Fragment key={`listbox-item-${item.value}`}>
                     {idx !== 0 && item.type !== options[idx - 1].type && (
                       <div className="my-3 h-0.5 border border-panel-border bg-panel-background-alt" />
                     )}
@@ -143,7 +144,7 @@ const SelectEpisodeList = ({ disabled = false, onChange, options, rowIdx, value 
                       || (toInteger(epFilter) > 0
                         ? item.number === toInteger(epFilter)
                         : item.label.toLowerCase().includes(epFilter.toLowerCase()))) && <SelectOption option={item} />}
-                  </React.Fragment>
+                  </Fragment>
                 ))}
               </div>
             </ListboxOptions>

--- a/src/components/Input/SelectSmall.tsx
+++ b/src/components/Input/SelectSmall.tsx
@@ -1,13 +1,13 @@
-import React from 'react';
+import type { ChangeEventHandler, ReactNode } from 'react';
 import { mdiChevronDown, mdiLoading } from '@mdi/js';
 import { Icon } from '@mdi/react';
 
 type Props = {
   id: string;
   value: string | number;
-  onChange: React.ChangeEventHandler<HTMLSelectElement>;
+  onChange: ChangeEventHandler<HTMLSelectElement>;
   className?: string;
-  children: React.ReactNode;
+  children: ReactNode;
   label?: string;
   isFetching?: boolean;
 };

--- a/src/components/Layout/AniDBBanDetectionItem.tsx
+++ b/src/components/Layout/AniDBBanDetectionItem.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { mdiInformationOutline, mdiOpenInNew } from '@mdi/js';
 import Icon from '@mdi/react';
 

--- a/src/components/Layout/ExternalLinkMenuItem.tsx
+++ b/src/components/Layout/ExternalLinkMenuItem.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Icon } from '@mdi/react';
 
 type ExternalLinkMenuItemProps = {

--- a/src/components/Layout/LinkMenuItem.tsx
+++ b/src/components/Layout/LinkMenuItem.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { NavLink } from 'react-router';
 import { Icon } from '@mdi/react';
 import cx from 'classnames';

--- a/src/components/Layout/MenuItem.tsx
+++ b/src/components/Layout/MenuItem.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Icon } from '@mdi/react';
 import cx from 'classnames';
 

--- a/src/components/Layout/TopNav.tsx
+++ b/src/components/Layout/TopNav.tsx
@@ -1,4 +1,5 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
+import type { MouseEvent } from 'react';
 import AnimateHeight from 'react-animate-height';
 import { Link, NavLink, useLocation } from 'react-router';
 import {
@@ -104,7 +105,7 @@ const TopNav = () => {
   const isOffline = !(networkStatus === NetworkAvailabilityEnum.Internet
     || networkStatus === NetworkAvailabilityEnum.PartialInternet);
 
-  const closeModalsAndSubmenus = (event?: React.MouseEvent, id?: string) => {
+  const closeModalsAndSubmenus = (event?: MouseEvent<HTMLAnchorElement>, id?: string) => {
     if (layoutEditMode && event) {
       event.preventDefault();
       return;

--- a/src/components/Panels/ModalPanel.tsx
+++ b/src/components/Panels/ModalPanel.tsx
@@ -1,14 +1,14 @@
-import React from 'react';
+import type { ReactNode } from 'react';
 import Modal from 'react-modal';
 import cx from 'classnames';
 
 type Props = {
-  children: React.ReactNode;
+  children: ReactNode;
   fullHeight?: boolean;
   show: boolean;
-  header?: React.ReactNode;
-  footer?: React.ReactNode;
-  subHeader?: React.ReactNode;
+  header?: ReactNode;
+  footer?: ReactNode;
+  subHeader?: ReactNode;
   size: keyof typeof sizeClass;
   noPadding?: boolean;
   noGap?: boolean;

--- a/src/components/Panels/ShokoPanel.tsx
+++ b/src/components/Panels/ShokoPanel.tsx
@@ -1,12 +1,12 @@
-import React, { type ReactNode } from 'react';
+import type { ReactNode } from 'react';
 import { mdiLoading } from '@mdi/js';
 import { Icon } from '@mdi/react';
 import cx from 'classnames';
 
 type Props = {
   title: ReactNode;
-  children: React.ReactNode;
-  options?: React.ReactNode;
+  children: ReactNode;
+  options?: ReactNode;
   className?: string;
   isFetching?: boolean;
   editMode?: boolean;

--- a/src/components/SeriesPoster.tsx
+++ b/src/components/SeriesPoster.tsx
@@ -1,4 +1,5 @@
-import React, { useMemo } from 'react';
+import { useMemo } from 'react';
+import type { MouseEvent, ReactNode } from 'react';
 import { Link } from 'react-router';
 import { mdiLoading, mdiPlusCircleOutline } from '@mdi/js';
 import { Icon } from '@mdi/react';
@@ -14,7 +15,7 @@ import { getAnidbAnimeLink, getAnidbEpisodeLink } from '@/core/util';
 import type { ImageType } from '@/core/types/api/common';
 
 type Props = {
-  children?: React.ReactNode;
+  children?: ReactNode;
   title: string;
   subtitle?: string;
   image?: ImageType;
@@ -45,7 +46,7 @@ const SeriesPoster = (props: Props) => {
 
   const { isPending: isCreatePending, mutate: refreshSeries } = useRefreshAniDBSeriesMutation();
 
-  const createSeries = (anidbId: number, event: React.MouseEvent<HTMLButtonElement>) => {
+  const createSeries = (anidbId: number, event: MouseEvent<HTMLButtonElement>) => {
     event.stopPropagation();
     event.preventDefault();
 

--- a/src/components/Settings/AddUserModal.tsx
+++ b/src/components/Settings/AddUserModal.tsx
@@ -1,4 +1,5 @@
-import React, { useLayoutEffect, useState } from 'react';
+import { useLayoutEffect, useState } from 'react';
+import type { ChangeEvent, KeyboardEvent } from 'react';
 import { useToggle } from 'usehooks-ts';
 
 import Button from '@/components/Input/Button';
@@ -17,7 +18,7 @@ export type AddUserModalProps = {
   onClose: () => void;
 };
 
-const AddUserModal = (props: AddUserModalProps): React.JSX.Element => {
+const AddUserModal = (props: AddUserModalProps) => {
   const { onClose, show, userId } = props;
   const dispatch = useDispatch();
   const currentUserQuery = useCurrentUserQuery();
@@ -37,11 +38,11 @@ const AddUserModal = (props: AddUserModalProps): React.JSX.Element => {
     onClose();
   };
 
-  const handleUsernameInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+  const handleUsernameInputChange = (event: ChangeEvent<HTMLInputElement>) => {
     setUsername(event.target.value);
   };
 
-  const handlePasswordInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+  const handlePasswordInputChange = (event: ChangeEvent<HTMLInputElement>) => {
     if (event.target.id === 'confirm-password') setPassword2(event.target.value);
     else setPassword1(event.target.value);
   };
@@ -80,7 +81,7 @@ const AddUserModal = (props: AddUserModalProps): React.JSX.Element => {
     }
   };
 
-  const handleKeyUp = (event: React.KeyboardEvent<HTMLInputElement>) => {
+  const handleKeyUp = (event: KeyboardEvent<HTMLInputElement>) => {
     if (event.key === 'Enter') handleSave();
   };
 

--- a/src/components/Settings/AvatarEditorModal.tsx
+++ b/src/components/Settings/AvatarEditorModal.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import AvatarEditor, { useAvatarEditor } from 'react-avatar-editor';
 import { mdiImageMinusOutline, mdiImagePlusOutline } from '@mdi/js';
 import { Icon } from '@mdi/react';

--- a/src/components/Settings/HashingAndReleaseSettings/ReleaseManagementSettings.tsx
+++ b/src/components/Settings/HashingAndReleaseSettings/ReleaseManagementSettings.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { mdiDragHorizontalVariant } from '@mdi/js';
 import { Icon } from '@mdi/react';
 

--- a/src/components/Settings/HashingAndReleaseSettings/ReleaseSettings.tsx
+++ b/src/components/Settings/HashingAndReleaseSettings/ReleaseSettings.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import type { ChangeEvent } from 'react';
 import { mdiInformationVariantCircleOutline, mdiLoading } from '@mdi/js';
 import { Icon } from '@mdi/react';
 
@@ -30,7 +30,7 @@ const ReleaseSettings = () => {
     }));
   };
 
-  const handleProviderToggle = (event: React.ChangeEvent<HTMLInputElement>, type: 'server' | 'webui') => {
+  const handleProviderToggle = (event: ChangeEvent<HTMLInputElement>, type: 'server' | 'webui') => {
     const id = event.target.id.replace(`-${type}`, '');
     const { checked } = event.target;
 

--- a/src/components/Settings/ManagedFolder.tsx
+++ b/src/components/Settings/ManagedFolder.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { Fragment } from 'react';
 import { mdiDatabaseEditOutline, mdiDatabaseSearchOutline } from '@mdi/js';
 import Icon from '@mdi/react';
 import cx from 'classnames';
@@ -42,7 +42,7 @@ const ManagedFolder = (props: ManagedFolderProps) => {
   };
 
   return (
-    <React.Fragment key={folder.ID}>
+    <Fragment key={folder.ID}>
       {index !== 0 && <div className="border-b border-panel-border" />}
 
       <div className={cx('flex flex-col', className)}>
@@ -89,7 +89,7 @@ const ManagedFolder = (props: ManagedFolderProps) => {
           </div>
         </div>
       </div>
-    </React.Fragment>
+    </Fragment>
   );
 };
 

--- a/src/components/Settings/MetadataSitesSettings/PlexSettings.tsx
+++ b/src/components/Settings/MetadataSitesSettings/PlexSettings.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
+import type { ChangeEvent } from 'react';
 import AnimateHeight from 'react-animate-height';
 import { mdiLoading } from '@mdi/js';
 import { Icon } from '@mdi/react';
@@ -132,7 +133,7 @@ const PlexSettings = () => {
     else setServerId('');
   }, [plexSettings.Server]);
 
-  const handleServerChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
+  const handleServerChange = (event: ChangeEvent<HTMLSelectElement>) => {
     // Optimistic update
     setServerId(event.target.value);
 
@@ -143,7 +144,7 @@ const PlexSettings = () => {
     });
   };
 
-  const handleLibraryChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+  const handleLibraryChange = (event: ChangeEvent<HTMLInputElement>) => {
     const key = toNumber(event.target.id);
 
     const newLibraries = plexSettings.Libraries.slice();

--- a/src/components/Settings/MetadataSitesSettings/TMDBDownloadSettings.tsx
+++ b/src/components/Settings/MetadataSitesSettings/TMDBDownloadSettings.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import type { ChangeEventHandler } from 'react';
 import cx from 'classnames';
 
 import Checkbox from '@/components/Input/Checkbox';
@@ -28,7 +28,7 @@ const TMDBDownloadSettings = (props: Props) => {
     MaxAutoThumbnails,
   } = newSettings.TMDB;
 
-  const handleInputChange: React.ChangeEventHandler<HTMLInputElement> = (event) => {
+  const handleInputChange: ChangeEventHandler<HTMLInputElement> = (event) => {
     const propId = event.target.id.replace('TMDB_', '');
     const value = event.target.type === 'checkbox' ? event.target.checked : event.target.value;
     updateSetting('TMDB', propId, value);

--- a/src/components/Settings/MetadataSitesSettings/TMDBSettings.tsx
+++ b/src/components/Settings/MetadataSitesSettings/TMDBSettings.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import type { ChangeEvent, ChangeEventHandler } from 'react';
 import { produce } from 'immer';
 
 import Checkbox from '@/components/Input/Checkbox';
@@ -17,13 +17,13 @@ const TMDBSettings = (props: Props) => {
 
   const { includeRestricted } = newSettings.WebUI_Settings.collection.tmdb;
 
-  const handleInputChange: React.ChangeEventHandler<HTMLInputElement> = (event) => {
+  const handleInputChange: ChangeEventHandler<HTMLInputElement> = (event) => {
     const propId = event.target.id.replace('TMDB_', '');
     const value = event.target.type === 'checkbox' ? event.target.checked : event.target.value;
     updateSetting('TMDB', propId, value);
   };
 
-  const handleIncludeRestrictedChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+  const handleIncludeRestrictedChange = (event: ChangeEvent<HTMLInputElement>) => {
     const value = event.target.checked;
     setNewSettings(produce(newSettings, (draftState) => {
       draftState.WebUI_Settings.collection.tmdb.includeRestricted = value;

--- a/src/components/Settings/PluginManagement/Dialogs/PluginInstallModal.tsx
+++ b/src/components/Settings/PluginManagement/Dialogs/PluginInstallModal.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import Button from '@/components/Input/Button';
 import ModalPanel from '@/components/Panels/ModalPanel';
 import ShokoMarkdown from '@/components/ShokoMarkdown';

--- a/src/components/Settings/PluginManagement/Dialogs/PluginUpdateSettingsModal.tsx
+++ b/src/components/Settings/PluginManagement/Dialogs/PluginUpdateSettingsModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { produce } from 'immer';
 import { isEqual, toNumber } from 'lodash';
 

--- a/src/components/Settings/PluginManagement/Dialogs/RepositoryModal.tsx
+++ b/src/components/Settings/PluginManagement/Dialogs/RepositoryModal.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import Button from '@/components/Input/Button';
 import Input from '@/components/Input/Input';

--- a/src/components/Settings/PluginManagement/Sections/BrowseSection.tsx
+++ b/src/components/Settings/PluginManagement/Sections/BrowseSection.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import AnimateHeight from 'react-animate-height';
 import { mdiLoading } from '@mdi/js';
 import { Icon } from '@mdi/react';

--- a/src/components/Settings/PluginManagement/Sections/InstalledSection.tsx
+++ b/src/components/Settings/PluginManagement/Sections/InstalledSection.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { mdiLoading, mdiPower, mdiTrashCanOutline } from '@mdi/js';
 import { Icon } from '@mdi/react';
 import cx from 'classnames';

--- a/src/components/Settings/PluginManagement/Sections/RepositoriesSection.tsx
+++ b/src/components/Settings/PluginManagement/Sections/RepositoriesSection.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 import { mdiLoading, mdiRefresh, mdiTrashCanOutline } from '@mdi/js';
 import { Icon } from '@mdi/react';
 import { useToggle } from 'usehooks-ts';

--- a/src/components/Settings/PluginManagement/Sections/UpdatesSection.tsx
+++ b/src/components/Settings/PluginManagement/Sections/UpdatesSection.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { mdiArrowRightThin, mdiLoading } from '@mdi/js';
 import { Icon } from '@mdi/react';
 import { filter } from 'lodash';

--- a/src/components/Settings/UpdateFrequencyValues.tsx
+++ b/src/components/Settings/UpdateFrequencyValues.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 type Props = {
   min24Hours?: boolean;
 };

--- a/src/components/ShokoIcon.tsx
+++ b/src/components/ShokoIcon.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 const ShokoIcon = ({ className }: { className?: string }) => (
   <svg
     className={className}

--- a/src/components/ShokoMarkdown.tsx
+++ b/src/components/ShokoMarkdown.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { ReactNode } from 'react';
 import type { Options } from 'react-markdown';
 import Markdown from 'react-markdown';

--- a/src/components/TabPills.tsx
+++ b/src/components/TabPills.tsx
@@ -1,9 +1,9 @@
-import React from 'react';
+import type { ReactNode } from 'react';
 import cx from 'classnames';
 
 type TabType = {
   id: string;
-  name: React.ReactNode;
+  name: ReactNode;
   onClick: () => void;
   active: boolean;
 };

--- a/src/components/ToastComponent.tsx
+++ b/src/components/ToastComponent.tsx
@@ -1,11 +1,11 @@
-import React from 'react';
+import type { ReactNode } from 'react';
 import type { ToastContentProps } from 'react-toastify';
 import { mdiCloseCircleOutline } from '@mdi/js';
 import { Icon } from '@mdi/react';
 
 type Props = ToastContentProps<{
   header: string;
-  message?: React.ReactNode;
+  message?: ReactNode;
   icon: string;
 }>;
 

--- a/src/components/TransitionDiv.tsx
+++ b/src/components/TransitionDiv.tsx
@@ -1,8 +1,8 @@
-import React from 'react';
+import type { ReactNode } from 'react';
 import { Transition } from '@headlessui/react';
 
 type Props = {
-  children: React.ReactNode;
+  children: ReactNode;
   className?: string;
   enter?: string;
   enterFrom?: string;

--- a/src/components/TreeView/TreeNode.tsx
+++ b/src/components/TreeView/TreeNode.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
+import type { MouseEvent, ReactNode } from 'react';
 import { mdiCheckboxMarkedCircleOutline, mdiChevronUp, mdiLoading } from '@mdi/js';
 import { Icon } from '@mdi/react';
 import cx from 'classnames';
@@ -39,7 +40,7 @@ const TreeNode = (props: Props) => {
     }
   }, [path, foldersQuery.error, foldersQuery.isError]);
 
-  const toggleExpanded = (event: React.MouseEvent) => {
+  const toggleExpanded = (event: MouseEvent<HTMLDivElement | HTMLLIElement>) => {
     if (!isAccessible) return;
     if (!loaded) {
       setExpanded(true);
@@ -50,12 +51,12 @@ const TreeNode = (props: Props) => {
     event.stopPropagation();
   };
 
-  const toggleSelected = (event: React.MouseEvent) => {
+  const toggleSelected = (event: MouseEvent<HTMLDivElement>) => {
     dispatch(setSelectedNode({ id: nodeId, path }));
     event.stopPropagation();
   };
 
-  const children: React.ReactNode[] = [];
+  const children: ReactNode[] = [];
   const data = nodeId === 0 ? drivesQuery.data! : foldersQuery.data!;
   if (expanded) {
     forEach(data, (node: DriveType | FolderType) => {

--- a/src/components/TreeView/TreeView.tsx
+++ b/src/components/TreeView/TreeView.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import TreeNode from '@/components/TreeView/TreeNode';
 
 const TreeView = () => (

--- a/src/components/Utilities/DuplicateFiles/DuplicateFilesModal.tsx
+++ b/src/components/Utilities/DuplicateFiles/DuplicateFilesModal.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { useHotkeys } from 'react-hotkeys-hook';
 import { mdiChevronLeft, mdiChevronRight, mdiLoading } from '@mdi/js';
 import { Icon } from '@mdi/react';

--- a/src/components/Utilities/DuplicateFiles/DuplicateFilesQuickSelectModal.tsx
+++ b/src/components/Utilities/DuplicateFiles/DuplicateFilesQuickSelectModal.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect, useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
+import type { ChangeEvent } from 'react';
 import { forEach, map, toNumber } from 'lodash';
 import { useImmer } from 'use-immer';
 
@@ -50,7 +51,7 @@ const DuplicateFilesQuickSelectModal = ({ onClose, seriesId, show }: Props) => {
     setGroupsToDelete(new Set());
   }, [setGroupsToDelete, show]);
 
-  const handleCheckboxChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+  const handleCheckboxChange = (event: ChangeEvent<HTMLInputElement>) => {
     const index = toNumber(event.target.id.split('-')[1]);
     setGroupsToDelete((state) => {
       if (event.target.checked) state.add(index);

--- a/src/components/Utilities/DuplicateFiles/DuplicatesInfo.tsx
+++ b/src/components/Utilities/DuplicateFiles/DuplicatesInfo.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { mdiTrashCanOutline } from '@mdi/js';
 import Icon from '@mdi/react';
 import cx from 'classnames';

--- a/src/components/Utilities/DuplicateFiles/Title.tsx
+++ b/src/components/Utilities/DuplicateFiles/Title.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import TabTitle from '@/components/Utilities/TabTitle';
 
 const tabs = [

--- a/src/components/Utilities/FilesSummary.tsx
+++ b/src/components/Utilities/FilesSummary.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { groupBy } from 'lodash';
 import prettyBytes from 'pretty-bytes';
 

--- a/src/components/Utilities/ItemCount.tsx
+++ b/src/components/Utilities/ItemCount.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 type Props = {
   count: number;
   selected?: number;

--- a/src/components/Utilities/ReleaseManagement/MultipleReleasesPreviewModal.tsx
+++ b/src/components/Utilities/ReleaseManagement/MultipleReleasesPreviewModal.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import AnimateHeight from 'react-animate-height';
 import { useHotkeys } from 'react-hotkeys-hook';
 import { useSearchParams } from 'react-router';

--- a/src/components/Utilities/ReleaseManagement/MultipleReleasesSeriesList.tsx
+++ b/src/components/Utilities/ReleaseManagement/MultipleReleasesSeriesList.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect, useMemo, useRef } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
+import type { MouseEvent } from 'react';
 import { Link, useSearchParams } from 'react-router';
 import { mdiCheckboxBlankCircleOutline, mdiCheckboxMarkedCircleOutline, mdiLoading, mdiOpenInNew } from '@mdi/js';
 import { Icon } from '@mdi/react';
@@ -147,7 +148,7 @@ const MultipleReleasesSeriesList = ({
   const { handleRowSelect, rowSelection, selectedRows, setRowSelection } = useRowSelection(series);
 
   const lastRowIndex = useRef<number>(undefined);
-  const handleRowClick = (event: React.MouseEvent, index: number) => {
+  const handleRowClick = (event: MouseEvent<HTMLDivElement>, index: number) => {
     if (!autoDeleteMode) {
       navigate(
         `${series[index].SeriesID.toString()}?tab=candidates&includeVariations=${

--- a/src/components/Utilities/ReleaseManagement/ReleaseManagementSeriesDetail.tsx
+++ b/src/components/Utilities/ReleaseManagement/ReleaseManagementSeriesDetail.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Link, useParams, useSearchParams } from 'react-router';
 import { mdiChevronRight, mdiFlagOutline, mdiLoading, mdiOpenInNew, mdiTrashCanOutline } from '@mdi/js';
 import { Icon } from '@mdi/react';

--- a/src/components/Utilities/ReleaseManagement/SeriesDetail/CandidateCard.tsx
+++ b/src/components/Utilities/ReleaseManagement/SeriesDetail/CandidateCard.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import AnimateHeight from 'react-animate-height';
 import { mdiAlertOutline, mdiArrowRightThin, mdiChevronDown, mdiFlagOutline, mdiStar, mdiSwapVertical } from '@mdi/js';
 import { Icon } from '@mdi/react';

--- a/src/components/Utilities/ReleaseManagement/SeriesDetail/CandidateCardFileList.tsx
+++ b/src/components/Utilities/ReleaseManagement/SeriesDetail/CandidateCardFileList.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { mdiAlertOutline } from '@mdi/js';
 import { Icon } from '@mdi/react';
 import cx from 'classnames';

--- a/src/components/Utilities/ReleaseManagement/SeriesDetail/CandidateCardSignals.tsx
+++ b/src/components/Utilities/ReleaseManagement/SeriesDetail/CandidateCardSignals.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import cx from 'classnames';
 
 import type { ReleaseCandidateType } from '@/core/types/api/release-management';

--- a/src/components/Utilities/ReleaseManagement/SeriesDetail/CandidatesTab.tsx
+++ b/src/components/Utilities/ReleaseManagement/SeriesDetail/CandidatesTab.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { mdiAlertOutline } from '@mdi/js';
 import { Icon } from '@mdi/react';
 

--- a/src/components/Utilities/ReleaseManagement/SeriesDetail/ManageVariationsModal.tsx
+++ b/src/components/Utilities/ReleaseManagement/SeriesDetail/ManageVariationsModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { mdiFlagOffOutline, mdiFlagOutline, mdiLoading } from '@mdi/js';
 import { Icon } from '@mdi/react';
 import { uniqBy } from 'lodash';

--- a/src/components/Utilities/ReleaseManagement/SeriesDetail/MixAndMatchEpisode.tsx
+++ b/src/components/Utilities/ReleaseManagement/SeriesDetail/MixAndMatchEpisode.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import AnimateHeight from 'react-animate-height';
 import { mdiAlertOutline, mdiChevronDown, mdiRadioboxBlank, mdiRadioboxMarked } from '@mdi/js';
 import { Icon } from '@mdi/react';

--- a/src/components/Utilities/ReleaseManagement/SeriesDetail/MixAndMatchTab.tsx
+++ b/src/components/Utilities/ReleaseManagement/SeriesDetail/MixAndMatchTab.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { mdiAlertOutline, mdiCheckboxMarkedCircleOutline } from '@mdi/js';
 import { Icon } from '@mdi/react';
 import cx from 'classnames';

--- a/src/components/Utilities/Renamer/AddFilesModal.tsx
+++ b/src/components/Utilities/Renamer/AddFilesModal.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { mdiMagnify, mdiPlayCircleOutline } from '@mdi/js';
 import { Icon } from '@mdi/react';
 import { toNumber } from 'lodash';

--- a/src/components/Utilities/Renamer/AddFilesSeriesList.tsx
+++ b/src/components/Utilities/Renamer/AddFilesSeriesList.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useRef } from 'react';
+import { useMemo, useRef } from 'react';
 import { mdiLoading } from '@mdi/js';
 import { Icon } from '@mdi/react';
 import { useVirtualizer } from '@tanstack/react-virtual';

--- a/src/components/Utilities/Renamer/PresetModal.tsx
+++ b/src/components/Utilities/Renamer/PresetModal.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import Button from '@/components/Input/Button';
 import Input from '@/components/Input/Input';

--- a/src/components/Utilities/Renamer/RenamerEditor.tsx
+++ b/src/components/Utilities/Renamer/RenamerEditor.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Editor } from '@monaco-editor/react';
 
 // To import custom monaco config

--- a/src/components/Utilities/Renamer/RenamerScript.tsx
+++ b/src/components/Utilities/Renamer/RenamerScript.tsx
@@ -1,4 +1,4 @@
-import React, { Suspense, lazy } from 'react';
+import { Suspense, lazy } from 'react';
 import { mdiLoading } from '@mdi/js';
 import { Icon } from '@mdi/react';
 import { findKey } from 'lodash';

--- a/src/components/Utilities/SeriesWithoutFiles/AddSeriesModal.tsx
+++ b/src/components/Utilities/SeriesWithoutFiles/AddSeriesModal.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { mdiInformationOutline, mdiLoading, mdiMagnify, mdiOpenInNew } from '@mdi/js';
 import { Icon } from '@mdi/react';
 import cx from 'classnames';

--- a/src/components/Utilities/TabTitle.tsx
+++ b/src/components/Utilities/TabTitle.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { Fragment } from 'react';
 import { NavLink } from 'react-router';
 import { mdiChevronRight } from '@mdi/js';
 import { Icon } from '@mdi/react';
@@ -27,10 +27,10 @@ const TabTitle = ({ basePath, tabs, title }: Props) => (
     {title}
     <Icon path={mdiChevronRight} size={1} />
     {tabs.map((tab, index) => (
-      <React.Fragment key={tab.id}>
+      <Fragment key={tab.id}>
         <TabButton basePath={basePath} tab={tab} />
         {index < tabs.length - 1 && <div>|</div>}
-      </React.Fragment>
+      </Fragment>
     ))}
   </div>
 );

--- a/src/components/Utilities/Unrecognized/AniDbRulesModal.tsx
+++ b/src/components/Utilities/Unrecognized/AniDbRulesModal.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
+import type { ReactNode } from 'react';
 import { useHotkeys } from 'react-hotkeys-hook';
 
 import Button from '@/components/Input/Button';
@@ -16,7 +17,7 @@ type Props = {
   onClose: () => void;
   onProceed: () => void;
   show: boolean;
-  stepDescription: React.ReactNode;
+  stepDescription: ReactNode;
 };
 
 const ANIDB_RULES_DELAY_SECONDS = 10;

--- a/src/components/Utilities/Unrecognized/AvDumpFileIcon.tsx
+++ b/src/components/Utilities/Unrecognized/AvDumpFileIcon.tsx
@@ -1,4 +1,5 @@
-import React, { useMemo } from 'react';
+import { useMemo } from 'react';
+import type { MouseEvent } from 'react';
 import {
   mdiDumpTruck,
   mdiFileDocumentAlertOutline,
@@ -91,7 +92,7 @@ const AVDumpFileIcon = ({ file, truck = false }: { file: FileType, truck?: boole
     } as const;
   }, [file, dumpSession, truck]);
 
-  const handleDump = (event: React.MouseEvent) => {
+  const handleDump = (event: MouseEvent<HTMLButtonElement>) => {
     event.stopPropagation();
     if (state === 'idle' || state === 'failed') {
       avdumpFiles({ FileIDs: [fileId], Priority: true })
@@ -99,7 +100,7 @@ const AVDumpFileIcon = ({ file, truck = false }: { file: FileType, truck?: boole
     }
   };
 
-  const handleCopy = (event: React.MouseEvent) => {
+  const handleCopy = (event: MouseEvent<HTMLButtonElement>) => {
     event.stopPropagation();
     copyToClipboard(hash, 'ED2K hash').catch(console.error);
   };

--- a/src/components/Utilities/Unrecognized/AvDumpSeriesSelectModal.tsx
+++ b/src/components/Utilities/Unrecognized/AvDumpSeriesSelectModal.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect, useLayoutEffect, useMemo, useState } from 'react';
+import { useEffect, useLayoutEffect, useMemo, useState } from 'react';
+import type { ReactNode } from 'react';
 import { mdiInformationOutline, mdiLoading, mdiMagnify, mdiOpenInNew } from '@mdi/js';
 import { Icon } from '@mdi/react';
 import { countBy, some, toNumber } from 'lodash';
@@ -45,7 +46,7 @@ const Title = ({ count, step, stepCount }: { count: number, step: number, stepCo
   </div>
 );
 
-const StepDescription = ({ children }: { children: React.ReactNode }) => (
+const StepDescription = ({ children }: { children: ReactNode }) => (
   <div className="flex justify-start gap-x-2">
     <Icon className="shrink-0" path={mdiInformationOutline} size={1} />
     <div className="flex">

--- a/src/components/Utilities/Unrecognized/LinkFilesWithProvider/AutoSearchReleaseModal.tsx
+++ b/src/components/Utilities/Unrecognized/LinkFilesWithProvider/AutoSearchReleaseModal.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect, useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
+import type { ChangeEvent } from 'react';
 import { useHotkeys } from 'react-hotkeys-hook';
 import { mdiInformationVariantCircleOutline } from '@mdi/js';
 import { Icon } from '@mdi/react';
@@ -79,7 +80,7 @@ const AutoSearchReleaseModal = (props: Props) => {
     });
   };
 
-  const handleToggle = (event: React.ChangeEvent<HTMLInputElement>) => {
+  const handleToggle = (event: ChangeEvent<HTMLInputElement>) => {
     const { checked, id } = event.target;
 
     setProviders((draftState) => {

--- a/src/components/Utilities/Unrecognized/LinkFilesWithProvider/CrossReference.tsx
+++ b/src/components/Utilities/Unrecognized/LinkFilesWithProvider/CrossReference.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import type { MouseEvent } from 'react';
 
 import { useEpisodeAniDBQuery } from '@/core/react-query/episode/queries';
 import { useSeriesAniDBQuery } from '@/core/react-query/series/queries';
@@ -8,7 +8,7 @@ import { getEpisodePrefix } from '@/core/utilities/getEpisodePrefix';
 
 import type { ReleaseCrossReferenceType } from '@/core/types/api/file';
 
-const stopPropagation = (event: React.MouseEvent) => {
+const stopPropagation = (event: MouseEvent<HTMLAnchorElement>) => {
   event.stopPropagation();
 };
 

--- a/src/components/Utilities/Unrecognized/LinkFilesWithProvider/Menu.tsx
+++ b/src/components/Utilities/Unrecognized/LinkFilesWithProvider/Menu.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { mdiMagnify, mdiPencil, mdiSelectAll, mdiSelection, mdiSelectionRemove, mdiTrayPlus } from '@mdi/js';
 
 import MenuButton from '@/components/Utilities/Unrecognized/MenuButton';

--- a/src/components/Utilities/Unrecognized/LinkFilesWithProvider/ProviderName.tsx
+++ b/src/components/Utilities/Unrecognized/LinkFilesWithProvider/ProviderName.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { LinkState } from '@/core/types/utilities/unrecognized-utility';
 
 import type { ManualLinkType } from '@/core/types/utilities/unrecognized-utility';

--- a/src/components/Utilities/Unrecognized/LinkFilesWithProvider/TitleOptions.tsx
+++ b/src/components/Utilities/Unrecognized/LinkFilesWithProvider/TitleOptions.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { countBy } from 'lodash';
 
 import { LinkState } from '@/core/types/utilities/unrecognized-utility';

--- a/src/components/Utilities/Unrecognized/LinkFilesWithProvider/UnrecognizedVideo.tsx
+++ b/src/components/Utilities/Unrecognized/LinkFilesWithProvider/UnrecognizedVideo.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import type { KeyboardEvent, MouseEvent } from 'react';
 import cx from 'classnames';
 
 import { LinkState } from '@/core/types/utilities/unrecognized-utility';
@@ -11,7 +11,7 @@ import type { ManualLinkType } from '@/core/types/utilities/unrecognized-utility
 
 type Props = {
   link: ManualLinkType;
-  toggleSelect: (event: React.KeyboardEvent | React.MouseEvent) => void;
+  toggleSelect: (event: KeyboardEvent<HTMLDivElement> | MouseEvent<HTMLDivElement>) => void;
   selected: boolean;
 };
 
@@ -44,19 +44,19 @@ const UnrecognizedVideo = (props: Props) => {
     border = 'border-panel-text-primary';
   }
 
-  const handleSelect = (event: React.KeyboardEvent | React.MouseEvent) => {
+  const handleSelect = (event: KeyboardEvent<HTMLDivElement> | MouseEvent<HTMLDivElement>) => {
     if (selectionDisabledStates.includes(link.state)) return;
     toggleSelect(event);
   };
 
-  const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+  const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
     if (event.code === 'Space') {
       event.preventDefault();
       handleSelect(event);
     }
   };
 
-  const handleMouseDown = (event: React.MouseEvent) => {
+  const handleMouseDown = (event: MouseEvent<HTMLDivElement>) => {
     // Prevent native text selection on shift+click to avoid flash of selection
     // and allow clean shift-range selection behavior
     if (event.shiftKey) event.preventDefault();

--- a/src/components/Utilities/Unrecognized/LinkFilesWithProvider/VideoMetadata.tsx
+++ b/src/components/Utilities/Unrecognized/LinkFilesWithProvider/VideoMetadata.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { ReleaseSource } from '@/core/types/api/file';
 
 import type { ManualLinkType } from '@/core/types/utilities/unrecognized-utility';

--- a/src/components/Utilities/Unrecognized/MenuButton.tsx
+++ b/src/components/Utilities/Unrecognized/MenuButton.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import type { MouseEventHandler } from 'react';
 import { Icon } from '@mdi/react';
 import cx from 'classnames';
 
@@ -6,7 +6,7 @@ import Button from '@/components/Input/Button';
 
 const MenuButton = (
   { disabled, highlightType, icon, keybinding, loading, name, onClick }: {
-    onClick?: React.MouseEventHandler<HTMLButtonElement>;
+    onClick?: MouseEventHandler<HTMLButtonElement>;
     icon: string;
     name: string;
     keybinding?: string;

--- a/src/components/Utilities/Unrecognized/RangeFillModal.tsx
+++ b/src/components/Utilities/Unrecognized/RangeFillModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 
 import Button from '@/components/Input/Button';
 import InputSmall from '@/components/Input/InputSmall';

--- a/src/components/Utilities/Unrecognized/Title.tsx
+++ b/src/components/Utilities/Unrecognized/Title.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import TabTitle from '@/components/Utilities/TabTitle';
 
 const tabs = [

--- a/src/components/Utilities/UtilitiesTable.tsx
+++ b/src/components/Utilities/UtilitiesTable.tsx
@@ -1,4 +1,5 @@
-import React, { useMemo, useRef } from 'react';
+import { useMemo, useRef } from 'react';
+import type { Dispatch, MouseEvent, SetStateAction } from 'react';
 import { mdiLoading, mdiMenuUp } from '@mdi/js';
 import { Icon } from '@mdi/react';
 import { useVirtualizer } from '@tanstack/react-virtual';
@@ -22,7 +23,7 @@ type Props = {
   fetchNextPage?: () => Promise<unknown>;
   isFetchingNextPage?: boolean;
   rows: EpisodeType[] | FileType[] | SeriesType[];
-  setSortCriteria?: React.Dispatch<React.SetStateAction<FileSortCriteriaEnum>>;
+  setSortCriteria?: Dispatch<SetStateAction<FileSortCriteriaEnum>>;
   skipSort?: boolean;
   sortCriteria?: FileSortCriteriaEnum;
   handleRowSelect?: (id: number, select: boolean) => void;
@@ -37,7 +38,7 @@ const selectRowId = (target: EpisodeType | FileType | SeriesType) => ('ID' in ta
 const Row = (
   props: {
     columns: UtilityHeaderType<EpisodeType | FileType | SeriesType>[];
-    handleRowSelect: (event: React.MouseEvent, index: number) => void;
+    handleRowSelect: (event: MouseEvent<HTMLDivElement>, index: number) => void;
     row: EpisodeType | FileType | SeriesType;
     selected: boolean;
     virtualRow: VirtualItem;
@@ -51,7 +52,7 @@ const Row = (
     virtualRow,
   } = props;
 
-  const handleMouseDown = (event: React.MouseEvent) => {
+  const handleMouseDown = (event: MouseEvent<HTMLDivElement>) => {
     // Prevent native text selection on shift+click to avoid flash of selection
     // and allow clean shift-range selection behavior
     if (event.shiftKey) event.preventDefault();
@@ -89,7 +90,7 @@ const HeaderItem = (
     className: string;
     id: string;
     name: string;
-    setSortCriteria?: React.Dispatch<React.SetStateAction<FileSortCriteriaEnum>>;
+    setSortCriteria?: Dispatch<SetStateAction<FileSortCriteriaEnum>>;
     skipSort?: boolean;
     sortCriteria?: FileSortCriteriaEnum;
   },
@@ -193,7 +194,7 @@ const UtilitiesTable = (props: Props) => {
   );
 
   const lastRowIndex = useRef<number>(undefined);
-  const handleSelect = (event: React.MouseEvent, index: number) => {
+  const handleSelect = (event: MouseEvent<HTMLDivElement>, index: number) => {
     if (!rowSelection || !handleRowSelect) return;
     handleShiftSelect({ event, handleRowSelect, index, lastRowIndex, rowSelection, rows, setRowSelection });
   };

--- a/src/components/Utilities/UtilitySeriesList.tsx
+++ b/src/components/Utilities/UtilitySeriesList.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Link, useSearchParams } from 'react-router';
 import { mdiLoading, mdiOpenInNew } from '@mdi/js';
 import { Icon } from '@mdi/react';

--- a/src/components/Utilities/constants.tsx
+++ b/src/components/Utilities/constants.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import type { ReactNode } from 'react';
 import { find } from 'lodash';
 import prettyBytes from 'pretty-bytes';
 
@@ -14,7 +14,7 @@ export type UtilityHeaderType<T extends EpisodeType | FileType | SeriesType | Re
   id: string;
   name: string;
   className: string;
-  item: (_: T) => React.ReactNode;
+  item: (_: T) => ReactNode;
 };
 
 export const criteriaMap = {

--- a/src/core/app.tsx
+++ b/src/core/app.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { StrictMode } from 'react';
 import { HotkeysProvider } from 'react-hotkeys-hook';
 import { Provider } from 'react-redux';
 import * as Sentry from '@sentry/react';
@@ -10,7 +10,7 @@ import Router from '@/core/router';
 import store from '@/core/store';
 
 const App = () => (
-  <React.StrictMode>
+  <StrictMode>
     <Provider store={store}>
       <Sentry.ErrorBoundary>
         <QueryClientProvider client={queryClient}>
@@ -21,7 +21,7 @@ const App = () => (
         </QueryClientProvider>
       </Sentry.ErrorBoundary>
     </Provider>
-  </React.StrictMode>
+  </StrictMode>
 );
 
 export default App;

--- a/src/core/router/AuthenticatedRoute.tsx
+++ b/src/core/router/AuthenticatedRoute.tsx
@@ -1,11 +1,11 @@
-import React, { type JSX } from 'react';
+import type { ReactNode } from 'react';
 import { Navigate, useLocation } from 'react-router';
 
 import { useServerStatusQuery } from '@/core/react-query/init/queries';
 import { useSelector } from '@/core/store';
 
 type Props = {
-  children: JSX.Element;
+  children: ReactNode;
 };
 
 const AuthenticatedRoute = ({ children }: Props) => {

--- a/src/core/router/index.tsx
+++ b/src/core/router/index.tsx
@@ -1,5 +1,5 @@
 /* global globalThis */
-import React, { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Navigate, Route, RouterProvider, createBrowserRouter, createRoutesFromElements } from 'react-router';
 import * as Sentry from '@sentry/react';
 

--- a/src/core/util.ts
+++ b/src/core/util.ts
@@ -1,5 +1,4 @@
-import type React from 'react';
-import type { RefObject } from 'react';
+import type { KeyboardEvent, MouseEvent, RefObject } from 'react';
 import copy from 'copy-to-clipboard';
 import dayjs from 'dayjs';
 import advancedFormat from 'dayjs/plugin/advancedFormat';
@@ -115,7 +114,7 @@ const selectRowId = (target: EpisodeType | FileType | ManualLinkType | SeriesTyp
  * When shift is held, selects all rows between the last clicked row and current row.
  */
 export const handleShiftSelect = (params: {
-  event: React.KeyboardEvent | React.MouseEvent;
+  event: KeyboardEvent<HTMLDivElement> | MouseEvent<HTMLDivElement>;
   handleRowSelect: (id: number, select: boolean) => void;
   index: number;
   lastRowIndex: RefObject<number | undefined>;

--- a/src/hooks/collection/useEditGroupCallback.ts
+++ b/src/hooks/collection/useEditGroupCallback.ts
@@ -1,4 +1,4 @@
-import type React from 'react';
+import type { MouseEvent } from 'react';
 
 import { setGroupId } from '@/core/slices/modals/editGroup';
 import { useDispatch } from '@/core/store';
@@ -9,7 +9,7 @@ import type { SeriesType } from '@/core/types/api/series';
 const useEditGroupCallback = (item: CollectionGroupType | SeriesType) => {
   const dispatch = useDispatch();
 
-  return (event: React.MouseEvent) => {
+  return (event: MouseEvent<HTMLButtonElement>) => {
     event.stopPropagation();
     event.preventDefault();
     if ('MainSeries' in item.IDs) dispatch(setGroupId(item.IDs.ID));

--- a/src/hooks/collection/useEditSeriesCallback.ts
+++ b/src/hooks/collection/useEditSeriesCallback.ts
@@ -1,4 +1,4 @@
-import type React from 'react';
+import type { MouseEvent } from 'react';
 
 import { setSeriesId } from '@/core/slices/modals/editSeries';
 import { useDispatch } from '@/core/store';
@@ -9,7 +9,7 @@ import type { SeriesType } from '@/core/types/api/series';
 const useEditSeriesCallback = (item: CollectionGroupType | SeriesType) => {
   const dispatch = useDispatch();
 
-  return (event: React.MouseEvent) => {
+  return (event: MouseEvent<HTMLButtonElement>) => {
     event.stopPropagation();
     event.preventDefault();
     dispatch(setSeriesId(('MainSeries' in item.IDs) ? item.IDs.MainSeries : item.IDs.ID));

--- a/src/hooks/useAutoFocusRef.ts
+++ b/src/hooks/useAutoFocusRef.ts
@@ -1,10 +1,10 @@
-import type React from 'react';
+import type { RefObject } from 'react';
 import { useEffect, useMemo, useRef } from 'react';
 
 type TimeoutType = ReturnType<typeof globalThis.setTimeout>;
 
 const useAutoFocusRef = (autoFocus: boolean) => {
-  const elementRef = useRef<HTMLInputElement | null>(null) as React.RefObject<HTMLInputElement | null> & {
+  const elementRef = useRef<HTMLInputElement | null>(null) as RefObject<HTMLInputElement | null> & {
     timeout?: TimeoutType;
   };
   const autoFocusRef = useRef(autoFocus);
@@ -46,7 +46,7 @@ const useAutoFocusRef = (autoFocus: boolean) => {
         }
       },
       // oxlint-disable-next-line react-hooks/exhaustive-deps -- elementRef and autoFocusRef are stable refs; the proxy must be created only once
-    }), []) as unknown as React.RefObject<HTMLInputElement | null>;
+    }), []) as unknown as RefObject<HTMLInputElement | null>;
 };
 
 export default useAutoFocusRef;

--- a/src/hooks/utilities/useTableSearchSortCriteria.ts
+++ b/src/hooks/utilities/useTableSearchSortCriteria.ts
@@ -1,4 +1,4 @@
-import type React from 'react';
+import type { ChangeEvent } from 'react';
 import { useEffect, useState } from 'react';
 import { useDebounceValue } from 'usehooks-ts';
 
@@ -16,7 +16,7 @@ const useTableSearchSortCriteria = (defaultSortCriteria: FileSortCriteriaEnum) =
     else setSortCriteria(newCriteria);
   };
 
-  const updateSearch = (event: React.ChangeEvent<HTMLInputElement>) => {
+  const updateSearch = (event: ChangeEvent<HTMLInputElement>) => {
     setSearch(event.target.value);
   };
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { useEffect } from 'react';
 import { createRoot } from 'react-dom/client';
 import { createRoutesFromChildren, matchRoutes, useLocation, useNavigationType } from 'react-router';
 import * as Sentry from '@sentry/react';
@@ -20,7 +20,7 @@ if (!isDebug()) {
     ],
     integrations: [
       Sentry.reactRouterV7BrowserTracingIntegration({
-        useEffect: React.useEffect,
+        useEffect,
         useLocation,
         useNavigationType,
         createRoutesFromChildren,

--- a/src/pages/SentryErrorBoundaryWrapper.tsx
+++ b/src/pages/SentryErrorBoundaryWrapper.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { Outlet, useLocation } from 'react-router';
 import * as Sentry from '@sentry/react';
 import semver from 'semver';

--- a/src/pages/collection/Collection.tsx
+++ b/src/pages/collection/Collection.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
+import type { ChangeEvent } from 'react';
 import { useLocation, useParams, useSearchParams } from 'react-router';
 import cx from 'classnames';
 import { cloneDeep, toNumber } from 'lodash';
@@ -94,7 +95,7 @@ const Collection = () => {
   const [searchParams, setSearchParams] = useSearchParams();
   const [groupSearch, setGroupSearch] = useState(searchParams.get('q') ?? '');
   const [seriesSearch, setSeriesSearch] = useState(searchParams.get('qs') ?? '');
-  const setSearch = (event: React.ChangeEvent<HTMLInputElement>) => {
+  const setSearch = (event: ChangeEvent<HTMLInputElement>) => {
     const query = event.target.value;
 
     if (isSeries) {

--- a/src/pages/collection/Series.tsx
+++ b/src/pages/collection/Series.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
+import type { RefObject } from 'react';
 import { Link, NavLink, Outlet, useOutletContext, useParams } from 'react-router';
 import useMeasure from 'react-use-measure';
 import {
@@ -58,7 +59,7 @@ const Series = () => {
   const series = useMemo(() => seriesQuery?.data ?? {} as SeriesType, [seriesQuery.data]);
   const groupQuery = useGroupQuery(series?.IDs?.ParentGroup ?? 0, !!series?.IDs?.ParentGroup);
 
-  const { scrollRef } = useOutletContext<{ scrollRef: React.RefObject<HTMLDivElement> }>();
+  const { scrollRef } = useOutletContext<{ scrollRef: RefObject<HTMLDivElement> }>();
 
   const dispatch = useDispatch();
 

--- a/src/pages/collection/series/SeriesCredits.tsx
+++ b/src/pages/collection/series/SeriesCredits.tsx
@@ -1,4 +1,5 @@
-import React, { useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
+import type { ChangeEvent } from 'react';
 import { useOutletContext } from 'react-router';
 
 import CreditsSearchAndFilterPanel from '@/components/Collection/Credits/CreditsSearchAndFilterPanel';
@@ -46,7 +47,7 @@ const SeriesCredits = () => {
     });
   };
 
-  const handleFilterChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+  const handleFilterChange = (event: ChangeEvent<HTMLInputElement>) => {
     const { id: description } = event.target;
     setRoleFilter((prevState) => {
       const newState = new Set(prevState);
@@ -55,7 +56,7 @@ const SeriesCredits = () => {
     });
   };
 
-  const handleSearchChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+  const handleSearchChange = (event: ChangeEvent<HTMLInputElement>) => {
     setSearch(event.target.value);
   };
 

--- a/src/pages/collection/series/SeriesEpisodes.tsx
+++ b/src/pages/collection/series/SeriesEpisodes.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
+import type { ChangeEvent } from 'react';
 import { useOutletContext, useSearchParams } from 'react-router';
 import { mdiCloseCircleOutline, mdiEyeOutline, mdiLoading } from '@mdi/js';
 import { Icon } from '@mdi/react';
@@ -50,7 +51,7 @@ const SeriesEpisodes = () => {
     search: debouncedSearch,
   } as FilterOptionsType), [debouncedSearch, searchParams]);
 
-  const onFilterChange = (event: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
+  const onFilterChange = (event: ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
     const { id: eventType, value } = event.target;
 
     if (eventType === 'search') {

--- a/src/pages/collection/series/SeriesFileSummary.tsx
+++ b/src/pages/collection/series/SeriesFileSummary.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { useOutletContext } from 'react-router';
 import { mdiLoading } from '@mdi/js';
 import { Icon } from '@mdi/react';

--- a/src/pages/collection/series/SeriesImages.tsx
+++ b/src/pages/collection/series/SeriesImages.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 import { useOutletContext, useParams } from 'react-router';
 import useMeasure from 'react-use-measure';
 import { mdiLoading, mdiStarCircleOutline } from '@mdi/js';

--- a/src/pages/collection/series/SeriesOverview.tsx
+++ b/src/pages/collection/series/SeriesOverview.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 import { useOutletContext } from 'react-router';
 import { mdiEarth, mdiOpenInNew } from '@mdi/js';
 import { Icon } from '@mdi/react';

--- a/src/pages/collection/series/SeriesTags.tsx
+++ b/src/pages/collection/series/SeriesTags.tsx
@@ -1,4 +1,5 @@
-import React, { useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
+import type { ChangeEvent } from 'react';
 import { useOutletContext } from 'react-router';
 import { mdiLoading, mdiTagTextOutline } from '@mdi/js';
 import { Icon } from '@mdi/react';
@@ -56,7 +57,7 @@ const SeriesTags = () => {
   const [tagSourceFilter, setTagSourceFilter] = useState<Set<string>>(new Set());
   const [sort, toggleSort] = useToggle(false);
 
-  const handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+  const handleInputChange = (event: ChangeEvent<HTMLInputElement>) => {
     const { checked, id: eventType, value } = event.target;
     switch (eventType) {
       case 'search':

--- a/src/pages/collection/series/TmdbLinking.tsx
+++ b/src/pages/collection/series/TmdbLinking.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 import { useOutletContext, useParams, useSearchParams } from 'react-router';
 import { mdiCogOutline, mdiLoading, mdiOpenInNew, mdiPencilCircleOutline } from '@mdi/js';
 import { Icon } from '@mdi/react';

--- a/src/pages/dashboard/DashboardPage.tsx
+++ b/src/pages/dashboard/DashboardPage.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useEffectEvent, useState } from 'react';
+import { useCallback, useEffect, useEffectEvent, useState } from 'react';
 import { ResponsiveGridLayout, useContainerWidth } from 'react-grid-layout';
 import { useLocation } from 'react-router';
 import { mdiMenuDown } from '@mdi/js';

--- a/src/pages/dashboard/components/EpisodeDetails.tsx
+++ b/src/pages/dashboard/components/EpisodeDetails.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import DashboardEpisode from '@/components/Dashboard/DashboardEpisode';
 import SeriesPoster from '@/components/SeriesPoster';
 import { useSettingsQuery } from '@/core/react-query/settings/queries';
@@ -42,7 +40,7 @@ const anidbEpisodePrefixes = (type: EpisodeTypeEnum, epNumber: number): string =
   }
 };
 
-const EpisodeDetails = ({ episode, isInCollection = false, showDate = false }: Props): React.ReactNode => {
+const EpisodeDetails = ({ episode, isInCollection = false, showDate = false }: Props) => {
   const settings = useSettingsQuery().data;
 
   const { useThumbnailsForEpisodes } = settings.WebUI_Settings.dashboard;

--- a/src/pages/dashboard/components/SeriesDetails.tsx
+++ b/src/pages/dashboard/components/SeriesDetails.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { reduce } from 'lodash';
 
 import SeriesPoster from '@/components/SeriesPoster';

--- a/src/pages/dashboard/components/WelcomeModal.tsx
+++ b/src/pages/dashboard/components/WelcomeModal.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import Modal from 'react-modal';
 
 import Button from '@/components/Input/Button';

--- a/src/pages/dashboard/panels/CollectionStats.tsx
+++ b/src/pages/dashboard/panels/CollectionStats.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Link } from 'react-router';
 import prettyBytes from 'pretty-bytes';
 

--- a/src/pages/dashboard/panels/ContinueWatching.tsx
+++ b/src/pages/dashboard/panels/ContinueWatching.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { map } from 'lodash';
 
 import ShokoPanel from '@/components/Panels/ShokoPanel';

--- a/src/pages/dashboard/panels/ManagedFolders.tsx
+++ b/src/pages/dashboard/panels/ManagedFolders.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { mdiFolderPlusOutline } from '@mdi/js';
 import { Icon } from '@mdi/react';
 

--- a/src/pages/dashboard/panels/MediaType.tsx
+++ b/src/pages/dashboard/panels/MediaType.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import type { ReactNode } from 'react';
 import cx from 'classnames';
 import { forEach } from 'lodash';
 
@@ -59,7 +59,7 @@ const MediaType = () => {
 
   seriesSummaryArray.sort((summaryA, summaryB) => (summaryA[1] < summaryB[1] ? 1 : -1));
 
-  const items: React.ReactNode[] = [];
+  const items: ReactNode[] = [];
 
   forEach(seriesSummaryArray, (item) => {
     let countPercentage = 0;

--- a/src/pages/dashboard/panels/NextUp.tsx
+++ b/src/pages/dashboard/panels/NextUp.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { map } from 'lodash';
 
 import ShokoPanel from '@/components/Panels/ShokoPanel';

--- a/src/pages/dashboard/panels/QueueProcessor.tsx
+++ b/src/pages/dashboard/panels/QueueProcessor.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import { useMemo } from 'react';
 import { mdiCloseCircleOutline, mdiPauseCircleOutline, mdiPlayCircleOutline, mdiProgressClock } from '@mdi/js';
 import { Icon } from '@mdi/react';
 import { map, uniqBy } from 'lodash';

--- a/src/pages/dashboard/panels/RecentlyImported.tsx
+++ b/src/pages/dashboard/panels/RecentlyImported.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { produce } from 'immer';
 import { map } from 'lodash';
 

--- a/src/pages/dashboard/panels/RecommendedAnime.tsx
+++ b/src/pages/dashboard/panels/RecommendedAnime.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { map } from 'lodash';
 
 import ShokoPanel from '@/components/Panels/ShokoPanel';

--- a/src/pages/dashboard/panels/ShokoNews.tsx
+++ b/src/pages/dashboard/panels/ShokoNews.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { mdiOpenInNew } from '@mdi/js';
 import { Icon } from '@mdi/react';
 import cx from 'classnames';

--- a/src/pages/dashboard/panels/UnrecognizedFiles.tsx
+++ b/src/pages/dashboard/panels/UnrecognizedFiles.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import { useMemo } from 'react';
 import { NavLink } from 'react-router';
 import { mdiBeta, mdiChevronRight, mdiCreation, mdiDatabaseSearchOutline } from '@mdi/js';
 import Icon from '@mdi/react';

--- a/src/pages/dashboard/panels/UpcomingAnime.tsx
+++ b/src/pages/dashboard/panels/UpcomingAnime.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { produce } from 'immer';
 import { map } from 'lodash';
 

--- a/src/pages/firstrun/Acknowledgement.tsx
+++ b/src/pages/firstrun/Acknowledgement.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import Button from '@/components/Input/Button';
 import TransitionDiv from '@/components/TransitionDiv';
 import { useServerStatusQuery } from '@/core/react-query/init/queries';

--- a/src/pages/firstrun/AniDBAccount.tsx
+++ b/src/pages/firstrun/AniDBAccount.tsx
@@ -1,4 +1,5 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
+import type { ChangeEvent, SubmitEvent } from 'react';
 
 import Input from '@/components/Input/Input';
 import TransitionDiv from '@/components/TransitionDiv';
@@ -27,14 +28,14 @@ const AniDBAccount = () => {
 
   const { Password, Username } = newSettings.AniDb;
 
-  const handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+  const handleInputChange = (event: ChangeEvent<HTMLInputElement>) => {
     const { id, value } = event.target;
     updateSetting('AniDb', id, value);
     setAnidbStatus({ type: 'success', text: '' });
     dispatch(unsetFirstRunSaved('anidb-account'));
   };
 
-  const handleTest = (event?: React.FormEvent) => {
+  const handleTest = (event?: SubmitEvent<HTMLFormElement>) => {
     if (event) event.preventDefault();
     testAniDbLogin({ Username, Password }, {
       onSuccess: () => {

--- a/src/pages/firstrun/DataCollection.tsx
+++ b/src/pages/firstrun/DataCollection.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import TransitionDiv from '@/components/TransitionDiv';
 
 import Footer from './Footer';

--- a/src/pages/firstrun/FirstRunPage.tsx
+++ b/src/pages/firstrun/FirstRunPage.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
+import type { ReactNode } from 'react';
 import { Outlet, useLocation } from 'react-router';
 import { mdiCheckboxBlankCircleOutline, mdiCheckboxMarkedCircleOutline, mdiCircleHalfFull, mdiLoading } from '@mdi/js';
 import { Icon } from '@mdi/react';
@@ -76,7 +77,7 @@ const FirstRunPage = () => {
     await patchSettings(newSettings);
   };
 
-  let parsedVersion: React.ReactNode = <Icon path={mdiLoading} spin size={1} className="ml-2 text-panel-icon-action" />;
+  let parsedVersion: ReactNode = <Icon path={mdiLoading} spin size={1} className="ml-2 text-panel-icon-action" />;
   if (!versionQuery.isFetching && versionQuery.data) {
     parsedVersion = versionQuery.data.Server.ReleaseChannel !== 'Stable'
       ? `${versionQuery.data.Server.Version}-${versionQuery.data.Server.ReleaseChannel} (${

--- a/src/pages/firstrun/Footer.tsx
+++ b/src/pages/firstrun/Footer.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import cx from 'classnames';
 
 import Button from '@/components/Input/Button';

--- a/src/pages/firstrun/LocalAccount.tsx
+++ b/src/pages/firstrun/LocalAccount.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
+import type { SubmitEvent } from 'react';
 
 import Input from '@/components/Input/Input';
 import TransitionDiv from '@/components/TransitionDiv';
@@ -25,7 +26,7 @@ const LocalAccount = () => {
     setUser(defaultUserQuery.data ?? { Username: 'Default', Password: '' });
   }, [defaultUserQuery.data]);
 
-  const handleSave = (event?: React.FormEvent) => {
+  const handleSave = (event?: SubmitEvent) => {
     if (event) event.preventDefault();
     createUser(user, {
       onSuccess: () => {

--- a/src/pages/firstrun/ManagedFolders.tsx
+++ b/src/pages/firstrun/ManagedFolders.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { mdiMinusCircleOutline, mdiPencilCircleOutline } from '@mdi/js';
 import { Icon } from '@mdi/react';
 

--- a/src/pages/firstrun/MetadataSources.tsx
+++ b/src/pages/firstrun/MetadataSources.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { mdiChevronRight } from '@mdi/js';
 import { Icon } from '@mdi/react';
 import cx from 'classnames';

--- a/src/pages/firstrun/MetadataSourcesTabs/AniDBTab.tsx
+++ b/src/pages/firstrun/MetadataSourcesTabs/AniDBTab.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import type { ChangeEventHandler } from 'react';
 
 import Checkbox from '@/components/Input/Checkbox';
 import InputSmall from '@/components/Input/InputSmall';
@@ -33,7 +33,7 @@ const AniDBTab = ({ setStatus }: Props) => {
     MyList_StorageState,
   } = newSettings.AniDb;
 
-  const handleInputChange: React.ChangeEventHandler<HTMLInputElement | HTMLSelectElement> = (event) => {
+  const handleInputChange: ChangeEventHandler<HTMLInputElement | HTMLSelectElement> = (event) => {
     const { id } = event.target;
     const value = event.target.type === 'checkbox' && 'checked' in event.target
       ? event.target.checked

--- a/src/pages/firstrun/MetadataSourcesTabs/TMDBTab.tsx
+++ b/src/pages/firstrun/MetadataSourcesTabs/TMDBTab.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import TMDBDownloadSettings from '@/components/Settings/MetadataSitesSettings/TMDBDownloadSettings';
 import TMDBSettings from '@/components/Settings/MetadataSitesSettings/TMDBSettings';
 import TransitionDiv from '@/components/TransitionDiv';

--- a/src/pages/firstrun/StartServer.tsx
+++ b/src/pages/firstrun/StartServer.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useOutletContext } from 'react-router';
 
 import Button from '@/components/Input/Button';

--- a/src/pages/login/LoginPage.tsx
+++ b/src/pages/login/LoginPage.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
+import type { SubmitEvent } from 'react';
 import { useSearchParams } from 'react-router';
 import { Slide, ToastContainer } from 'react-toastify';
 import {
@@ -74,7 +75,7 @@ const LoginPage = () => {
     }
   }, [serverStatusQuery.data, apiSession, navigate, searchParams]);
 
-  const handleSignIn = (event: React.FormEvent) => {
+  const handleSignIn = (event: SubmitEvent) => {
     event.preventDefault();
     if (!username) return;
 

--- a/src/pages/logs/LogsPage.tsx
+++ b/src/pages/logs/LogsPage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { mdiArrowVerticalLock, mdiLoading } from '@mdi/js';
 import { Icon } from '@mdi/react';
 import { useVirtualizer } from '@tanstack/react-virtual';
@@ -12,7 +12,7 @@ const LogsPage = () => {
   const logLines = useLogsQuery().data;
   const [scrollToBottom, setScrollToBottom] = useState(true);
 
-  const parentRef = React.useRef<HTMLDivElement>(null);
+  const parentRef = useRef<HTMLDivElement>(null);
   const rowVirtualizer = useVirtualizer({
     count: logLines.length,
     getScrollElement: () => parentRef.current,

--- a/src/pages/main/MainPage.tsx
+++ b/src/pages/main/MainPage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import { Outlet } from 'react-router';
 import { Slide, ToastContainer } from 'react-toastify';
 import { Tooltip } from 'react-tooltip';

--- a/src/pages/settings/SettingsPage.tsx
+++ b/src/pages/settings/SettingsPage.tsx
@@ -1,5 +1,5 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
 /* global globalThis */
-import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { NavLink, Outlet, useLocation } from 'react-router';
 import useMeasure from 'react-use-measure';
 import { mdiLoading, mdiOpenInNew } from '@mdi/js';

--- a/src/pages/settings/plugin/PluginPageEmbed.tsx
+++ b/src/pages/settings/plugin/PluginPageEmbed.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { useParams } from 'react-router';
 import { mdiLoading } from '@mdi/js';
 import { Icon } from '@mdi/react';

--- a/src/pages/settings/tabs/AniDBSettings.tsx
+++ b/src/pages/settings/tabs/AniDBSettings.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import Button from '@/components/Input/Button';
 import Checkbox from '@/components/Input/Checkbox';
 import InputSmall from '@/components/Input/InputSmall';

--- a/src/pages/settings/tabs/ApiKeys.tsx
+++ b/src/pages/settings/tabs/ApiKeys.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
+import type { ChangeEvent } from 'react';
 import { mdiClipboardTextOutline } from '@mdi/js';
 import cx from 'classnames';
 import { map } from 'lodash';
@@ -40,7 +41,7 @@ const UserApiTokens = ({ token }: { token: AuthToken }) => {
 const ApiKeys = () => {
   const [deviceName, setDeviceName] = useState('');
 
-  const onDeviceNameChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+  const onDeviceNameChange = (event: ChangeEvent<HTMLInputElement>) => {
     setDeviceName(event.target.value);
   };
 

--- a/src/pages/settings/tabs/CollectionSettings.tsx
+++ b/src/pages/settings/tabs/CollectionSettings.tsx
@@ -1,4 +1,5 @@
-import React, { useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
+import type { ChangeEvent } from 'react';
 import { mdiLoading, mdiMinusCircleOutline, mdiPlusCircleOutline } from '@mdi/js';
 import { Icon } from '@mdi/react';
 import { keys, remove } from 'lodash';
@@ -128,7 +129,7 @@ const CollectionSettings = () => {
 
   const isExclusionKey = (id: string): id is keyof typeof exclusionMapping => id in exclusionMapping;
 
-  const handleExclusionChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+  const handleExclusionChange = (event: ChangeEvent<HTMLInputElement>) => {
     if (!(event.target.id in exclusionMapping)) return;
     const { checked, id } = event.target;
 

--- a/src/pages/settings/tabs/GeneralSettings.tsx
+++ b/src/pages/settings/tabs/GeneralSettings.tsx
@@ -1,4 +1,5 @@
-import React, { useMemo, useRef } from 'react';
+import { useMemo, useRef } from 'react';
+import type { ChangeEvent, MouseEvent } from 'react';
 import { mdiBrushOutline, mdiOpenInNew, mdiRefresh } from '@mdi/js';
 import { Icon } from '@mdi/react';
 import cx from 'classnames';
@@ -45,7 +46,7 @@ const GeneralSettings = () => {
   const themesQuery = useWebuiThemesQuery();
   const { isPending: isUploading, mutate: uploadTheme } = useWebuiUploadThemeMutation();
 
-  const onOpenFileDialog = (event: React.SyntheticEvent) => {
+  const onOpenFileDialog = (event: MouseEvent<HTMLButtonElement>) => {
     if (isUploading) {
       return;
     }
@@ -57,7 +58,7 @@ const GeneralSettings = () => {
     }
   };
 
-  const onFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+  const onFileChange = (event: ChangeEvent<HTMLInputElement>) => {
     if (isUploading) {
       return;
     }

--- a/src/pages/settings/tabs/HashingAndReleaseSettings.tsx
+++ b/src/pages/settings/tabs/HashingAndReleaseSettings.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { mdiCog, mdiInformationVariantCircleOutline, mdiLoading } from '@mdi/js';
 import Icon from '@mdi/react';
 import { produce } from 'immer';

--- a/src/pages/settings/tabs/ImportSettings.tsx
+++ b/src/pages/settings/tabs/ImportSettings.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { mdiFolderPlusOutline } from '@mdi/js';
 import Icon from '@mdi/react';
 import { produce } from 'immer';

--- a/src/pages/settings/tabs/IntegrationsSettings.tsx
+++ b/src/pages/settings/tabs/IntegrationsSettings.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import PlexSettings from '@/components/Settings/MetadataSitesSettings/PlexSettings';
 
 const IntegrationsSettings = () => (

--- a/src/pages/settings/tabs/PluginManagementSettings.tsx
+++ b/src/pages/settings/tabs/PluginManagementSettings.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { Navigate, useParams } from 'react-router';
 import { mdiCogOutline, mdiMagnify } from '@mdi/js';
 import Icon from '@mdi/react';

--- a/src/pages/settings/tabs/TmdbSettings.tsx
+++ b/src/pages/settings/tabs/TmdbSettings.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import TMDBDownloadSettings from '@/components/Settings/MetadataSitesSettings/TMDBDownloadSettings';
 import TMDBSettings from '@/components/Settings/MetadataSitesSettings/TMDBSettings';
 import useSettingsContext from '@/hooks/useSettingsContext';

--- a/src/pages/settings/tabs/UserManagementSettings.tsx
+++ b/src/pages/settings/tabs/UserManagementSettings.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
+import type { ChangeEvent } from 'react';
 import { mdiAccountPlus, mdiCircleEditOutline, mdiLoading, mdiMagnify, mdiMinusCircleOutline } from '@mdi/js';
 import { Icon } from '@mdi/react';
 import { find, isEqual, map, remove } from 'lodash';
@@ -76,7 +77,7 @@ const UserManagementSettings = () => {
     }
   }, [selectedUser, unsavedChanges]);
 
-  const handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+  const handleInputChange = (event: ChangeEvent<HTMLInputElement>) => {
     const { id } = event.target;
     const value = event.target.type === 'checkbox' ? event.target.checked : event.target.value;
 
@@ -91,7 +92,7 @@ const UserManagementSettings = () => {
     setSelectedUser(find(usersQuery.data, user => user.ID === selectedUser?.ID));
   };
 
-  const openAvatarModal = (event: React.ChangeEvent<HTMLInputElement>) => {
+  const openAvatarModal = (event: ChangeEvent<HTMLInputElement>) => {
     const avatar = event.target.files?.[0];
     // oxlint-disable-next-line no-param-reassign
     event.target.value = ''; // This is a hack (yes, another) to make the onChange trigger even when same file is selected

--- a/src/pages/unsupported/UnsupportedPage.tsx
+++ b/src/pages/unsupported/UnsupportedPage.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import ShokoMascot from '@/../images/shoko_mascot.png';
 import Button from '@/components/Input/Button';
 import Events from '@/core/events';

--- a/src/pages/utilities/DuplicateFilesTabs/DuplicateFilesLinkedTab.tsx
+++ b/src/pages/utilities/DuplicateFilesTabs/DuplicateFilesLinkedTab.tsx
@@ -1,4 +1,5 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
+import type { ChangeEvent } from 'react';
 import { useHotkeys } from 'react-hotkeys-hook';
 import { useSearchParams } from 'react-router';
 import { mdiRefresh, mdiSelectMultiple } from '@mdi/js';
@@ -33,7 +34,7 @@ const DuplicateFilesLinkedTab = () => {
 
   const onlyFinishedSeries = searchParams.get('onlyFinishedSeries') === 'true';
 
-  const handleFilterChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+  const handleFilterChange = (event: ChangeEvent<HTMLInputElement>) => {
     setSearchParams((currentParams) => {
       const newParams = new URLSearchParams(currentParams);
       newParams.set(event.target.id, String(event.target.checked));

--- a/src/pages/utilities/DuplicateFilesTabs/DuplicateFilesUnrecognizedTab.tsx
+++ b/src/pages/utilities/DuplicateFilesTabs/DuplicateFilesUnrecognizedTab.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { useHotkeys } from 'react-hotkeys-hook';
 import { mdiLoading, mdiMagnify, mdiRefresh } from '@mdi/js';
 import { Icon } from '@mdi/react';

--- a/src/pages/utilities/FileSearch.tsx
+++ b/src/pages/utilities/FileSearch.tsx
@@ -1,4 +1,5 @@
-import React, { useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
+import type { MouseEvent } from 'react';
 import { Link } from 'react-router';
 import {
   mdiChevronLeft,
@@ -177,7 +178,7 @@ const MediaInfoDetails = ({ file }: { file: FileType }) => {
   const mediaInfo = useMediaInfo(file);
   const ed2kHash = useMemo(() => getEd2kLink(file), [file]);
 
-  const copyEd2kLink = (event: React.MouseEvent) => {
+  const copyEd2kLink = (event: MouseEvent<HTMLDivElement>) => {
     event.stopPropagation();
     copyToClipboard(ed2kHash, 'ED2K Hash').catch(console.error);
   };

--- a/src/pages/utilities/MissingEpisodes.tsx
+++ b/src/pages/utilities/MissingEpisodes.tsx
@@ -1,4 +1,5 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
+import type { ChangeEvent } from 'react';
 import { useHotkeys } from 'react-hotkeys-hook';
 import { useSearchParams } from 'react-router';
 import { mdiEyeOffOutline, mdiRefresh } from '@mdi/js';
@@ -36,7 +37,7 @@ const MissingEpisodes = () => {
   const onlyCollecting = searchParams.get('onlyCollecting') === 'true';
   const onlyFinishedSeries = searchParams.get('onlyFinishedSeries') === 'true';
 
-  const handleFilterChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+  const handleFilterChange = (event: ChangeEvent<HTMLInputElement>) => {
     setSearchParams((currentParams) => {
       const newParams = new URLSearchParams(currentParams);
       newParams.set(event.target.id, String(event.target.checked));

--- a/src/pages/utilities/ReleaseManagement.tsx
+++ b/src/pages/utilities/ReleaseManagement.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
+import type { ChangeEvent } from 'react';
 import { useHotkeys } from 'react-hotkeys-hook';
 import { useSearchParams } from 'react-router';
 import {
@@ -38,7 +39,7 @@ const ReleaseManagement = () => {
     });
   }, [debouncedSearch, setSearchParams]);
 
-  const handleFilterChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+  const handleFilterChange = (event: ChangeEvent<HTMLInputElement>) => {
     setSearchParams((currentParams) => {
       const newParams = new URLSearchParams(currentParams);
       newParams.set(event.target.id, String(event.target.checked));

--- a/src/pages/utilities/Renamer.tsx
+++ b/src/pages/utilities/Renamer.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useEffectEvent, useMemo, useState } from 'react';
+import { useEffect, useEffectEvent, useMemo, useState } from 'react';
 import AnimateHeight from 'react-animate-height';
 import {
   mdiAlertCircleOutline,

--- a/src/pages/utilities/SeriesWithoutFilesUtility.tsx
+++ b/src/pages/utilities/SeriesWithoutFilesUtility.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { Link } from 'react-router';
 import {
   mdiCloseCircleOutline,

--- a/src/pages/utilities/UnrecognizedUtilityTabs/IgnoredFilesTab.tsx
+++ b/src/pages/utilities/UnrecognizedUtilityTabs/IgnoredFilesTab.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { mdiCloseCircleOutline, mdiEyeOutline, mdiLoading, mdiMagnify, mdiRefresh } from '@mdi/js';
 import { Icon } from '@mdi/react';
 import { countBy } from 'lodash';

--- a/src/pages/utilities/UnrecognizedUtilityTabs/LinkFilesTab.tsx
+++ b/src/pages/utilities/UnrecognizedUtilityTabs/LinkFilesTab.tsx
@@ -1,5 +1,6 @@
 // This is the least maintainable file in the entire codebase
-import React, { useCallback, useEffect, useEffectEvent, useMemo, useState } from 'react';
+import { useCallback, useEffect, useEffectEvent, useMemo, useState } from 'react';
+import type { ReactNode } from 'react';
 import { useLocation } from 'react-router';
 import {
   mdiLink,
@@ -156,7 +157,7 @@ const AnimeSelectPanel = (
   const searchQuery = useSeriesAniDBSearchQuery(debouncedSearch, !!debouncedSearch);
 
   const searchRows = useMemo(() => {
-    const rows: React.ReactNode[] = [];
+    const rows: ReactNode[] = [];
     if (!seriesUpdating && !searchQuery.isPending) {
       forEach(searchQuery.data, (data) => {
         rows.push(<AnimeResultRow key={data.ID} data={data} changeSelectedSeries={changeSelectedSeries} />);
@@ -606,7 +607,7 @@ const LinkFilesTab = () => {
     });
 
   const renderDynamicFileLinks = () =>
-    reduce<ManualLink, React.ReactNode[]>(orderedLinks, (result, link, idx) => {
+    reduce<ManualLink, ReactNode[]>(orderedLinks, (result, link, idx) => {
       const file = find(selectedRows, ['ID', link.FileID]);
       const path = file?.Locations?.[0]?.RelativePath ?? '<missing file path>';
       const isSameFile = idx > 0 && orderedLinks[idx - 1].FileID === link.FileID;

--- a/src/pages/utilities/UnrecognizedUtilityTabs/LinkFilesWithProvidersTab.tsx
+++ b/src/pages/utilities/UnrecognizedUtilityTabs/LinkFilesWithProvidersTab.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect, useEffectEvent, useMemo, useRef, useState } from 'react';
+import { useEffect, useEffectEvent, useMemo, useRef, useState } from 'react';
+import type { KeyboardEvent, MouseEvent } from 'react';
 import { useHotkeys } from 'react-hotkeys-hook';
 import { useLocation } from 'react-router';
 import { mdiLoading } from '@mdi/js';
@@ -149,7 +150,7 @@ const LinkFilesWithProvidersTab = () => {
   } = useRowSelection(links);
 
   const lastRowIndex = useRef<number>(undefined);
-  const handleSelect = (event: React.KeyboardEvent | React.MouseEvent, index: number) => {
+  const handleSelect = (event: KeyboardEvent<HTMLDivElement> | MouseEvent<HTMLDivElement>, index: number) => {
     handleShiftSelect({ event, handleRowSelect, index, lastRowIndex, rowSelection, rows: links, setRowSelection });
   };
 

--- a/src/pages/utilities/UnrecognizedUtilityTabs/ManuallyLinkedTab.tsx
+++ b/src/pages/utilities/UnrecognizedUtilityTabs/ManuallyLinkedTab.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { Link } from 'react-router';
 import {
   mdiCloseCircleOutline,

--- a/src/pages/utilities/UnrecognizedUtilityTabs/UnrecognizedTab.tsx
+++ b/src/pages/utilities/UnrecognizedUtilityTabs/UnrecognizedTab.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import {
   mdiBeta,
   mdiCloseCircleOutline,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
         "strict": false,
         "strictNullChecks": true,
         "module": "es2022",
-        "jsx": "react",
+        "jsx": "react-jsx",
         "target": "esnext",
         "allowJs": true,
         "checkJs": false,


### PR DESCRIPTION
React 17+ introduced the [automatic JSX transform](https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html), eliminating the need for explicit `import React from 'react'` in every file that uses JSX. The build tooling (Vite with `@vitejs/plugin-react` v6) already defaults to the automatic runtime, but the codebase still carried explicit React imports and namespace usages from the classic transform era.

## Why this matters

- **Reduced boilerplate** — ~231 files no longer need `import React from 'react'`
- **Leaner bundle** — the automatic transform imports `jsx`/`jsxs` helpers directly instead of the full `React` object, enabling smarter tree-shaking
- **Improved readability** — components focus on what they use (hooks, types, etc.) rather than importing the whole namespace
- **Ecosystem alignment** — the automatic transform has been the default since React 17 (2020) and is the expected standard

## Changes

- **`tsconfig.json`**: `"jsx": "react"` → `"jsx": "react-jsx"`
- **`.oxlintrc.json`**: disabled `react/react-in-jsx-scope` to prevent false positives
- **~240 source files**: removed all `import React from 'react'` lines, replaced `React.` namespace usages (`React.FC`, `React.ReactNode`, `React.Fragment`, etc.) with direct imports