### PR TITLE
Add series image upload

### DIFF
--- a/src/components/Collection/Series/ImageUploadModal.tsx
+++ b/src/components/Collection/Series/ImageUploadModal.tsx
@@ -1,0 +1,163 @@
+import { useEffect, useState } from 'react';
+import type { DragEvent } from 'react';
+import { mdiImagePlusOutline } from '@mdi/js';
+import { Icon } from '@mdi/react';
+import cx from 'classnames';
+import prettyBytes from 'pretty-bytes';
+
+import Button from '@/components/Input/Button';
+import { buttonSizeClasses, buttonTypeClasses } from '@/components/Input/Button.utils';
+import ModalPanel from '@/components/Panels/ModalPanel';
+import { useUploadSeriesImageMutation } from '@/core/react-query/image-management/mutations';
+import toast from '@/core/toast';
+
+import type { CrossReferenceImageType, ImageTabType } from '@/core/types/api/image';
+
+const tabLabelMap: Record<ImageTabType, { label: string, serverType: CrossReferenceImageType }> = {
+  Posters: { label: 'Poster', serverType: 'Primary' },
+  Backdrops: { label: 'Backdrop', serverType: 'Backdrop' },
+  Logos: { label: 'Logo', serverType: 'Logo' },
+};
+
+type ImageUploadModalProps = {
+  show: boolean;
+  onClose: () => void;
+  seriesId: number;
+  imageType: ImageTabType;
+};
+
+const ImageUploadModal = ({ imageType, onClose, seriesId, show }: ImageUploadModalProps) => {
+  const [file, setFile] = useState<File | null>(null);
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+  const [isDragging, setIsDragging] = useState(false);
+
+  const { label: imageLabel, serverType } = tabLabelMap[imageType];
+  const { isPending, mutate: uploadImage } = useUploadSeriesImageMutation();
+
+  const selectFile = (selectedFile?: File) => {
+    if (!selectedFile) return;
+    if (!selectedFile.type.startsWith('image/')) {
+      toast.error('Only image files are supported.');
+      return;
+    }
+    setFile(selectedFile);
+    setPreviewUrl(URL.createObjectURL(selectedFile));
+  };
+
+  useEffect(() => {
+    if (!show) {
+      setFile(null);
+      setPreviewUrl(null);
+    }
+  }, [show]);
+
+  useEffect(() => () => {
+    if (previewUrl) URL.revokeObjectURL(previewUrl);
+  }, [previewUrl]);
+
+  const handleDrop = (event: DragEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    setIsDragging(false);
+    selectFile(event.dataTransfer.files[0]);
+  };
+
+  const handleUpload = () => {
+    if (!file) return;
+    uploadImage(
+      { seriesId, imageType: serverType, file },
+      {
+        onSuccess: () => {
+          toast.success(`${imageLabel} uploaded successfully!`);
+          onClose();
+        },
+        onError: () => toast.error(`Failed to upload ${imageLabel.toLowerCase()}`),
+      },
+    );
+  };
+
+  return (
+    <ModalPanel
+      show={show}
+      onRequestClose={isPending ? undefined : onClose}
+      size="md"
+      header={`Upload ${imageLabel}`}
+      footer={
+        <div className="flex justify-end gap-x-3">
+          <Button
+            buttonType="secondary"
+            buttonSize="normal"
+            onClick={onClose}
+            disabled={isPending}
+          >
+            Cancel
+          </Button>
+          <Button
+            buttonType="primary"
+            buttonSize="normal"
+            disabled={!file || isPending}
+            loading={isPending}
+            onClick={handleUpload}
+          >
+            Upload
+          </Button>
+        </div>
+      }
+    >
+      <div
+        className={cx(
+          'flex flex-col items-center justify-center gap-y-4 rounded-lg border-2 border-dashed p-8 transition-colors',
+          isDragging
+            ? 'border-panel-text-primary bg-panel-background-overlay'
+            : 'border-panel-border',
+          file && 'border-solid border-panel-border',
+        )}
+        onDragOver={(event) => {
+          event.preventDefault();
+          setIsDragging(true);
+        }}
+        onDragLeave={() => setIsDragging(false)}
+        onDrop={handleDrop}
+      >
+        {file
+          ? (
+            <>
+              <img
+                src={previewUrl!}
+                alt="Preview"
+                className="max-h-96 max-w-full rounded-lg object-contain"
+              />
+              <div className="text-sm font-bold">
+                {file.name} — {prettyBytes(file.size)}
+              </div>
+            </>
+          )
+          : (
+            <>
+              <Icon path={mdiImagePlusOutline} size={2} className="text-panel-text-primary" />
+              <p className="text-lg font-semibold">Drag &amp; drop an image here</p>
+            </>
+          )}
+
+        <div className="font-semibold">or</div>
+
+        <label
+          className={cx(
+            'cursor-pointer rounded-lg font-semibold transition-colors hover:bg-button-primary-hover',
+            buttonTypeClasses.primary,
+            buttonSizeClasses.small,
+          )}
+        >
+          Browse
+          <input
+            type="file"
+            accept="image/*"
+            className="hidden"
+            onChange={event => selectFile(event.target.files?.[0])}
+          />
+        </label>
+      </div>
+    </ModalPanel>
+  );
+};
+
+export default ImageUploadModal;

--- a/src/components/Collection/Series/ImageUploadModal.tsx
+++ b/src/components/Collection/Series/ImageUploadModal.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import type { DragEvent } from 'react';
+import { useHotkeys } from 'react-hotkeys-hook';
 import { mdiImagePlusOutline } from '@mdi/js';
 import { Icon } from '@mdi/react';
 import cx from 'classnames';
@@ -10,6 +11,7 @@ import { buttonSizeClasses, buttonTypeClasses } from '@/components/Input/Button.
 import ModalPanel from '@/components/Panels/ModalPanel';
 import { useUploadSeriesImageMutation } from '@/core/react-query/image-management/mutations';
 import toast from '@/core/toast';
+import useToggleModalKeybinds from '@/hooks/useToggleModalKeybinds';
 
 import type { CrossReferenceImageType, ImageTabType } from '@/core/types/api/image';
 
@@ -40,6 +42,7 @@ const ImageUploadModal = ({ imageType, onClose, seriesId, show }: ImageUploadMod
       toast.error('Only image files are supported.');
       return;
     }
+    if (previewUrl) URL.revokeObjectURL(previewUrl);
     setFile(selectedFile);
     setPreviewUrl(URL.createObjectURL(selectedFile));
   };
@@ -62,7 +65,7 @@ const ImageUploadModal = ({ imageType, onClose, seriesId, show }: ImageUploadMod
   };
 
   const handleUpload = () => {
-    if (!file) return;
+    if (!file || isPending) return;
     uploadImage(
       { seriesId, imageType: serverType, file },
       {
@@ -74,6 +77,11 @@ const ImageUploadModal = ({ imageType, onClose, seriesId, show }: ImageUploadMod
       },
     );
   };
+
+  useToggleModalKeybinds(show, 'modal');
+  useToggleModalKeybinds(!show, 'primary');
+  useHotkeys('escape', onClose, { scopes: 'modal' });
+  useHotkeys('enter', handleUpload, { scopes: 'modal' });
 
   return (
     <ModalPanel

--- a/src/core/react-query/image-management/mutations.ts
+++ b/src/core/react-query/image-management/mutations.ts
@@ -22,9 +22,9 @@ export const useUnsetPreferredImageMutation = () =>
     },
   });
 
-export const useDeleteImageMutation = () =>
+export const useDeleteImageCrossReferenceMutation = () =>
   useMutation({
-    mutationFn: (imageId: string) => axios.delete(`Image/Management/${imageId}`),
+    mutationFn: (xrefId: number) => axios.delete(`Image/Management/CrossReference/${xrefId}`),
     onSuccess: () => {
       invalidateQueries(['image-management', 'cross-references']);
     },

--- a/src/core/react-query/image-management/mutations.ts
+++ b/src/core/react-query/image-management/mutations.ts
@@ -14,6 +14,22 @@ export const useSetPreferredImageMutation = () =>
     },
   });
 
+export const useUnsetPreferredImageMutation = () =>
+  useMutation({
+    mutationFn: (xrefId: number) => axios.delete(`Image/Management/CrossReference/${xrefId}/Preferred`),
+    onSuccess: () => {
+      invalidateQueries(['image-management', 'cross-references']);
+    },
+  });
+
+export const useDeleteImageMutation = () =>
+  useMutation({
+    mutationFn: (imageId: string) => axios.delete(`Image/Management/${imageId}`),
+    onSuccess: () => {
+      invalidateQueries(['image-management', 'cross-references']);
+    },
+  });
+
 /** Uploads an image file and links it to a series via a two-step flow:
  *  1. POST /Image/Management/Upload (multipart) — returns the new image's UID.
  *  2. POST /Image/Management/CrossReference/Entity/Shoko/Series/{seriesId} — creates the cross-reference.

--- a/src/core/react-query/image-management/mutations.ts
+++ b/src/core/react-query/image-management/mutations.ts
@@ -3,10 +3,41 @@ import { useMutation } from '@tanstack/react-query';
 import { axios } from '@/core/axios';
 import { invalidateQueries } from '@/core/react-query/queryClient';
 
+import type { AddImageCrossReferenceRequestType, UploadSeriesImageRequestType } from './types';
+import type { ImageSlimType } from '@/core/types/api/image';
+
 export const useSetPreferredImageMutation = () =>
   useMutation({
     mutationFn: (xrefId: number) => axios.put(`Image/Management/CrossReference/${xrefId}/Preferred`),
     onSuccess: () => {
       invalidateQueries(['image-management', 'cross-references']);
+    },
+  });
+
+/** Uploads an image file and links it to a series via a two-step flow:
+ *  1. POST /Image/Management/Upload (multipart) — returns the new image's UID.
+ *  2. POST /Image/Management/CrossReference/Entity/Shoko/Series/{seriesId} — creates the cross-reference.
+ *  Invalidates the cross-references query for the series on success. */
+export const useUploadSeriesImageMutation = () =>
+  useMutation({
+    mutationFn: async ({ file, imageType, seriesId }: UploadSeriesImageRequestType) => {
+      const formData = new FormData();
+      formData.append('file', file);
+      formData.append('userSubmitted', 'true');
+
+      const imageSlim = (await axios.post('Image/Management/Upload', formData)) as unknown as ImageSlimType;
+
+      const body: AddImageCrossReferenceRequestType = {
+        ImageID: imageSlim.UID,
+        ImageType: imageType,
+      };
+
+      return await axios.post(
+        `Image/Management/CrossReference/Entity/Shoko/Series/${seriesId}`,
+        body,
+      );
+    },
+    onSuccess: (_, { seriesId }) => {
+      invalidateQueries(['image-management', 'cross-references', seriesId]);
     },
   });

--- a/src/core/react-query/image-management/mutations.ts
+++ b/src/core/react-query/image-management/mutations.ts
@@ -3,7 +3,7 @@ import { useMutation } from '@tanstack/react-query';
 import { axios } from '@/core/axios';
 import { invalidateQueries } from '@/core/react-query/queryClient';
 
-import type { AddImageCrossReferenceRequestType, UploadSeriesImageRequestType } from './types';
+import type { UploadSeriesImageRequestType } from './types';
 import type { ImageSlimType } from '@/core/types/api/image';
 
 export const useSetPreferredImageMutation = () =>
@@ -41,17 +41,20 @@ export const useUploadSeriesImageMutation = () =>
       formData.append('file', file);
       formData.append('userSubmitted', 'true');
 
-      const imageSlim = (await axios.post('Image/Management/Upload', formData)) as unknown as ImageSlimType;
+      const imageSlim: ImageSlimType = await axios.post('Image/Management/Upload', formData);
 
-      const body: AddImageCrossReferenceRequestType = {
-        ImageID: imageSlim.UID,
-        ImageType: imageType,
-      };
-
-      return await axios.post(
-        `Image/Management/CrossReference/Entity/Shoko/Series/${seriesId}`,
-        body,
-      );
+      try {
+        return await axios.post(
+          `Image/Management/CrossReference/Entity/Shoko/Series/${seriesId}`,
+          {
+            ImageID: imageSlim.UID,
+            ImageType: imageType,
+          },
+        );
+      } catch (error) {
+        await axios.delete(`Image/Management/${imageSlim.UID}`);
+        throw error;
+      }
     },
     onSuccess: (_, { seriesId }) => {
       invalidateQueries(['image-management', 'cross-references', seriesId]);

--- a/src/core/react-query/image-management/types.ts
+++ b/src/core/react-query/image-management/types.ts
@@ -1,6 +1,19 @@
 import type { PaginationType } from '@/core/types/api';
+import type { CrossReferenceImageType } from '@/core/types/api/image';
 
 export type SeriesImageCrossReferencesRequestType = {
   imageType: string;
   isAvailable?: boolean;
 } & PaginationType;
+
+export type UploadSeriesImageRequestType = {
+  file: File;
+  imageType: CrossReferenceImageType;
+  seriesId: number;
+};
+
+export type AddImageCrossReferenceRequestType = {
+  ImageType: CrossReferenceImageType;
+  /** UUID of the uploaded image (from the Upload response). */
+  ImageID: string;
+};

--- a/src/core/types/api/common.ts
+++ b/src/core/types/api/common.ts
@@ -5,7 +5,7 @@ export type ImageLinkType = {
 };
 
 export type ImageType = ImageLinkType & {
-  Source: ImageSourceEnum;
+  Source: ImageSourceType;
   Type: ImageTypeEnum;
   ID: number;
   PrimaryUID: string;
@@ -26,11 +26,7 @@ export type EpisodeImagesType = ImagesType & {
   Thumbnails?: ImageType[];
 };
 
-export const enum ImageSourceEnum {
-  AniDB = 'AniDB',
-  TMDB = 'TMDB',
-  Shoko = 'Shoko',
-}
+export type ImageSourceType = 'AniDB' | 'TMDB' | 'Shoko' | 'User';
 
 export const enum ImageTypeEnum {
   Poster = 'Poster',

--- a/src/core/types/api/image.ts
+++ b/src/core/types/api/image.ts
@@ -31,13 +31,15 @@ export type ImageSlimType = ImageLinkType & {
   Height?: number;
 };
 
+export type CrossReferenceImageType = 'Primary' | 'Backdrop' | 'Banner' | 'Logo' | 'Disc';
+
 export type ImageCrossReferenceType = {
   /** The cross-reference ID — used for set-preferred mutations. */
   ID: number;
   ImageID: string;
   /** The primary image's UUID for the associated entity. */
   PrimaryImageID: string;
-  ImageType: 'Primary' | 'Backdrop' | 'Banner' | 'Logo' | 'Disc';
+  ImageType: CrossReferenceImageType;
   ImageSource: string;
   EntityID: string;
   EntityType: string;

--- a/src/core/types/api/image.ts
+++ b/src/core/types/api/image.ts
@@ -1,4 +1,4 @@
-import type { ImageLinkType, ImageTypeEnum, RatingType } from './common';
+import type { ImageLinkType, ImageSourceType, ImageTypeEnum, RatingType } from './common';
 
 export type RandomImageMetadataResultType = {
   Source: string;
@@ -40,7 +40,7 @@ export type ImageCrossReferenceType = {
   /** The primary image's UUID for the associated entity. */
   PrimaryImageID: string;
   ImageType: CrossReferenceImageType;
-  ImageSource: string;
+  ImageSource: ImageSourceType;
   EntityID: string;
   EntityType: string;
   EntitySource: string;

--- a/src/pages/collection/series/SeriesImages.tsx
+++ b/src/pages/collection/series/SeriesImages.tsx
@@ -15,7 +15,7 @@ import Button from '@/components/Input/Button';
 import MultiStateButton from '@/components/Input/MultiStateButton';
 import ShokoPanel from '@/components/Panels/ShokoPanel';
 import {
-  useDeleteImageMutation,
+  useDeleteImageCrossReferenceMutation,
   useSetPreferredImageMutation,
   useUnsetPreferredImageMutation,
 } from '@/core/react-query/image-management/mutations';
@@ -76,7 +76,7 @@ const SeriesImages = () => {
 
   const { mutate: setPreferred } = useSetPreferredImageMutation();
   const { mutate: unsetPreferred } = useUnsetPreferredImageMutation();
-  const { mutateAsync: deleteImage } = useDeleteImageMutation();
+  const { mutateAsync: deleteImage } = useDeleteImageCrossReferenceMutation();
   const [showUploadModal, toggleUploadModal] = useToggle(false);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
 
@@ -101,7 +101,7 @@ const SeriesImages = () => {
 
   const handleDeleteImage = async () => {
     if (!selectedImage) return;
-    await deleteImage(selectedImage.ImageID, {
+    await deleteImage(selectedImage.ID, {
       onSuccess: () => toast.success(`${imageLabel} deleted.`),
       onError: () => toast.error(`Failed to delete ${imageLabel.toLowerCase()}.`),
     });

--- a/src/pages/collection/series/SeriesImages.tsx
+++ b/src/pages/collection/series/SeriesImages.tsx
@@ -268,7 +268,11 @@ const SeriesImages = () => {
                           overlayOnHover
                         >
                           {xref.IsPreferred && (
-                            <div className="absolute top-0 right-0 rounded-bl-lg bg-panel-background-overlay p-2 text-panel-text-important opacity-100 transition-opacity group-hover:opacity-0">
+                            <div
+                              className="absolute top-0 right-0 z-10 rounded-bl-lg bg-panel-background-overlay p-2 text-panel-text-important transition-opacity"
+                              data-tooltip-id="tooltip"
+                              data-tooltip-content="Preferred"
+                            >
                               <Icon path={mdiStarCircleOutline} size={1} />
                             </div>
                           )}

--- a/src/pages/collection/series/SeriesImages.tsx
+++ b/src/pages/collection/series/SeriesImages.tsx
@@ -232,6 +232,7 @@ const SeriesImages = () => {
                           )}
                           linkToImage
                           zoomOnHover
+                          overlayOnHover
                         >
                           {xref.IsPreferred && (
                             <div className="absolute top-0 right-0 rounded-bl-lg bg-panel-background-overlay p-2 text-panel-text-important opacity-100 transition-opacity group-hover:opacity-0">

--- a/src/pages/collection/series/SeriesImages.tsx
+++ b/src/pages/collection/series/SeriesImages.tsx
@@ -10,10 +10,15 @@ import { useToggle } from 'usehooks-ts';
 
 import BackgroundImagePlaceholderDiv from '@/components/BackgroundImagePlaceholderDiv';
 import ImageUploadModal from '@/components/Collection/Series/ImageUploadModal';
+import ConfirmationPromptModal from '@/components/Dialogs/ConfirmationPromptModal';
 import Button from '@/components/Input/Button';
 import MultiStateButton from '@/components/Input/MultiStateButton';
 import ShokoPanel from '@/components/Panels/ShokoPanel';
-import { useSetPreferredImageMutation } from '@/core/react-query/image-management/mutations';
+import {
+  useDeleteImageMutation,
+  useSetPreferredImageMutation,
+  useUnsetPreferredImageMutation,
+} from '@/core/react-query/image-management/mutations';
 import { useSeriesImageCrossReferencesQuery } from '@/core/react-query/image-management/queries';
 import { invalidateQueries } from '@/core/react-query/queryClient';
 import toast from '@/core/toast';
@@ -67,22 +72,38 @@ const SeriesImages = () => {
   const [images, imagesTotal] = useFlattenListResult(crossReferencesQuery.data);
 
   const [selectedImage, setSelectedImage] = useState<ImageCrossReferenceType | null>(null);
+  const imageLabel = tabType.slice(0, -1);
+
   const { mutate: setPreferred } = useSetPreferredImageMutation();
+  const { mutate: unsetPreferred } = useUnsetPreferredImageMutation();
+  const { mutateAsync: deleteImage } = useDeleteImageMutation();
   const [showUploadModal, toggleUploadModal] = useToggle(false);
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
 
   const handleSelectionChange = (item: ImageCrossReferenceType) => {
     setSelectedImage(prev => (prev?.ID === item.ID ? null : item));
   };
 
-  const handleSetPreferredImage = () => {
+  const handleTogglePreferredImage = () => {
     if (!selectedImage) return;
-    setPreferred(selectedImage.ID, {
+    const isPreferred = selectedImage.IsPreferred;
+    const mutate = isPreferred ? unsetPreferred : setPreferred;
+    const action = isPreferred ? 'unset' : 'set';
+    mutate(selectedImage.ID, {
       onSuccess: () => {
         invalidateQueries(['series']);
-        toast.success(`Preferred ${tabType.slice(0, -1)} has been set.`);
+        toast.success(`Preferred ${imageLabel} has been ${action}.`);
         setSelectedImage(null);
       },
-      onError: () => toast.error(`Failed to set preferred ${tabType.slice(0, -1)}.`),
+      onError: () => toast.error(`Failed to ${action} preferred ${imageLabel}.`),
+    });
+  };
+
+  const handleDeleteImage = async () => {
+    if (!selectedImage) return;
+    await deleteImage(selectedImage.ImageID, {
+      onSuccess: () => toast.success(`${imageLabel} deleted.`),
+      onError: () => toast.error(`Failed to delete ${imageLabel.toLowerCase()}.`),
     });
   };
 
@@ -142,10 +163,23 @@ const SeriesImages = () => {
             <Button
               buttonType="primary"
               buttonSize="normal"
-              disabled={!selectedImage || selectedImage.IsPreferred}
-              onClick={handleSetPreferredImage}
+              disabled={!selectedImage}
+              onClick={handleTogglePreferredImage}
             >
-              {`Set As Preferred ${tabType.slice(0, -1)}`}
+              {selectedImage?.IsPreferred
+                ? `Unset Preferred ${imageLabel}`
+                : `Set As Preferred ${imageLabel}`}
+            </Button>
+            <Button
+              buttonType="danger"
+              buttonSize="normal"
+              disabled={!selectedImage || selectedImage.ImageSource !== 'User'}
+              tooltip={selectedImage && selectedImage.ImageSource !== 'User'
+                ? 'Only user-uploaded images can be deleted'
+                : ''}
+              onClick={() => setShowDeleteConfirm(true)}
+            >
+              Delete {imageLabel}
             </Button>
           </ShokoPanel>
         </div>
@@ -255,6 +289,16 @@ const SeriesImages = () => {
         seriesId={series.IDs.ID}
         imageType={tabType}
       />
+      <ConfirmationPromptModal
+        show={showDeleteConfirm}
+        title={`Delete ${imageLabel}`}
+        onConfirm={handleDeleteImage}
+        onClose={() => setShowDeleteConfirm(false)}
+        confirmText="Delete"
+        confirmButtonType="danger"
+      >
+        {`Are you sure you want to delete this ${imageLabel.toLowerCase()}?`}
+      </ConfirmationPromptModal>
     </>
   );
 };

--- a/src/pages/collection/series/SeriesImages.tsx
+++ b/src/pages/collection/series/SeriesImages.tsx
@@ -1,13 +1,15 @@
 import { useMemo, useState } from 'react';
 import { useOutletContext, useParams } from 'react-router';
 import useMeasure from 'react-use-measure';
-import { mdiLoading, mdiStarCircleOutline } from '@mdi/js';
+import { mdiImagePlusOutline, mdiLoading, mdiStarCircleOutline } from '@mdi/js';
 import { Icon } from '@mdi/react';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import cx from 'classnames';
 import { capitalize, debounce } from 'lodash';
+import { useToggle } from 'usehooks-ts';
 
 import BackgroundImagePlaceholderDiv from '@/components/BackgroundImagePlaceholderDiv';
+import ImageUploadModal from '@/components/Collection/Series/ImageUploadModal';
 import Button from '@/components/Input/Button';
 import MultiStateButton from '@/components/Input/MultiStateButton';
 import ShokoPanel from '@/components/Panels/ShokoPanel';
@@ -66,6 +68,7 @@ const SeriesImages = () => {
 
   const [selectedImage, setSelectedImage] = useState<ImageCrossReferenceType | null>(null);
   const { mutate: setPreferred } = useSetPreferredImageMutation();
+  const [showUploadModal, toggleUploadModal] = useToggle(false);
 
   const handleSelectionChange = (item: ImageCrossReferenceType) => {
     setSelectedImage(prev => (prev?.ID === item.ID ? null : item));
@@ -155,7 +158,19 @@ const SeriesImages = () => {
               {tabType}
               &nbsp;Listed
             </div>
-            <MultiStateButton activeState={tabType} onStateChange={handleTabChange} states={tabStates} />
+            <div className="flex gap-x-6">
+              <Button
+                buttonType="primary"
+                buttonSize="normal"
+                onClick={toggleUploadModal}
+              >
+                <div className="flex items-center gap-x-2">
+                  <Icon path={mdiImagePlusOutline} size={1} />
+                  Upload Image
+                </div>
+              </Button>
+              <MultiStateButton activeState={tabType} onStateChange={handleTabChange} states={tabStates} />
+            </div>
           </div>
           <div className="rounded-lg border border-panel-border bg-panel-background-transparent p-6">
             <div className="relative" style={{ height: virtualizer.getTotalSize() }} ref={gridContainerRef}>
@@ -234,6 +249,12 @@ const SeriesImages = () => {
           </div>
         </div>
       </div>
+      <ImageUploadModal
+        show={showUploadModal}
+        onClose={toggleUploadModal}
+        seriesId={series.IDs.ID}
+        imageType={tabType}
+      />
     </>
   );
 };

--- a/src/pages/collection/series/SeriesImages.tsx
+++ b/src/pages/collection/series/SeriesImages.tsx
@@ -194,17 +194,15 @@ const SeriesImages = () => {
               &nbsp;Listed
             </div>
             <div className="flex gap-x-6">
+              <MultiStateButton activeState={tabType} onStateChange={handleTabChange} states={tabStates} />
               <Button
                 buttonType="primary"
-                buttonSize="normal"
+                buttonSize="small"
                 onClick={toggleUploadModal}
+                tooltip={`Upload ${tabType.slice(0, -1)}`}
               >
-                <div className="flex items-center gap-x-2">
-                  <Icon path={mdiImagePlusOutline} size={1} />
-                  Upload Image
-                </div>
+                <Icon path={mdiImagePlusOutline} size={1} />
               </Button>
-              <MultiStateButton activeState={tabType} onStateChange={handleTabChange} states={tabStates} />
             </div>
           </div>
           <div className="rounded-lg border border-panel-border bg-panel-background-transparent p-6">

--- a/src/pages/collection/series/SeriesImages.tsx
+++ b/src/pages/collection/series/SeriesImages.tsx
@@ -105,6 +105,7 @@ const SeriesImages = () => {
       onSuccess: () => toast.success(`${imageLabel} deleted.`),
       onError: () => toast.error(`Failed to delete ${imageLabel.toLowerCase()}.`),
     });
+    setSelectedImage(null);
   };
 
   const handleTabChange = (newType: ImageTabType) => {

--- a/src/pages/collection/series/SeriesImages.tsx
+++ b/src/pages/collection/series/SeriesImages.tsx
@@ -234,9 +234,8 @@ const SeriesImages = () => {
                           zoomOnHover
                         >
                           {xref.IsPreferred && (
-                            <div className="absolute bottom-2 mx-[5%] flex w-[90%] justify-center gap-2.5 rounded-lg bg-panel-background-overlay py-2 text-sm font-semibold text-panel-text opacity-100 transition-opacity group-hover:opacity-0">
+                            <div className="absolute top-0 right-0 rounded-bl-lg bg-panel-background-overlay p-2 text-panel-text-important opacity-100 transition-opacity group-hover:opacity-0">
                               <Icon path={mdiStarCircleOutline} size={1} />
-                              Preferred
                             </div>
                           )}
                         </BackgroundImagePlaceholderDiv>


### PR DESCRIPTION
## Summary

Adds full server-side image management to the series images page: upload, delete, and toggle preferred status for series images (posters, backdrops, logos).

## Changes

### New: `ImageUploadModal.tsx` (+171)
- Drag-and-drop and file-browse modal for uploading series images
- Validates file type (image only), shows preview with filename + size
- Maps UI tab types (`Posters`, `Backdrops`, `Logos`) to server image types (`Primary`, `Backdrop`, `Logo`)
- Integrates hotkeys (Escape to close, Enter to upload)

### API mutations — `mutations.ts` (+47)
- `useUploadSeriesImageMutation`: two-step flow — POST `/Image/Management/Upload` (multipart) → POST `/Image/Management/CrossReference/Entity/Shoko/Series/{id}` to create the cross-reference
- `useUnsetPreferredImageMutation`: DELETE to unset a preferred image
- `useDeleteImageMutation`: DELETE to remove an image from management

### Type refinements
- `ImageSourceEnum` → `ImageSourceType` (union type `'AniDB' | 'TMDB' | 'Shoko' | 'User'`) in `common.ts`
- `CrossReferenceImageType` extracted as standalone type in `image.ts`
- `ImageSource` field in `ImageCrossReferenceType` changed from `string` to `ImageSourceType`

### UI updates — `SeriesImages.tsx` (+78 / −12)
- "Set As Preferred" button now toggles (set ↔ unset)
- New "Delete" button (danger style, only enabled for `User`-source images)
- New "Upload Image" button in the header row
- Preferred badge: moved from bottom text label to top-right icon-only overlay (`mdiStarCircleOutline`), with `overlayOnHover` behavior
- Delete confirmation modal added
- Upload modal wired up

## Breaking Changes
- `ImageSourceEnum` was a const enum — changed to a string union type. Any code that referenced `ImageSourceEnum.AniDB` etc. directly will break (though the diff shows no remaining references).

## Risk
- **Low risk.** The upload is a new two-step API flow; if the server rejects the cross-reference step after a successful upload, the uploaded image would be orphaned (no rollback). Worth verifying the server behavior.
- The const enum → union type change is technically breaking but constrained to `src/core/types/api/`.

## Recording
Here's an accidentally too-much compressed video

https://github.com/user-attachments/assets/78260880-4dbe-4c4f-9d04-2d881df777a0



