### PR TITLE
Use new endpoint for series image upload

### DIFF
--- a/src/components/Collection/Series/ImageUploadModal.tsx
+++ b/src/components/Collection/Series/ImageUploadModal.tsx
@@ -9,7 +9,7 @@ import prettyBytes from 'pretty-bytes';
 import Button from '@/components/Input/Button';
 import { buttonSizeClasses, buttonTypeClasses } from '@/components/Input/Button.utils';
 import ModalPanel from '@/components/Panels/ModalPanel';
-import { useUploadSeriesImageMutation } from '@/core/react-query/image-management/mutations';
+import { useUploadSeriesImageMutation } from '@/core/react-query/series/mutations';
 import toast from '@/core/toast';
 import useToggleModalKeybinds from '@/hooks/useToggleModalKeybinds';
 

--- a/src/core/react-query/image-management/mutations.ts
+++ b/src/core/react-query/image-management/mutations.ts
@@ -3,9 +3,6 @@ import { useMutation } from '@tanstack/react-query';
 import { axios } from '@/core/axios';
 import { invalidateQueries } from '@/core/react-query/queryClient';
 
-import type { UploadSeriesImageRequestType } from './types';
-import type { ImageSlimType } from '@/core/types/api/image';
-
 export const useSetPreferredImageMutation = () =>
   useMutation({
     mutationFn: (xrefId: number) => axios.put(`Image/Management/CrossReference/${xrefId}/Preferred`),
@@ -27,36 +24,5 @@ export const useDeleteImageCrossReferenceMutation = () =>
     mutationFn: (xrefId: number) => axios.delete(`Image/Management/CrossReference/${xrefId}`),
     onSuccess: () => {
       invalidateQueries(['image-management', 'cross-references']);
-    },
-  });
-
-/** Uploads an image file and links it to a series via a two-step flow:
- *  1. POST /Image/Management/Upload (multipart) — returns the new image's UID.
- *  2. POST /Image/Management/CrossReference/Entity/Shoko/Series/{seriesId} — creates the cross-reference.
- *  Invalidates the cross-references query for the series on success. */
-export const useUploadSeriesImageMutation = () =>
-  useMutation({
-    mutationFn: async ({ file, imageType, seriesId }: UploadSeriesImageRequestType) => {
-      const formData = new FormData();
-      formData.append('file', file);
-      formData.append('userSubmitted', 'true');
-
-      const imageSlim: ImageSlimType = await axios.post('Image/Management/Upload', formData);
-
-      try {
-        return await axios.post(
-          `Image/Management/CrossReference/Entity/Shoko/Series/${seriesId}`,
-          {
-            ImageID: imageSlim.UID,
-            ImageType: imageType,
-          },
-        );
-      } catch (error) {
-        await axios.delete(`Image/Management/${imageSlim.UID}`);
-        throw error;
-      }
-    },
-    onSuccess: (_, { seriesId }) => {
-      invalidateQueries(['image-management', 'cross-references', seriesId]);
     },
   });

--- a/src/core/react-query/image-management/types.ts
+++ b/src/core/react-query/image-management/types.ts
@@ -1,19 +1,6 @@
 import type { PaginationType } from '@/core/types/api';
-import type { CrossReferenceImageType } from '@/core/types/api/image';
 
 export type SeriesImageCrossReferencesRequestType = {
   imageType: string;
   isAvailable?: boolean;
 } & PaginationType;
-
-export type UploadSeriesImageRequestType = {
-  file: File;
-  imageType: CrossReferenceImageType;
-  seriesId: number;
-};
-
-export type AddImageCrossReferenceRequestType = {
-  ImageType: CrossReferenceImageType;
-  /** UUID of the uploaded image (from the Upload response). */
-  ImageID: string;
-};

--- a/src/core/react-query/series/mutations.ts
+++ b/src/core/react-query/series/mutations.ts
@@ -8,6 +8,7 @@ import type {
   DeleteSeriesRequestType,
   RefreshAniDBSeriesRequestType,
   RefreshSeriesAniDBInfoRequestType,
+  UploadSeriesImageRequestType,
   WatchSeriesEpisodesRequestType,
 } from '@/core/react-query/series/types';
 import type { SeriesAniDBSearchResult } from '@/core/types/api/series';
@@ -123,4 +124,16 @@ export const useRelocateSeriesFilesMutation = (seriesId: number) =>
   useMutation({
     mutationFn: () => axios.post(`Series/${seriesId}/File/Relocate`),
     onSuccess: () => toast.success('Series files renamed/moved!'),
+  });
+
+export const useUploadSeriesImageMutation = () =>
+  useMutation({
+    mutationFn: async ({ file, imageType, seriesId }: UploadSeriesImageRequestType) => {
+      const formData = new FormData();
+      formData.append('file', file);
+      return axios.post(`Series/${seriesId}/Images/${imageType}/Upload`, formData);
+    },
+    onSuccess: (_, { seriesId }) => {
+      invalidateQueries(['image-management', 'cross-references', seriesId]);
+    },
   });

--- a/src/core/react-query/series/types.ts
+++ b/src/core/react-query/series/types.ts
@@ -2,6 +2,7 @@ import type { IncludeOnlyFilterType } from '@/core/react-query/types';
 import type { PaginationType } from '@/core/types/api';
 import type { DataSourceType } from '@/core/types/api/common';
 import type { EpisodeTypeEnum } from '@/core/types/api/episode';
+import type { CrossReferenceImageType } from '@/core/types/api/image';
 
 type SeriesEpisodesBaseRequestType = {
   includeMissing?: IncludeOnlyFilterType;
@@ -65,6 +66,12 @@ export type RefreshAniDBSeriesRequestType = {
 export type RefreshSeriesAniDBInfoRequestType = {
   force?: boolean;
   cacheOnly?: boolean;
+};
+
+export type UploadSeriesImageRequestType = {
+  file: File;
+  imageType: CrossReferenceImageType;
+  seriesId: number;
 };
 
 export type WatchSeriesEpisodesRequestType = {

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -77,7 +77,7 @@ export default defineConfig(async () => {
 async function setupEnv(isDebug) {
   const gitHash = childProcess.execSync("git log --pretty=format:'%h' -n 1").toString().replace(/["']/g, '');
   const appVersion = pkg.version;
-  const minimumServerVersion = '6.0.0-dev.374';
+  const minimumServerVersion = '6.0.0-dev.384';
 
   process.env.VITE_GITHASH = gitHash;
   process.env.VITE_APPVERSION = appVersion;


### PR DESCRIPTION
## Summary

Migrates `useUploadSeriesImageMutation` to the new single-request series image upload endpoint and bumps the minimum Shoko Server version.

### Changes

- **Endpoint migration**: Replaced the two-step upload flow (`POST Image/Management/Upload` → `POST Image/Management/CrossReference/...`) with the new atomic `POST Series/{seriesID}/Images/{imageType}/Upload` endpoint. The server now handles upload and cross-reference creation in a single request — eliminating the need for manual cleanup on failure.
- **Moved mutation**: Relocated `useUploadSeriesImageMutation` from `image-management/mutations.ts` to `series/mutations.ts` since it no longer uses Image Management endpoints.
- **Housekeeping**: Removed dead `AddImageCrossReferenceRequestType` type and unused imports from the image-management files.
- **Server version**: Bumped minimum required Shoko Server version from `6.0.0-dev.374` to `6.0.0-dev.384` (the version where the new endpoint was introduced).