### PR TITLE
Update ReleaseManagement query layer for ShokoServer PR #1396

### DIFF
--- a/src/components/Utilities/DuplicateFiles/DuplicateFilesQuickSelectModal.tsx
+++ b/src/components/Utilities/DuplicateFiles/DuplicateFilesQuickSelectModal.tsx
@@ -73,7 +73,7 @@ const DuplicateFilesQuickSelectModal = ({ onClose, seriesId, show }: Props) => {
       { locationIds, removeFolder: true },
       {
         onSuccess: () => {
-          resetQueries(['release-management']);
+          resetQueries(['duplicate-files']);
           toast.success(
             `${locationIds.length} ${locationIds.length === 1 ? 'duplicate file' : 'duplicate files'} deleted!`,
           );

--- a/src/components/Utilities/DuplicateFiles/DuplicatesInfo.tsx
+++ b/src/components/Utilities/DuplicateFiles/DuplicatesInfo.tsx
@@ -28,7 +28,7 @@ const DuplicatesInfo = ({ file, location }: Props) => {
     if (!confirmDelete) return;
 
     await deleteFileLocation({ locationId: location.ID });
-    invalidateQueries(['release-management', 'series', 'episodes']);
+    invalidateQueries(['duplicate-files', 'series', 'episodes']);
   };
 
   // To re-enable the correct keybinds once the delete confirmation modal closes

--- a/src/components/Utilities/ReleaseManagement/ReleaseManagementPreviewModal.tsx
+++ b/src/components/Utilities/ReleaseManagement/ReleaseManagementPreviewModal.tsx
@@ -134,7 +134,7 @@ const SeriesPreviewRow = (
   );
 };
 
-const MultipleReleasesPreviewModal = ({
+const ReleaseManagementPreviewModal = ({
   allSelected,
   mixMatchSelection,
   onClose,
@@ -304,4 +304,4 @@ const MultipleReleasesPreviewModal = ({
   );
 };
 
-export default MultipleReleasesPreviewModal;
+export default ReleaseManagementPreviewModal;

--- a/src/components/Utilities/ReleaseManagement/ReleaseManagementSeriesDetail.tsx
+++ b/src/components/Utilities/ReleaseManagement/ReleaseManagementSeriesDetail.tsx
@@ -12,8 +12,8 @@ import Button from '@/components/Input/Button';
 import Checkbox from '@/components/Input/Checkbox';
 import ShokoPanel from '@/components/Panels/ShokoPanel';
 import ShokoIcon from '@/components/ShokoIcon';
-import MultipleReleasesPreviewModal from '@/components/Utilities/ReleaseManagement/MultipleReleasesPreviewModal';
-import { useMultipleReleaseSeriesDetailQuery } from '@/core/react-query/release-management/queries';
+import ReleaseManagementPreviewModal from '@/components/Utilities/ReleaseManagement/ReleaseManagementPreviewModal';
+import { useReleaseManagementSeriesDetailQuery } from '@/core/react-query/release-management/queries';
 import toast from '@/core/toast';
 import { getAnidbAnimeLink } from '@/core/util';
 import useNavigateVoid from '@/hooks/useNavigateVoid';
@@ -95,7 +95,7 @@ const ReleaseManagementSeriesDetail = () => {
   const [mixMatchSelection, setMixMatchSelection] = useImmer<Map<string, number>>(new Map());
   const [mixMatchUnassignedCount, setMixMatchUnassignedCount] = useState(0);
 
-  const seriesQuery = useMultipleReleaseSeriesDetailQuery(seriesId, includeVariations, seriesId > 0);
+  const seriesQuery = useReleaseManagementSeriesDetailQuery(seriesId, includeVariations, seriesId > 0);
   const series = seriesQuery.data;
 
   useEffect(() => {
@@ -236,7 +236,7 @@ const ReleaseManagementSeriesDetail = () => {
         onClose={toggleManageVariationsModal}
       />
 
-      <MultipleReleasesPreviewModal
+      <ReleaseManagementPreviewModal
         selectedSeries={[seriesId]}
         show={showPreviewModal}
         onClose={togglePreviewModal}

--- a/src/components/Utilities/ReleaseManagement/ReleaseManagementSeriesList.tsx
+++ b/src/components/Utilities/ReleaseManagement/ReleaseManagementSeriesList.tsx
@@ -9,7 +9,7 @@ import { debounce } from 'lodash';
 
 import { Badge } from '@/components/Badge';
 import ShokoIcon from '@/components/ShokoIcon';
-import { useMultipleReleaseSeriesQuery } from '@/core/react-query/release-management/queries';
+import { useReleaseManagementSeriesQuery } from '@/core/react-query/release-management/queries';
 import { getAnidbAnimeLink, handleShiftSelect } from '@/core/util';
 import useFlattenListResult from '@/hooks/useFlattenListResult';
 import useNavigateVoid from '@/hooks/useNavigateVoid';
@@ -120,7 +120,7 @@ const SeriesRow = ({
   );
 };
 
-const MultipleReleasesSeriesList = ({
+const ReleaseManagementSeriesList = ({
   allSelected,
   autoDeleteMode,
   setSelectedSeries,
@@ -132,7 +132,7 @@ const MultipleReleasesSeriesList = ({
   const onlyFinishedSeries = searchParams.get('onlyFinishedSeries') === 'true';
   const includeVariations = searchParams.get('includeVariations') === 'true';
 
-  const { fetchNextPage, ...seriesQuery } = useMultipleReleaseSeriesQuery({
+  const { fetchNextPage, ...seriesQuery } = useReleaseManagementSeriesQuery({
     onlyFinishedSeries,
     includeVariations,
     onlyWithRedundant: autoDeleteMode,
@@ -271,4 +271,4 @@ const MultipleReleasesSeriesList = ({
   );
 };
 
-export default MultipleReleasesSeriesList;
+export default ReleaseManagementSeriesList;

--- a/src/components/Utilities/ReleaseManagement/SeriesDetail/ManageVariationsModal.tsx
+++ b/src/components/Utilities/ReleaseManagement/SeriesDetail/ManageVariationsModal.tsx
@@ -10,7 +10,7 @@ import Checkbox from '@/components/Input/Checkbox';
 import ModalPanel from '@/components/Panels/ModalPanel';
 import { useMarkVariationMutation } from '@/core/react-query/file/mutations';
 import { resetQueries } from '@/core/react-query/queryClient';
-import { useMultipleReleaseSeriesDetailQuery } from '@/core/react-query/release-management/queries';
+import { useReleaseManagementSeriesDetailQuery } from '@/core/react-query/release-management/queries';
 import toast from '@/core/toast';
 import { buildEpisodeCoverageString } from '@/core/utilities/releaseManagementHelpers';
 import useToggleModalKeybinds from '@/hooks/useToggleModalKeybinds';
@@ -30,7 +30,7 @@ const ManageVariationsModal = ({ onClose, seriesId, seriesTitle, show }: Props) 
   useToggleModalKeybinds(show, 'modal');
   useToggleModalKeybinds(!show, 'primary');
 
-  const seriesQuery = useMultipleReleaseSeriesDetailQuery(seriesId, true, show && seriesId > 0);
+  const seriesQuery = useReleaseManagementSeriesDetailQuery(seriesId, true, show && seriesId > 0);
 
   const allFiles = seriesQuery.data
     ? uniqBy(seriesQuery.data.Candidates.flatMap(candidate => candidate.Files), 'VideoLocalID')

--- a/src/components/Utilities/UtilitySeriesList.tsx
+++ b/src/components/Utilities/UtilitySeriesList.tsx
@@ -7,11 +7,9 @@ import { useToggle } from 'usehooks-ts';
 
 import ShokoIcon from '@/components/ShokoIcon';
 import UtilitiesTable from '@/components/Utilities/UtilitiesTable';
+import { useDuplicateFilesQuery, useDuplicateFilesSeriesQuery } from '@/core/react-query/duplicate-files/queries';
+import { useMissingEpisodesQuery, useMissingEpisodesSeriesQuery } from '@/core/react-query/missing-episodes/queries';
 import { resetQueries } from '@/core/react-query/queryClient';
-import {
-  useReleaseManagementSeries,
-  useReleaseManagementSeriesEpisodes,
-} from '@/core/react-query/release-management/queries';
 import { getAnidbAnimeLink, getAnidbEpisodeLink } from '@/core/util';
 import { getEpisodePrefix } from '@/core/utilities/getEpisodePrefix';
 import useFlattenListResult from '@/hooks/useFlattenListResult';
@@ -20,7 +18,6 @@ import useRowSelection from '@/hooks/useRowSelection';
 import DuplicateFilesModal from './DuplicateFiles/DuplicateFilesModal';
 
 import type { UtilityHeaderType } from '@/components/Utilities/constants';
-import type { ReleaseManagementItemType } from '@/core/react-query/release-management/types';
 import type { EpisodeType } from '@/core/types/api/episode';
 import type { ReleaseManagementSeriesType } from '@/core/types/api/series';
 
@@ -128,7 +125,7 @@ const duplicatesEpisodeFileCountColumn: UtilityHeaderType<EpisodeType> = {
 };
 
 type Props = {
-  type: ReleaseManagementItemType;
+  type: 'DuplicateFiles' | 'MissingEpisodes';
   setSelectedEpisodes?: (episodes: EpisodeType[]) => void;
   setSelectedSeriesId?: (id: number) => void;
   setSeriesCount: (count: number) => void;
@@ -148,14 +145,18 @@ const UtilitySeriesList = (
 
   const [selectedSeries, setSelectedSeries] = useState(0);
 
-  const seriesQuery = useReleaseManagementSeries(
-    type,
+  const duplicateFilesSeriesQuery = useDuplicateFilesSeriesQuery(
     { collecting: onlyCollecting, onlyFinishedSeries, pageSize: 50 },
+    type === 'DuplicateFiles',
   );
+  const missingEpisodesSeriesQuery = useMissingEpisodesSeriesQuery(
+    { collecting: onlyCollecting, onlyFinishedSeries, pageSize: 50 },
+    type === 'MissingEpisodes',
+  );
+  const seriesQuery = type === 'DuplicateFiles' ? duplicateFilesSeriesQuery : missingEpisodesSeriesQuery;
   const [series, seriesCount] = useFlattenListResult(seriesQuery.data);
 
-  const episodesQuery = useReleaseManagementSeriesEpisodes(
-    type,
+  const duplicateFilesQuery = useDuplicateFilesQuery(
     selectedSeries,
     {
       collecting: onlyCollecting,
@@ -163,12 +164,24 @@ const UtilitySeriesList = (
       includeAbsolutePaths: true,
       pageSize: 50,
     },
-    selectedSeries > 0,
+    selectedSeries > 0 && type === 'DuplicateFiles',
   );
+  const missingEpisodesQuery = useMissingEpisodesQuery(
+    selectedSeries,
+    {
+      collecting: onlyCollecting,
+      includeDataFrom: ['AniDB'],
+      includeAbsolutePaths: true,
+      pageSize: 50,
+    },
+    selectedSeries > 0 && type === 'MissingEpisodes',
+  );
+  const episodesQuery = type === 'DuplicateFiles' ? duplicateFilesQuery : missingEpisodesQuery;
   const [episodes, episodeCount] = useFlattenListResult(episodesQuery.data);
 
   useEffect(() => () => {
-    resetQueries(['release-management', 'series', 'episodes']);
+    resetQueries(['duplicate-files', 'series', 'episodes']);
+    resetQueries(['missing-episodes', 'series', 'episodes']);
   }, []);
 
   const [showEpisodeModal, toggleEpisodeModal, setEpisodeModal] = useToggle(false);

--- a/src/core/react-query/duplicate-files/queries.ts
+++ b/src/core/react-query/duplicate-files/queries.ts
@@ -1,0 +1,58 @@
+import { useInfiniteQuery } from '@tanstack/react-query';
+
+import { axios } from '@/core/axios';
+
+import type {
+  DuplicateFilesEpisodesRequestType,
+  DuplicateFilesSeriesRequestType,
+} from '@/core/react-query/duplicate-files/types';
+import type { ListResultType } from '@/core/types/api';
+import type { EpisodeType } from '@/core/types/api/episode';
+import type { ReleaseManagementSeriesType } from '@/core/types/api/series';
+
+export const useDuplicateFilesSeriesQuery = (params: DuplicateFilesSeriesRequestType, enabled = true) =>
+  useInfiniteQuery<ListResultType<ReleaseManagementSeriesType>>({
+    queryKey: ['duplicate-files', 'series', params],
+    queryFn: ({ pageParam }) =>
+      axios.get(
+        'DuplicateFiles/Series',
+        {
+          params: {
+            ...params,
+            page: pageParam as number,
+          },
+        },
+      ),
+    initialPageParam: 1,
+    getNextPageParam: (lastPage, _, lastPageParam: number) => {
+      if (!params.pageSize || lastPage.Total / params.pageSize <= lastPageParam) return undefined;
+      return lastPageParam + 1;
+    },
+    enabled,
+  });
+
+export const useDuplicateFilesQuery = (
+  seriesId: number,
+  params: DuplicateFilesEpisodesRequestType,
+  enabled = true,
+) =>
+  useInfiniteQuery<ListResultType<EpisodeType>>({
+    queryKey: ['duplicate-files', 'series', 'episodes', seriesId, params],
+    queryFn: ({ pageParam }) =>
+      axios.get(
+        `DuplicateFiles/Series/${seriesId}/Episodes`,
+        {
+          params: {
+            ...params,
+            page: pageParam as number,
+          },
+        },
+      ),
+    initialPageParam: 1,
+    getNextPageParam: (lastPage, _, lastPageParam: number) => {
+      if (!params.pageSize || lastPage.Total / params.pageSize <= lastPageParam) return undefined;
+      return lastPageParam + 1;
+    },
+    enabled,
+    staleTime: Infinity,
+  });

--- a/src/core/react-query/duplicate-files/types.ts
+++ b/src/core/react-query/duplicate-files/types.ts
@@ -1,0 +1,18 @@
+import type { PaginationType } from '@/core/types/api';
+import type { DataSourceType } from '@/core/types/api/common';
+
+export type DuplicateFilesSeriesRequestType = {
+  collecting?: boolean;
+  ignoreVariations?: boolean;
+  includeDataFrom?: DataSourceType[];
+  onlyFinishedSeries?: boolean;
+} & PaginationType;
+
+export type DuplicateFilesEpisodesRequestType = {
+  collecting?: boolean;
+  ignoreVariations?: boolean;
+  includeAbsolutePaths?: boolean;
+  includeDataFrom?: DataSourceType[];
+  includeFiles?: boolean;
+  includeMediaInfo?: boolean;
+} & PaginationType;

--- a/src/core/react-query/missing-episodes/queries.ts
+++ b/src/core/react-query/missing-episodes/queries.ts
@@ -1,0 +1,58 @@
+import { useInfiniteQuery } from '@tanstack/react-query';
+
+import { axios } from '@/core/axios';
+
+import type {
+  MissingEpisodesRequestType,
+  MissingEpisodesSeriesRequestType,
+} from '@/core/react-query/missing-episodes/types';
+import type { ListResultType } from '@/core/types/api';
+import type { EpisodeType } from '@/core/types/api/episode';
+import type { ReleaseManagementSeriesType } from '@/core/types/api/series';
+
+export const useMissingEpisodesSeriesQuery = (params: MissingEpisodesSeriesRequestType, enabled = true) =>
+  useInfiniteQuery<ListResultType<ReleaseManagementSeriesType>>({
+    queryKey: ['missing-episodes', 'series', params],
+    queryFn: ({ pageParam }) =>
+      axios.get(
+        'MissingEpisodes/Series',
+        {
+          params: {
+            ...params,
+            page: pageParam as number,
+          },
+        },
+      ),
+    initialPageParam: 1,
+    getNextPageParam: (lastPage, _, lastPageParam: number) => {
+      if (!params.pageSize || lastPage.Total / params.pageSize <= lastPageParam) return undefined;
+      return lastPageParam + 1;
+    },
+    enabled,
+  });
+
+export const useMissingEpisodesQuery = (
+  seriesId: number,
+  params: MissingEpisodesRequestType,
+  enabled = true,
+) =>
+  useInfiniteQuery<ListResultType<EpisodeType>>({
+    queryKey: ['missing-episodes', 'series', 'episodes', seriesId, params],
+    queryFn: ({ pageParam }) =>
+      axios.get(
+        `MissingEpisodes/Series/${seriesId}/Episodes`,
+        {
+          params: {
+            ...params,
+            page: pageParam as number,
+          },
+        },
+      ),
+    initialPageParam: 1,
+    getNextPageParam: (lastPage, _, lastPageParam: number) => {
+      if (!params.pageSize || lastPage.Total / params.pageSize <= lastPageParam) return undefined;
+      return lastPageParam + 1;
+    },
+    enabled,
+    staleTime: Infinity,
+  });

--- a/src/core/react-query/missing-episodes/types.ts
+++ b/src/core/react-query/missing-episodes/types.ts
@@ -1,0 +1,18 @@
+import type { PaginationType } from '@/core/types/api';
+import type { DataSourceType } from '@/core/types/api/common';
+
+export type MissingEpisodesSeriesRequestType = {
+  collecting?: boolean;
+  ignoreVariations?: boolean;
+  includeDataFrom?: DataSourceType[];
+  onlyFinishedSeries?: boolean;
+} & PaginationType;
+
+export type MissingEpisodesRequestType = {
+  collecting?: boolean;
+  ignoreVariations?: boolean;
+  includeAbsolutePaths?: boolean;
+  includeDataFrom?: DataSourceType[];
+  includeFiles?: boolean;
+  includeMediaInfo?: boolean;
+} & PaginationType;

--- a/src/core/react-query/release-management/mutations.ts
+++ b/src/core/react-query/release-management/mutations.ts
@@ -6,5 +6,5 @@ import type { ReleaseDeletionRequestType } from '@/core/react-query/release-mana
 
 export const useReleaseDeleteMutation = () =>
   useMutation({
-    mutationFn: (body: ReleaseDeletionRequestType) => axios.post('ReleaseManagement/MultipleReleases/Execute', body),
+    mutationFn: (body: ReleaseDeletionRequestType) => axios.post('ReleaseManagement/Execute', body),
   });

--- a/src/core/react-query/release-management/queries.ts
+++ b/src/core/react-query/release-management/queries.ts
@@ -3,76 +3,19 @@ import { useInfiniteQuery, useQuery } from '@tanstack/react-query';
 import { axios } from '@/core/axios';
 
 import type {
-  MultipleReleasesSeriesRequestType,
   ReleaseDeletionPreviewRequestType,
-  ReleaseManagementItemType,
-  ReleaseManagementSeriesEpisodesType,
   ReleaseManagementSeriesRequestType,
   ReleaseMixMatchDeletionPreviewRequestType,
 } from '@/core/react-query/release-management/types';
 import type { ListResultType } from '@/core/types/api';
-import type { EpisodeType } from '@/core/types/api/episode';
 import type { ReleaseDeletionPreviewType, SeriesWithCandidatesType } from '@/core/types/api/release-management';
-import type { ReleaseManagementSeriesType } from '@/core/types/api/series';
 
-export const useReleaseManagementSeries = (
-  type: ReleaseManagementItemType,
-  params: ReleaseManagementSeriesRequestType,
-) =>
-  useInfiniteQuery<ListResultType<ReleaseManagementSeriesType>>({
-    queryKey: ['release-management', 'series', type, params],
-    queryFn: ({ pageParam }) =>
-      axios.get(
-        `ReleaseManagement/${type}/Series`,
-        {
-          params: {
-            ...params,
-            // It is supposed to infer the type from the initialPageParam property but it doesn't work
-            page: pageParam as number,
-          },
-        },
-      ),
-    initialPageParam: 1,
-    getNextPageParam: (lastPage, _, lastPageParam: number) => {
-      if (!params.pageSize || lastPage.Total / params.pageSize <= lastPageParam) return undefined;
-      return lastPageParam + 1;
-    },
-  });
-
-export const useReleaseManagementSeriesEpisodes = (
-  type: ReleaseManagementItemType,
-  seriesId: number,
-  params: ReleaseManagementSeriesEpisodesType,
-  enabled = true,
-) =>
-  useInfiniteQuery<ListResultType<EpisodeType>>({
-    queryKey: ['release-management', 'series', 'episodes', type, seriesId, params],
-    queryFn: ({ pageParam }) =>
-      axios.get(
-        `ReleaseManagement/${type}/Series/${seriesId}/Episodes`,
-        {
-          params: {
-            ...params,
-            // It is supposed to infer the type from the initialPageParam property but it doesn't work
-            page: pageParam as number,
-          },
-        },
-      ),
-    initialPageParam: 1,
-    getNextPageParam: (lastPage, _, lastPageParam: number) => {
-      if (!params.pageSize || lastPage.Total / params.pageSize <= lastPageParam) return undefined;
-      return lastPageParam + 1;
-    },
-    enabled,
-    staleTime: Infinity,
-  });
-
-export const useMultipleReleaseSeriesQuery = (params: MultipleReleasesSeriesRequestType) =>
+export const useReleaseManagementSeriesQuery = (params: ReleaseManagementSeriesRequestType) =>
   useInfiniteQuery<ListResultType<SeriesWithCandidatesType>>({
-    queryKey: ['release-management', 'multiple-releases', 'series', params],
+    queryKey: ['release-management', 'series', params],
     queryFn: ({ pageParam }) =>
       axios.get(
-        'ReleaseManagement/MultipleReleases/Series',
+        'ReleaseManagement/Series',
         {
           params: {
             ...params,
@@ -87,12 +30,12 @@ export const useMultipleReleaseSeriesQuery = (params: MultipleReleasesSeriesRequ
     },
   });
 
-export const useMultipleReleaseSeriesDetailQuery = (seriesId: number, includeVariations = false, enabled = true) =>
+export const useReleaseManagementSeriesDetailQuery = (seriesId: number, includeVariations = false, enabled = true) =>
   useQuery<SeriesWithCandidatesType>({
-    queryKey: ['release-management', 'multiple-releases', 'series', seriesId, includeVariations],
+    queryKey: ['release-management', 'series', seriesId, includeVariations],
     queryFn: () =>
       axios.get(
-        `ReleaseManagement/MultipleReleases/Series/${seriesId}`,
+        `ReleaseManagement/Series/${seriesId}`,
         { params: { includeVariations } },
       ),
     enabled: enabled && seriesId > 0,
@@ -106,9 +49,9 @@ export const useReleaseDeletionPreviewQuery = (
   enabled = true,
 ) =>
   useQuery<ReleaseDeletionPreviewType[]>({
-    queryKey: ['release-management', 'multiple-releases', 'preview', body, onlyFinishedSeries, includeVariations],
+    queryKey: ['release-management', 'preview', body, onlyFinishedSeries, includeVariations],
     queryFn: () =>
-      axios.post('ReleaseManagement/MultipleReleases/Preview', body, {
+      axios.post('ReleaseManagement/Preview', body, {
         params: { includeVariations, onlyFinishedSeries },
       }),
     enabled,
@@ -120,7 +63,7 @@ export const useReleaseMixMatchDeletionPreviewQuery = (
   enabled = true,
 ) =>
   useQuery<ReleaseDeletionPreviewType>({
-    queryKey: ['release-management', 'multiple-releases', 'preview', 'mix-match', seriesId, body],
-    queryFn: () => axios.post(`ReleaseManagement/MultipleReleases/Series/${seriesId}/Override`, body),
+    queryKey: ['release-management', 'preview', 'mix-match', seriesId, body],
+    queryFn: () => axios.post(`ReleaseManagement/Series/${seriesId}/Override`, body),
     enabled,
   });

--- a/src/core/react-query/release-management/types.ts
+++ b/src/core/react-query/release-management/types.ts
@@ -1,35 +1,11 @@
 import type { PaginationType } from '@/core/types/api';
-import type { DataSourceType } from '@/core/types/api/common';
 
-export type ReleaseManagementItemType = 'DuplicateFiles' | 'MissingEpisodes';
-
-export type MultipleReleasesSeriesRequestType = {
+export type ReleaseManagementSeriesRequestType = {
   onlyFinishedSeries?: boolean;
   onlyWithRedundant?: boolean;
   includeVariations?: boolean;
   search?: string;
 } & PaginationType;
-
-export type ReleaseManagementSeriesRequestType = {
-  ignoreVariations?: boolean;
-  includeDataFrom?: DataSourceType[];
-  collecting?: boolean;
-  onlyFinishedSeries?: boolean;
-} & PaginationType;
-
-export type ReleaseManagementSeriesEpisodesType = {
-  includeDataFrom?: DataSourceType[];
-  includeFiles?: boolean;
-  includeMediaInfo?: boolean;
-  includeAbsolutePaths?: boolean;
-  collecting?: boolean;
-  ignoreVariations?: boolean;
-} & PaginationType;
-
-export type SeriesCandidateOverride = {
-  seriesID: number;
-  preferredCandidateKey: string;
-};
 
 export type ReleaseMixMatchDeletionPreviewRequestType = {
   selectedPlaceIDs: number[];
@@ -38,7 +14,10 @@ export type ReleaseMixMatchDeletionPreviewRequestType = {
 export type ReleaseDeletionPreviewRequestType = {
   includedSeriesIDs?: number[];
   excludedSeriesIDs?: number[];
-  overrides?: SeriesCandidateOverride[];
+  overrides?: {
+    seriesID: number;
+    preferredCandidateKey: string;
+  }[];
 };
 
 export type ReleaseDeletionRequestType = {

--- a/src/core/signalr/eventHandlers.ts
+++ b/src/core/signalr/eventHandlers.ts
@@ -33,8 +33,12 @@ const invalidateSeries = debounce(
   1000,
 );
 
-const invalidateReleaseManagement = debounce(
-  () => invalidateQueries(['release-management', 'multiple-releases']),
+const invalidateUtilities = debounce(
+  () => {
+    invalidateQueries(['release-management']);
+    invalidateQueries(['duplicate-files']);
+    invalidateQueries(['missing-episodes']);
+  },
   2000,
 );
 
@@ -47,7 +51,7 @@ export const handleEvent = (event: string, data?: SeriesUpdateEventType) => {
       invalidateDashboard();
       invalidateFiles();
       invalidateManagedFolders();
-      if (event === 'FileDeleted' || event === 'FileMatched') invalidateReleaseManagement();
+      if (event === 'FileDeleted' || event === 'FileMatched') invalidateUtilities();
       break;
     case 'FileMoved':
       invalidateFiles();

--- a/src/pages/utilities/DuplicateFilesTabs/DuplicateFilesLinkedTab.tsx
+++ b/src/pages/utilities/DuplicateFilesTabs/DuplicateFilesLinkedTab.tsx
@@ -20,14 +20,14 @@ import { resetQueries } from '@/core/react-query/queryClient';
 const DuplicateFilesLinkedTab = () => {
   const [searchParams, setSearchParams] = useSearchParams();
 
-  const isSeriesQueryFetching = useIsFetching({ queryKey: ['release-management', 'series'] }) > 0;
+  const isSeriesQueryFetching = useIsFetching({ queryKey: ['duplicate-files', 'series'] }) > 0;
 
   const [seriesCount, setSeriesCount] = useState(0);
   const [selectedSeries, setSelectedSeries] = useState(0);
 
   const handleRefresh = () => {
     if (isSeriesQueryFetching) return;
-    resetQueries(['release-management', 'series']);
+    resetQueries(['duplicate-files', 'series']);
   };
 
   useHotkeys('r', handleRefresh, { scopes: 'primary' });

--- a/src/pages/utilities/MissingEpisodes.tsx
+++ b/src/pages/utilities/MissingEpisodes.tsx
@@ -22,14 +22,14 @@ import type { EpisodeType } from '@/core/types/api/episode';
 const MissingEpisodes = () => {
   const [searchParams, setSearchParams] = useSearchParams();
 
-  const isSeriesQueryFetching = useIsFetching({ queryKey: ['release-management', 'series'] }) > 0;
+  const isSeriesQueryFetching = useIsFetching({ queryKey: ['missing-episodes', 'series'] }) > 0;
 
   const [seriesCount, setSeriesCount] = useState(0);
   const [selectedEpisodes, setSelectedEpisodes] = useState<EpisodeType[]>([]);
 
   const handleRefresh = () => {
     if (isSeriesQueryFetching) return;
-    resetQueries(['release-management', 'series']);
+    resetQueries(['missing-episodes', 'series']);
   };
 
   useHotkeys('r', handleRefresh, { scopes: 'primary' });
@@ -59,7 +59,7 @@ const MissingEpisodes = () => {
       .catch(() => toast.error('One or more operations failed!'))
       .finally(() => {
         setHidePending(false);
-        resetQueries(['release-management']);
+        resetQueries(['missing-episodes']);
         setSelectedEpisodes([]);
       });
   };

--- a/src/pages/utilities/ReleaseManagement.tsx
+++ b/src/pages/utilities/ReleaseManagement.tsx
@@ -20,8 +20,8 @@ import Checkbox from '@/components/Input/Checkbox';
 import Input from '@/components/Input/Input';
 import ShokoPanel from '@/components/Panels/ShokoPanel';
 import ItemCount from '@/components/Utilities/ItemCount';
-import MultipleReleasesPreviewModal from '@/components/Utilities/ReleaseManagement/MultipleReleasesPreviewModal';
-import MultipleReleasesSeriesList from '@/components/Utilities/ReleaseManagement/MultipleReleasesSeriesList';
+import ReleaseManagementPreviewModal from '@/components/Utilities/ReleaseManagement/ReleaseManagementPreviewModal';
+import ReleaseManagementSeriesList from '@/components/Utilities/ReleaseManagement/ReleaseManagementSeriesList';
 import MenuButton from '@/components/Utilities/Unrecognized/MenuButton';
 import { resetQueries } from '@/core/react-query/queryClient';
 
@@ -56,13 +56,13 @@ const ReleaseManagement = () => {
   const [allSelected, toggleAllSelected] = useToggle(true);
   const [selectedSeries, setSelectedSeries] = useState<number[]>([]);
 
-  const isSeriesQueryFetching = useIsFetching({ queryKey: ['release-management', 'multiple-releases', 'series'] }) > 0;
+  const isSeriesQueryFetching = useIsFetching({ queryKey: ['release-management', 'series'] }) > 0;
   const [seriesCount, setSeriesCount] = useState(0);
   const selectedCount = allSelected ? (seriesCount - selectedSeries.length) : selectedSeries.length;
 
   const handleRefresh = () => {
     if (isSeriesQueryFetching) return;
-    resetQueries(['release-management', 'multiple-releases']);
+    resetQueries(['release-management']);
   };
   useHotkeys('r', handleRefresh, { scopes: 'primary' });
 
@@ -157,7 +157,7 @@ const ReleaseManagement = () => {
           </div>
         </ShokoPanel>
 
-        <MultipleReleasesSeriesList
+        <ReleaseManagementSeriesList
           allSelected={allSelected}
           autoDeleteMode={autoDeleteMode}
           setSelectedSeries={setSelectedSeries}
@@ -165,7 +165,7 @@ const ReleaseManagement = () => {
         />
       </div>
 
-      <MultipleReleasesPreviewModal
+      <ReleaseManagementPreviewModal
         show={showPreviewModal}
         onClose={togglePreviewModal}
         allSelected={allSelected}

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -77,7 +77,7 @@ export default defineConfig(async () => {
 async function setupEnv(isDebug) {
   const gitHash = childProcess.execSync("git log --pretty=format:'%h' -n 1").toString().replace(/["']/g, '');
   const appVersion = pkg.version;
-  const minimumServerVersion = '6.0.0-dev.384';
+  const minimumServerVersion = '6.0.0-dev.388';
 
   process.env.VITE_GITHASH = gitHash;
   process.env.VITE_APPVERSION = appVersion;


### PR DESCRIPTION
## Summary

Updates the WebUI's ReleaseManagement query layer to match the renamed controller routes in [ShokoServer#1396](https://github.com/ShokoAnime/ShokoServer/pull/1396).

## Changes

### Folder split
Split the monolithic `release-management/` React Query layer into three domain-specific folders matching the new server controllers:

| Folder | Controllers | Endpoint Prefix |
|---|---|---|
| `duplicate-files/` (new) | DuplicateFilesController | `DuplicateFiles/*` |
| `missing-episodes/` (new) | MissingEpisodesController | `MissingEpisodes/*` |
| `release-management/` (updated) | ReleaseManagementController | `ReleaseManagement/*` |

### URL updates

| Old URL | New URL |
|---|---|
| `ReleaseManagement/DuplicateFiles/Series` | `DuplicateFiles/Series` |
| `ReleaseManagement/DuplicateFiles/Series/{id}/Episodes` | `DuplicateFiles/Series/{id}/Episodes` |
| `ReleaseManagement/MissingEpisodes/Series` | `MissingEpisodes/Series` |
| `ReleaseManagement/MissingEpisodes/Series/{id}/Episodes` | `MissingEpisodes/Series/{id}/Episodes` |
| `ReleaseManagement/MultipleReleases/Series` | `ReleaseManagement/Series` |
| `ReleaseManagement/MultipleReleases/Series/{id}` | `ReleaseManagement/Series/{id}` |
| `ReleaseManagement/MultipleReleases/Preview` | `ReleaseManagement/Preview` |
| `ReleaseManagement/MultipleReleases/Series/{id}/Override` | `ReleaseManagement/Series/{id}/Override` |
| `ReleaseManagement/MultipleReleases/Execute` | `ReleaseManagement/Execute` |

### Renames
- `useMultipleReleaseSeriesQuery` → `useReleaseManagementSeriesQuery`
- `useMultipleReleaseSeriesDetailQuery` → `useReleaseManagementSeriesDetailQuery`
- `MultipleReleasesSeriesRequestType` → `ReleaseManagementSeriesRequestType`
- `MultipleReleasesSeriesList` / `MultipleReleasesPreviewModal` components renamed to drop prefix
- Inlined `SeriesCandidateOverride` into `ReleaseDeletionPreviewRequestType`

### Query key updates
- DuplicateFiles domain: `['duplicate-files', ...]`
- MissingEpisodes domain: `['missing-episodes', ...]`
- ReleaseManagement domain: dropped `'multiple-releases'` middle segment

### SignalR
- Renamed `invalidateReleaseManagement` → `invalidateUtilities`
- Now invalidates all three query domains on `FileDeleted`/`FileMatched`

### Version bump
- Min server version: `6.0.0-dev.384` → `6.0.0-dev.388`