### PR TITLE
Attach response body breadcrumbs to Sentry API calls

### DIFF
--- a/src/core/axios.ts
+++ b/src/core/axios.ts
@@ -1,8 +1,10 @@
+import * as Sentry from '@sentry/react';
 import { create } from 'axios';
 
 import store from '@/core/store';
+import { isDebug } from '@/core/util';
 
-import type { InternalAxiosRequestConfig } from 'axios';
+import type { AxiosError, AxiosResponse, InternalAxiosRequestConfig } from 'axios';
 
 export const axios = create({
   baseURL: '/api/v3',
@@ -33,13 +35,54 @@ axios.interceptors.request.use(addApikeyInterceptor);
 axiosV2.interceptors.request.use(addApikeyInterceptor);
 axiosPlex.interceptors.request.use(addApikeyInterceptor);
 
+// Auth endpoints return the actual apikey in the response body - never attach it to a Sentry breadcrumb.
+const AUTH_URL_PATTERN = /^\/?auth/i;
+const MAX_BODY_LENGTH = 2000;
+
+const truncateBody = (data: unknown) => {
+  try {
+    const text = JSON.stringify(data) ?? '';
+    return text.length > MAX_BODY_LENGTH ? `${text.slice(0, MAX_BODY_LENGTH)}…[truncated]` : text;
+  } catch {
+    return undefined;
+  }
+};
+
+// Records a snapshot of the response body as a Sentry breadcrumb so that any error captured
+// afterwards (eg. a downstream TypeError from an unexpected shape) has the real payload attached,
+// not just the method/url/status that Sentry's automatic http breadcrumbs already provide.
+const addResponseBreadcrumb = (response: AxiosResponse, level: 'error' | 'info') => {
+  if (isDebug()) return;
+  const url = response.config?.url ?? '';
+  if (AUTH_URL_PATTERN.test(url)) return;
+
+  Sentry.addBreadcrumb({
+    category: 'api-response',
+    level,
+    data: {
+      method: response.config?.method?.toUpperCase(),
+      status: response.status,
+      url,
+      body: truncateBody(response.data),
+    },
+  });
+};
+
 // The type of response.data depends on the endpoint called. It has to be any.
 // We are only adding this interceptor so that we don't have to get response.data every time we call axios from react-query
-// oxlint-disable-next-line typescript/no-unsafe-return
-axios.interceptors.response.use(response => response.data);
-// oxlint-disable-next-line typescript/no-unsafe-return
-axiosV2.interceptors.response.use(response => response.data);
-// oxlint-disable-next-line typescript/no-unsafe-return
-axiosPlex.interceptors.response.use(response => response.data);
+const unwrapResponse = (response: AxiosResponse) => {
+  addResponseBreadcrumb(response, 'info');
+  // oxlint-disable-next-line typescript/no-unsafe-return
+  return response.data;
+};
+
+const handleResponseError = (error: AxiosError) => {
+  if (error.response) addResponseBreadcrumb(error.response, 'error');
+  return Promise.reject(error);
+};
+
+axios.interceptors.response.use(unwrapResponse, handleResponseError);
+axiosV2.interceptors.response.use(unwrapResponse, handleResponseError);
+axiosPlex.interceptors.response.use(unwrapResponse, handleResponseError);
 // oxlint-disable-next-line typescript/no-unsafe-return
 axiosExternal.interceptors.response.use(response => response.data);

--- a/src/core/axios.ts
+++ b/src/core/axios.ts
@@ -4,7 +4,7 @@ import { create } from 'axios';
 import store from '@/core/store';
 import { isDebug } from '@/core/util';
 
-import type { AxiosError, AxiosResponse, InternalAxiosRequestConfig } from 'axios';
+import type { AxiosError, AxiosRequestConfig, AxiosResponse, InternalAxiosRequestConfig } from 'axios';
 
 export const axios = create({
   baseURL: '/api/v3',
@@ -35,35 +35,44 @@ axios.interceptors.request.use(addApikeyInterceptor);
 axiosV2.interceptors.request.use(addApikeyInterceptor);
 axiosPlex.interceptors.request.use(addApikeyInterceptor);
 
-// Auth endpoints return the actual apikey in the response body - never attach it to a Sentry breadcrumb.
+// Auth endpoints return the actual apikey in the request/response body - never attach them to a Sentry breadcrumb.
 const AUTH_URL_PATTERN = /^\/?auth/i;
 const MAX_BODY_LENGTH = 2000;
 
 const truncateBody = (data: unknown) => {
+  if (data === undefined) return undefined;
   try {
-    const text = JSON.stringify(data) ?? '';
+    const text = typeof data === 'string' ? data : JSON.stringify(data) ?? '';
     return text.length > MAX_BODY_LENGTH ? `${text.slice(0, MAX_BODY_LENGTH)}…[truncated]` : text;
   } catch {
     return undefined;
   }
 };
 
-// Records a snapshot of the response body as a Sentry breadcrumb so that any error captured
-// afterwards (eg. a downstream TypeError from an unexpected shape) has the real payload attached,
-// not just the method/url/status that Sentry's automatic http breadcrumbs already provide.
-const addResponseBreadcrumb = (response: AxiosResponse, level: 'error' | 'info') => {
+// Records a snapshot of the request and response body as a Sentry breadcrumb so that any error
+// captured afterwards (eg. a downstream TypeError from an unexpected shape) has the real payload
+// attached, not just the method/url/status that Sentry's automatic http breadcrumbs already provide.
+// Also fires for network-level failures with no response (status 0), since config is still available.
+const addApiBreadcrumb = (
+  config: AxiosRequestConfig | undefined,
+  data: unknown,
+  status: number | undefined,
+  level: 'error' | 'info',
+) => {
   if (isDebug()) return;
-  const url = response.config?.url ?? '';
+  const url = config?.url ?? '';
   if (AUTH_URL_PATTERN.test(url)) return;
 
   Sentry.addBreadcrumb({
     category: 'api-response',
     level,
     data: {
-      method: response.config?.method?.toUpperCase(),
-      status: response.status,
+      method: config?.method?.toUpperCase(),
+      status,
       url,
-      body: truncateBody(response.data),
+      requestParams: truncateBody(config?.params),
+      requestBody: truncateBody(config?.data),
+      responseBody: truncateBody(data),
     },
   });
 };
@@ -71,13 +80,13 @@ const addResponseBreadcrumb = (response: AxiosResponse, level: 'error' | 'info')
 // The type of response.data depends on the endpoint called. It has to be any.
 // We are only adding this interceptor so that we don't have to get response.data every time we call axios from react-query
 const unwrapResponse = (response: AxiosResponse) => {
-  addResponseBreadcrumb(response, 'info');
+  addApiBreadcrumb(response.config, response.data, response.status, 'info');
   // oxlint-disable-next-line typescript/no-unsafe-return
   return response.data;
 };
 
 const handleResponseError = (error: AxiosError) => {
-  if (error.response) addResponseBreadcrumb(error.response, 'error');
+  addApiBreadcrumb(error.config, (error.response as AxiosResponse | undefined)?.data, error.response?.status, 'error');
   return Promise.reject(error);
 };
 


### PR DESCRIPTION
## Summary
- Sentry's automatic http breadcrumbs only record method/url/status/size, so diagnosing crashes caused by an unexpected server response shape currently means guessing at what the payload actually looked like.
- `axios`/`axiosV2`/`axiosPlex` response interceptors now record a truncated (≤2000 char) JSON snapshot of each response body as a Sentry breadcrumb, on both success and error, so any error captured afterward (e.g. a downstream `TypeError` from an unexpected shape) shows the real recent payloads in its timeline.
- Auth endpoints (`auth`, `auth/apikey`) are excluded since they return the raw apikey. The whole thing is gated on `!isDebug()` so it's a no-op locally (Sentry isn't initialized in dev anyway).

## Test plan
- [x] `pnpm dprint:fix` / `pnpm oxlint:fix` / `pnpm lint` clean on the changed file
- [x] `tsc --noEmit` reports no new errors
- [ ] Verify in a deployed build that a Sentry issue's breadcrumbs include an `api-response` entry with the response body, and that `auth`/`auth/apikey` calls are never captured

🤖 Generated with [Claude Code](https://claude.com/claude-code)