### PR TITLE
Auto-recover from the known React DOM removeChild/insertBefore race instead of showing the crash page

### DIFF
--- a/src/pages/SentryErrorBoundaryWrapper.tsx
+++ b/src/pages/SentryErrorBoundaryWrapper.tsx
@@ -1,4 +1,5 @@
-import { useEffect } from 'react';
+import { useEffect, useLayoutEffect, useRef } from 'react';
+import type { RefObject } from 'react';
 import { Outlet, useLocation } from 'react-router';
 import * as Sentry from '@sentry/react';
 import semver from 'semver';
@@ -8,10 +9,49 @@ import { useVersionQuery } from '@/core/react-query/init/queries';
 import { getMinimumServerVersion, isDebug } from '@/core/util';
 import useNavigateVoid from '@/hooks/useNavigateVoid';
 
+const RECOVERY_THROTTLE_MS = 5000;
+
+// Works around a documented React limitation, not specific to any React version: React doesn't support
+// something outside its control (a browser extension, a third-party script) mutating a DOM node it manages —
+// see https://react.dev/learn/manipulating-the-dom-with-refs ("Avoid changing DOM nodes managed by React") and
+// https://github.com/facebook/react/issues/17256 (still open; a Chrome extension causes this exact error) — a
+// later commit's removeChild/insertBefore then targets a node that's already gone. It isn't caused by our code —
+// seen on unrelated screens with frequent re-renders, e.g. /webui/firstrun/start-server (status polling) and
+// /webui/collection/filter/live (debounced search) — so we recover instead of showing the crash page.
+const isRecoverableDomRaceError = (error: unknown): error is Error =>
+  error instanceof Error
+  && error.name === 'NotFoundError'
+  && /Failed to execute '(removeChild|insertBefore)' on 'Node'/.test(error.message);
+
+type RaceRecoveryFallbackProps = {
+  error?: Error;
+  lastAutoRecoveredAtRef: RefObject<number>;
+  resetError: () => void;
+};
+
+const RaceRecoveryFallback = ({ error, lastAutoRecoveredAtRef, resetError }: RaceRecoveryFallbackProps) => {
+  const recoveryRef = lastAutoRecoveredAtRef;
+  const now = Date.now();
+  const canAutoRecover = isRecoverableDomRaceError(error)
+    && (now - recoveryRef.current > RECOVERY_THROTTLE_MS);
+
+  useLayoutEffect(() => {
+    if (!canAutoRecover) return;
+    recoveryRef.current = now;
+    resetError();
+    // oxlint-disable-next-line react-hooks/exhaustive-deps -- only re-run when the recoverability verdict changes
+  }, [canAutoRecover, resetError]);
+
+  if (canAutoRecover) return null;
+
+  return <ErrorBoundary error={error} resetError={resetError} />;
+};
+
 const SentryErrorBoundaryWrapper = () => {
   const { pathname } = useLocation();
   const navigate = useNavigateVoid();
   const versionQuery = useVersionQuery();
+  const lastAutoRecoveredAtRef = useRef(0);
 
   useEffect(() => {
     Sentry.setTag('server_release', versionQuery.data?.Server?.Version ?? 'Unknown');
@@ -34,7 +74,13 @@ const SentryErrorBoundaryWrapper = () => {
   return (
     <Sentry.ErrorBoundary
       // oxlint-disable-next-line typescript/unbound-method -- Not our code, so we cannot fix it
-      fallback={({ error, resetError }) => <ErrorBoundary error={error as Error} resetError={resetError} />}
+      fallback={({ error, resetError }) => (
+        <RaceRecoveryFallback
+          error={error as Error}
+          lastAutoRecoveredAtRef={lastAutoRecoveredAtRef}
+          resetError={resetError}
+        />
+      )}
     >
       <Outlet />
     </Sentry.ErrorBoundary>


### PR DESCRIPTION
## Summary

Sentry has been reporting an intermittent crash (issues SHOKO-WEBUI-195 and SHOKO-WEBUI-161):

`NotFoundError: Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node.`


This is a documented React limitation, not specific to React 19 or any particular version: React doesn't support something outside its control (a browser extension, a third-party script) mutating a DOM node it manages. See the [official docs](https://react.dev/learn/manipulating-the-dom-with-refs) ("Avoid changing DOM nodes managed by React") and [facebook/react#17256](https://github.com/facebook/react/issues/17256) (still open — a Chrome extension causes this exact error). A later commit's `removeChild`/`insertBefore` then targets a node that's already gone. It is not caused by application code.

### Investigation

Two independent crash sites were confirmed in Sentry, and neither points to a shared component we can patch:

- **`/webui/firstrun/start-server`** (most frequent) — `StartServer.tsx` polls server status every 500ms while the UI re-renders inside a `TransitionDiv` (Headless UI `<Transition>`).
- **`/webui/collection/filter/live`** (rarer) — `CollectionTitle.tsx`, plain conditional JSX with no Headless UI, no `react-virtual`, no `react-modal` — nothing exotic.

Several targeted hypotheses were investigated and ruled out with evidence before landing on this fix:
- A redirect race in `FirstRunPage` was ruled out — `isPersistent` is set `true` before polling starts, so the redirect guard can't fire while the crash is observed (confirmed via Sentry session replay).
- A Headless UI `Transition`-specific bug was ruled out — the second crash site doesn't use `Transition` (or any DOM-managing library) at all.

The only thing the two sites share is frequent state updates landing near a React commit — the generic signature of this class of bug, which can surface anywhere and isn't fixable by chasing individual components.

### Fix

`SentryErrorBoundaryWrapper.tsx` wraps the whole `webui` route tree in a single `Sentry.ErrorBoundary`. Previously, *any* uncaught error there rendered the disruptive "You Broke The Web UI!" page. This PR adds a fallback that recognizes this specific error signature (`error.name === 'NotFoundError'` + message matching `removeChild`/`insertBefore`) and silently calls `resetError()` instead, since the underlying app state is intact and only a single DOM commit glitched. A throttle guard (5s) prevents an infinite recovery loop if the error turns out to be persistent rather than transient. Sentry still captures the error for telemetry — only the user-facing crash page is suppressed.

Any other error still falls through to the existing crash page, unchanged.

### Verification

- `pnpm lint` and `tsc --noEmit` pass clean.
- The recoverable-error predicate was checked against realistic `removeChild`/`insertBefore` exceptions plus near-miss cases (unrelated errors, other `NotFoundError`s, non-`Error` throws) to confirm it only catches what it should.
- Not reproducible locally (likely requires a specific browser extension or third-party script), so the fix targets the documented failure mode rather than a local repro.
