### PR TITLE
refactor(tmdb): support DateKindaMatches rating, convert MatchRatingType to string union

### DIFF
--- a/src/components/Collection/Tmdb/MatchRating.tsx
+++ b/src/components/Collection/Tmdb/MatchRating.tsx
@@ -1,22 +1,24 @@
 import cx from 'classnames';
 
-import { MatchRatingType } from '@/core/types/api/episode';
+import type { MatchRatingType } from '@/core/types/api/episode';
 
 const getAbbreviation = (rating?: MatchRatingType) => {
   switch (rating) {
-    case MatchRatingType.DateAndTitleMatches:
+    case 'DateAndTitleMatches':
       return ['DT', 'Date & Title'];
-    case MatchRatingType.DateAndTitleKindaMatches:
+    case 'DateAndTitleKindaMatches':
       return ['~DT', 'Date & Approx. Title'];
-    case MatchRatingType.DateMatches:
+    case 'DateMatches':
       return ['D', 'Date'];
-    case MatchRatingType.TitleMatches:
+    case 'TitleMatches':
       return ['T', 'Title'];
-    case MatchRatingType.TitleKindaMatches:
+    case 'TitleKindaMatches':
       return ['~T', 'Approx. Title'];
-    case MatchRatingType.UserVerified:
+    case 'DateKindaMatches':
+      return ['~D', 'Approx. Date'];
+    case 'UserVerified':
       return ['UO', 'User Override'];
-    case MatchRatingType.FirstAvailable:
+    case 'FirstAvailable':
       return ['BG', 'Best Guess'];
     default:
       return ['', ''];
@@ -34,14 +36,14 @@ const MatchRating = ({ isDisabled, isOdd, rating }: Props) => (
     className={cx(
       'flex w-16 items-center justify-center rounded-md border border-panel-border text-button-primary-text',
       {
-        'bg-panel-text-important': rating === MatchRatingType.DateAndTitleMatches
-          || rating === MatchRatingType.TitleMatches,
-        'bg-panel-text-warning': rating === MatchRatingType.DateMatches || rating === MatchRatingType.TitleKindaMatches
-          || rating === MatchRatingType.DateAndTitleKindaMatches,
-        'bg-panel-text-primary': rating === MatchRatingType.UserVerified,
-        'bg-panel-text-danger': rating === MatchRatingType.FirstAvailable,
-        'bg-panel-background': (!rating || rating === MatchRatingType.None) && !isOdd,
-        'bg-panel-background-alt': (!rating || rating === MatchRatingType.None) && isOdd,
+        'bg-panel-text-important': rating === 'DateAndTitleMatches'
+          || rating === 'TitleMatches',
+        'bg-panel-text-warning': rating === 'DateMatches' || rating === 'TitleKindaMatches'
+          || rating === 'DateAndTitleKindaMatches' || rating === 'DateKindaMatches',
+        'bg-panel-text-primary': rating === 'UserVerified',
+        'bg-panel-text-danger': rating === 'FirstAvailable',
+        'bg-panel-background': (!rating || rating === 'None') && !isOdd,
+        'bg-panel-background-alt': (!rating || rating === 'None') && isOdd,
         'opacity-65': isDisabled,
       },
     )}

--- a/src/components/Collection/Tmdb/TopPanel.tsx
+++ b/src/components/Collection/Tmdb/TopPanel.tsx
@@ -7,9 +7,9 @@ import { countBy, filter, flatMap } from 'lodash';
 import Button from '@/components/Input/Button';
 import ShokoPanel from '@/components/Panels/ShokoPanel';
 import ItemCount from '@/components/Utilities/ItemCount';
-import { MatchRatingType } from '@/core/types/api/episode';
 import useNavigateVoid from '@/hooks/useNavigateVoid';
 
+import type { MatchRatingType } from '@/core/types/api/episode';
 import type { TmdbEpisodeXrefType } from '@/core/types/api/tmdb';
 
 type Props = {
@@ -30,7 +30,7 @@ const TopPanel = (props: Props) => {
       if (!xrefs) return undefined;
       return filter(
         flatMap(xrefs, xref => xref),
-        xref => xref.Rating !== MatchRatingType.None,
+        xref => xref.Rating !== 'None',
       );
     },
     [xrefs],
@@ -65,7 +65,7 @@ const TopPanel = (props: Props) => {
           <div className="flex items-center gap-x-2">
             <div className="rounded-md bg-panel-text-warning px-2 text-button-primary-text">
               {(matchRatingCounts.DateAndTitleKindaMatches ?? 0) + (matchRatingCounts.DateMatches ?? 0)
-                + (matchRatingCounts.TitleKindaMatches ?? 0)}
+                + (matchRatingCounts.TitleKindaMatches ?? 0) + (matchRatingCounts.DateKindaMatches ?? 0)}
             </div>
             Approximate
           </div>

--- a/src/core/types/api/episode.ts
+++ b/src/core/types/api/episode.ts
@@ -58,13 +58,13 @@ export type AniDBEpisodeType = {
   Rating: RatingType;
 };
 
-export enum MatchRatingType {
-  UserVerified = 'UserVerified',
-  DateAndTitleKindaMatches = 'DateAndTitleKindaMatches',
-  DateAndTitleMatches = 'DateAndTitleMatches',
-  DateMatches = 'DateMatches',
-  TitleKindaMatches = 'TitleKindaMatches',
-  TitleMatches = 'TitleMatches',
-  FirstAvailable = 'FirstAvailable',
-  None = 'None',
-}
+export type MatchRatingType =
+  | 'DateAndTitleKindaMatches'
+  | 'DateAndTitleMatches'
+  | 'DateKindaMatches'
+  | 'DateMatches'
+  | 'FirstAvailable'
+  | 'None'
+  | 'TitleKindaMatches'
+  | 'TitleMatches'
+  | 'UserVerified';

--- a/src/pages/collection/series/TmdbLinking.tsx
+++ b/src/pages/collection/series/TmdbLinking.tsx
@@ -30,7 +30,7 @@ import {
   useTmdbShowOrMovieQuery,
 } from '@/core/react-query/tmdb/queries';
 import toast from '@/core/toast';
-import { EpisodeTypeEnum, MatchRatingType } from '@/core/types/api/episode';
+import { EpisodeTypeEnum } from '@/core/types/api/episode';
 import { getAnidbAnimeLink } from '@/core/util';
 import useFlattenListResult from '@/hooks/useFlattenListResult';
 import useNavigateVoid from '@/hooks/useNavigateVoid';
@@ -185,7 +185,7 @@ const TmdbLinking = () => {
           TmdbShowID: tmdbId,
           TmdbEpisodeID: overrideId,
           Index: index,
-          Rating: MatchRatingType.UserVerified,
+          Rating: 'UserVerified',
         });
       });
     });


### PR DESCRIPTION
## Summary
- Follow-up to [ShokoAnime/ShokoServer#1389](https://github.com/ShokoAnime/ShokoServer/pull/1389) (season-scoped nearest-air-date TMDB fallback), which adds a new `DateKindaMatches` match rating on the server.
- Converts `MatchRatingType` from a TS enum to a string union, per [harshithmohan's review comment](https://github.com/ShokoAnime/ShokoServer/pull/1389#discussion_r3704218385) on that PR.
- Adds `DateKindaMatches` to the abbreviation/color mapping in `MatchRating.tsx` and the "Approximate" count bucket in `TopPanel.tsx`.

[ShokoAnime/ShokoServer#1389](https://github.com/ShokoAnime/ShokoServer/pull/1389) has merged upstream — ready for review.

## Test plan
- [x] `pnpm lint` (dprint + oxlint) passes
- [x] `pnpm tscheck` passes
- [ ] Manual verification against a server build that includes [ShokoAnime/ShokoServer#1389](https://github.com/ShokoAnime/ShokoServer/pull/1389)'s `DateKindaMatches` rating

## Rebase history
- 2026-08-13 17:30 UTC — rebased onto `master` @ `e963cede` (1 commits), now at `a9ab2385`
- 2026-08-16 09:20 UTC — rebased onto `master` @ `f3ab53be` (1 commits), now at `b788423a`
