### PR TITLE
Rework collection filter format to align with server, add preset editing

### DIFF
--- a/docs/FILTERS.md
+++ b/docs/FILTERS.md
@@ -1,0 +1,330 @@
+# Collection Filter System
+
+Developer-level specification for the Collection filter builder
+(`src/components/Collection/Filter/`) and its supporting layers
+(`src/core/utilities/filterTree.ts`, `src/core/slices/collection.ts`,
+`src/core/react-query/filter/`). Covers the data model, the bidirectional
+conversion between the server's expression tree and the editable UI state, and
+how to extend the system to support additional server expression types.
+
+This document describes the *current, shipped* implementation, not a design
+proposal. Where something is intentionally unsupported, that's called out
+explicitly along with why.
+
+## 1. Server contract
+
+The Shoko Server backend exposes collection filters as a generic binary
+expression tree. The relevant API v3 shapes (`Shoko.Server/API/v3/Models/Shoko/Filter.cs`)
+are:
+
+```csharp
+class FilterCondition {
+    string Type;              // e.g. "And", "Not", "HasTag", "InYear"
+    FilterCondition? Left;
+    FilterCondition? Right;
+    string? Parameter;
+    string? SecondParameter;
+}
+```
+
+A `Filter` (saved preset) carries an optional `Expression: FilterCondition` (no
+`Expression` at all means "match everything") plus `Name`, `Sorting`,
+`IsDirectory`, `IsHidden`, `ApplyAtSeriesLevel`, and parent/ID fields.
+
+The server also exposes a **self-describing catalog** via
+`GET /api/v3/Filter/Expressions`, returning one entry per known expression
+type:
+
+```csharp
+class FilterExpressionHelp {
+    string Expression;   // wire type name, e.g. "HasTag", "NumberGreaterThan"
+    string Name;
+    string Description;
+    string Group;         // "Info" | "Logic" | "Function" | "Selector"
+    string Type;           // this expression's own return type, e.g. "Expression" (bool),
+                            // "NumberSelector", "DateSelector", "StringSelector", "StringSetSelector"
+    string? Left;          // required type of the Left slot, if this expression has one
+    string? Right;         // required type of the Right slot, if this expression has one
+    string? Parameter;     // required type of the constant Parameter slot, if any
+    string? SecondParameter;
+    string[]? PossibleParameters;       // live-computed valid values, e.g. all known tags/years
+    string[]? PossibleSecondParameters;
+    string[][]? PossibleParameterPairs; // e.g. [year, season] pairs for InSeason
+}
+```
+
+**`Group` has exactly four values** (`Shoko.Abstractions/Filtering/Expressions/FilterExpressionGroup.cs`):
+`Info`, `Logic`, `Function`, `Selector`. It defaults to `Info` on the base
+`FilterExpression<T>` class and is only overridden by combinators/comparisons
+(`Logic`), `Today`/`DateAdd`/`DateDiff` (`Function`), and the ~106 leaf
+value-getters like `EpisodeCountSelector` (`Selector`). Notably, **every
+predicate under the C# `Info/`, `Files/`, and `User/` source folders reports
+`Group: "Info"`** — the folder is a source-organization convenience, not the
+wire-level group. There is no "Files" or "User" `Group` value; don't assume
+one when reading older design notes.
+
+Full details on the server side, including the concrete expression catalog
+and known serialization quirks, live in `Shoko.Server/Filters/readme.md` and
+are summarized in §7 below.
+
+## 2. WebUI data model
+
+`src/core/types/api/filter.ts` mirrors the wire DTOs (`FilterCondition`,
+`FilterExpression`, `SortingCriteria`, `CreateOrUpdateFilterType`, `FilterType`)
+and additionally defines the **editable UI tree**:
+
+```ts
+type LeafValue =
+  | { kind: 'boolean'; value: boolean }
+  | { kind: 'multi'; values: string[]; match: 'And' | 'Or' }
+  | { kind: 'multiPair'; values: [string, string][]; match: 'And' | 'Or' }
+  | { kind: 'tag'; tags: FilterTag[] }; // FilterTag = { Name: string; isExcluded: boolean }
+
+type LeafNode = { id: string; kind: 'leaf'; expression: string; negate: boolean; value: LeafValue };
+type GroupNode = { id: string; kind: 'group'; operator: 'And' | 'Or'; negate: boolean; children: TreeNode[] };
+type UnsupportedNode = { id: string; kind: 'unsupported'; raw: FilterCondition };
+type TreeNode = LeafNode | GroupNode | UnsupportedNode;
+```
+
+Redux (`src/core/slices/collection.ts`, slice `collection`) holds `tree:
+GroupNode | null` as the single source of truth for the sidebar. The root is
+always either `null` (no filter) or a `GroupNode` — never a bare `LeafNode` —
+so every consumer can rely on one shape. Nodes are addressed by generated
+`id` (`crypto.randomUUID()`, see `generateNodeId` in `filterTree.ts`), not by
+expression name, so the same expression can legitimately appear more than
+once in the tree (two independent `InYear` conditions in different branches,
+for example) — something the old flat, map-by-expression-name model could
+not represent.
+
+`UnsupportedNode.raw` holds the **original, untouched `FilterCondition`
+subtree** for anything the editable widgets can't represent. It is never
+partially interpreted — building the tree back into a `FilterCondition`
+returns `raw` byte-for-byte.
+
+## 3. Bidirectional conversion (`src/core/utilities/filterTree.ts`)
+
+### `getWidgetKind(entry: FilterExpression): 'boolean' | 'multi' | 'multiPair' | 'tag'`
+
+The single source of truth for how a catalog entry maps to a leaf widget:
+
+1. `HasTag` / `HasCustomTag` → `'tag'` (hardcoded by name — see §6, this is the
+   one place expression identity is checked directly instead of shape,
+   because their value source is a separate tag-search API, not
+   `PossibleParameters`).
+2. Has `PossibleParameterPairs` → `'multiPair'`.
+3. Has `PossibleParameters`, or `Parameter === 'Number'` → `'multi'`.
+4. Otherwise → `'boolean'`.
+
+### `parseFilterTree(condition, catalog): GroupNode | null`
+
+Total — always succeeds, never throws. Recursively walks the `FilterCondition`
+tree:
+
+- `And` / `Or` nodes recursively flatten same-operator chains into one
+  `GroupNode` (so a right-leaning `And(a, And(b, And(c, d)))` becomes one
+  4-child group, not 3 nested ones).
+- `Not(And(...)|Or(...))` negates the resulting `GroupNode` in place
+  (`negate: true`) rather than wrapping it opaquely — this is what lets
+  `Not(Or(HasTvDBLink, HasTmdbLink))` round-trip as an editable negated `Or`
+  group instead of becoming unsupported.
+- `Not(<leaf>)` is absorbed directly into the leaf: boolean leaves flip their
+  `value.value`; tag leaves set `isExcluded` per-tag; multi/multiPair leaves
+  set `negate: true` on the leaf itself.
+- Sibling leaves of the *same expression* produced by chaining multiple
+  values under one operator (e.g. `HasTag('a') And HasTag('b')`, or
+  `Or(InYear(2020), InYear(2021))`) are merged back into **one** multi-value
+  widget row instead of showing one row per value (`mergeGroupChildren`).
+  Merging is skipped for a negated multi/multiPair leaf, since a per-value
+  `Not` can't be folded into a shared value list without losing its meaning.
+- Anything else — a leaf whose catalog entry has a `Left` or `Right` slot
+  (comparison operators, `Function` calls plumbed with `Selector`s), or an
+  expression not found in the catalog at all — becomes an `UnsupportedNode`,
+  and recursion stops there.
+- If the root condition isn't itself a plain `And`, it's wrapped as the sole
+  child of an implicit top-level `And` `GroupNode` so Redux state always has
+  one shape (see §2).
+
+### `buildFilterTree(node: GroupNode | null): FilterCondition | undefined`
+
+The inverse, and much simpler since it's not trying to recover a "natural"
+shape: `null`/empty tree → `undefined` (omit `Expression` from the request
+entirely). Groups build a right-leaning `And`/`Or` chain over their built
+children (wrapped in `Not` if negated). Leaves expand back into one
+`FilterCondition` per multi/tag value, chained by the leaf's own `match`
+operator. `UnsupportedNode` returns `raw` unchanged.
+
+**Note:** `buildFilterTree` does not attempt to preserve the original tree's
+exact nesting shape — AND is associative, so a left-leaning input tree may
+come back right-leaning after a round trip. This is semantically identical
+and matches how the pre-tree-rewrite flat builder already behaved; only
+`UnsupportedNode` subtrees are preserved byte-for-byte.
+
+## 4. Component architecture
+
+```
+FilterSidebar.tsx          — panel shell: title, Save/Save Changes/Clear Filter, renders root FilterGroup
+  FilterGroup.tsx           — recursive: renders one GroupNode's chrome + children + Add controls
+    FilterGroup.tsx          (nested groups recurse into themselves)
+    FilterLeaf.tsx           — dispatches a LeafNode to the right widget by `value.kind`
+      DefaultCriteria.tsx      — boolean toggle (True/False)
+      MultiValueCriteria.tsx   — multi/multiPair display row → MultiValueCriteriaModal.tsx
+      TagCriteria.tsx          — tag display row → TagCriteriaModal.tsx
+      Criteria.tsx             — shared card chrome (name, NOT toggle, edit/remove icons,
+                                  modal launcher) used by MultiValueCriteria/TagCriteria
+    UnsupportedCondition.tsx — read-only card, remove-only
+  AddCriteriaModal.tsx      — "add condition to this group" (per-group instance)
+NotToggle.tsx               — shared NOT button (leaf + group headers)
+SavePresetModal.tsx         — "Save as new preset" (create only; unchanged by this system)
+```
+
+Leaf widgets read/write a specific `LeafNode` by `id` via the slice's
+`updateLeafValue`/`setNegate` actions — they do not know about the tree
+structure around them.
+
+## 5. Progressive disclosure
+
+The sidebar looks and behaves exactly like a flat AND list until there's a
+reason not to:
+
+- A `GroupNode`'s header chrome (Match ALL/ANY dropdown, NOT toggle) is
+  hidden when `isRoot && operator === 'And' && !negate` — i.e. the root of a
+  plain AND tree, which is all "+ Add condition" alone ever produces.
+- Chrome reappears automatically the moment it's load-bearing: a loaded
+  preset whose root is actually `Or` and/or negated shows it immediately
+  (never silently misrepresented), and any nested group (added via
+  "+ Add group") always shows its own chrome, since choosing to nest is
+  itself the deliberate advanced action.
+- Per-row NOT is a real `Button` (blue when active, not red — red reads as
+  disabled/error rather than "toggled on"; see `NotToggle.tsx`), available on
+  every leaf that isn't boolean/tag-kind (see §3) and every group.
+
+## 6. Scope boundaries — what's supported and why
+
+Only expressions whose catalog entry has **no `Left`/`Right` slot** (a plain
+boolean predicate, optionally with a single constant `Parameter` or a
+`Parameter`+`SecondParameter` pair) are representable as an editable leaf.
+Concretely, that means:
+
+- ✅ Everything in `Group: "Info"` that takes 0–2 constant parameters — the
+  majority of real-world filters (`HasTag`, `InYear`, `IsFinished`,
+  `HasAudioLanguage`, `IsFavorite`, `InSeason`, etc.), regardless of which C#
+  source folder (`Info/`, `Files/`, `User/`) they live in (see §1 — they all
+  report `Group: "Info"`).
+- ❌ `Group: "Logic"` comparison operators (`NumberGreaterThan`,
+  `StringContains`, `DateGreaterThanEquals`, ...) and `Group: "Function"`
+  calls (`Today`, `DateAdd`, `DateDiff`) — these plumb `Selector`s or other
+  expressions into `Left`/`Right` instead of taking a constant `Parameter`.
+- ❌ `Group: "Selector"` entries on their own — they're value-getters
+  (`EpisodeCountSelector`, `LastWatchedDate`, ...), not boolean predicates;
+  they only make sense as the `Left`/`Right` of a `Logic`/`Function`
+  expression, which is itself unsupported.
+
+**This is a deliberate, standing product boundary, not a temporary gap.**
+The filter sidebar was originally kept as a flat AND-only list because a full
+expression tree felt too complex for the actual (non-programmer) user base;
+the tree rewrite added AND/OR/NOT grouping because real usage needed it
+(confirmed by the shipped default filters), but exposing `DateDiff`-style
+comparison logic was explicitly ruled out even for that follow-up — it's
+considered hard to reason about even for programmers, let alone the target
+audience. `UnsupportedCondition.tsx`'s copy ("uses advanced logic that can't
+be edited here") is intentionally worded to not imply this is coming later.
+Any change here needs a product decision, not just an engineering one.
+
+Unsupported subtrees are always preserved verbatim (`UnsupportedNode.raw`) —
+editing part of a preset can never silently corrupt a part built by another
+tool or hand-crafted against the API directly.
+
+## 7. Known wire-format quirks
+
+- **`': '`-joined parameter pairs**: fixed in this system. `LeafValue.multiPair`
+  carries real `[string, string]` tuples end-to-end; the join only happens
+  transiently inside `MultiValueCriteriaModal` to build a display string for
+  its option list (matched back against the catalog's original pair, not
+  re-split, so a value containing `': '` can't be misinterpreted).
+- **`StringSet`-typed `Parameter` values** (`IWithStringSetParameter`, e.g.
+  `StringInExpression`, `SetOverlapsExpression`): the server serializes these
+  by joining with `|||` but deserializes by stripping the first and last
+  character of the parameter string before splitting
+  (`Shoko.Server/API/v3/Helpers/FilterFactory.cs`, `GetExpressionTree`) — an
+  apparent server-side bug/quirk. None of the currently-supported leaf kinds
+  (§6) hit this path today. If you add support for a `StringSet`-parameter
+  expression, verify the actual wire round-trip against a running server
+  before shipping — it's undocumented and not covered by any test.
+
+## 8. Adding support for a new expression
+
+### 8a. A new simple `Info`-group expression — no frontend change needed
+
+If the server adds a new `Group: "Info"` expression with 0–2 constant
+`Parameter`s (optionally with `PossibleParameters`/`PossibleParameterPairs`),
+it becomes usable automatically: `getWidgetKind` classifies it by shape, the
+catalog fetch (`useFilterExpressionsQuery` / `useAllFilterExpressionsQuery`,
+`src/core/react-query/filter/queries.ts`) already returns it, and
+`AddCriteriaModal` already lists every `Group: "Info"` entry
+(`transformFilterExpressions`, `src/core/react-query/filter/helpers.ts`). No
+code changes required.
+
+The one exception is `'tag'`-kind widgets: they're hardcoded to `HasTag` /
+`HasCustomTag` by name (`TAG_LIKE_EXPRESSIONS` in `filterTree.ts`) because
+their value source is a dedicated search endpoint
+(`useAniDBTagsQuery`/`useUserTagsQuery`), not `PossibleParameters`. A new
+tag-like expression with its own bespoke value source would need its own
+name added to that set, its own query hook, and its own branch in
+`TagCriteriaModal.tsx` (which currently branches on
+`catalogEntry.Expression === 'HasTag'` to choose the AniDB vs. user tag
+query).
+
+### 8b. Widening visibility beyond `Group: "Info"`
+
+Not currently needed in practice — see §1/§6, everything simple enough for
+the current widgets already reports `Group: "Info"`. If a future server
+change puts a simple, no-`Left`/`Right` expression under `Logic`/`Function`/
+`Selector` for some reason, widen the filter in
+`transformFilterExpressions` (`helpers.ts`) — it's a one-line change
+(`item.Group === 'Info'` → whatever's needed), and `parseFilterTree` already
+accepts the *full*, unfiltered catalog (via `useAllFilterExpressionsQuery`),
+so previously-unrecognized-but-shape-compatible leaves in an existing preset
+would already parse as editable even without this change — only the "Add
+condition" dropdown is currently scoped to `Info`.
+
+### 8c. A comparison/Function expression (e.g. `DateDiff`) — architecture extension
+
+This is **not implemented and not currently planned** (§6) — treat the
+following as a design sketch for if/when product direction changes, not a
+todo.
+
+An expression like `DateGreaterThanEquals(Left: DateSelector, Right:
+DateSelector | Parameter)` doesn't fit the current `LeafValue` shapes at all:
+it needs to hold a nested sub-expression (a `Selector`), not just a flat
+constant. Supporting it end-to-end would require:
+
+1. **A new `LeafValue` kind** capable of holding a `Left`/`Right` pair of
+   nested `TreeNode`s (or a dedicated smaller structure just for
+   selector-comparison expressions, if scoping this to only a few known
+   comparison shapes rather than the fully generic case).
+2. **Extending `getWidgetKind`** to recognize the new shape — e.g. a
+   `'comparison'` kind for entries whose `Left`/`Right` types are
+   `*Selector` — and to classify the `Selector`-group entries themselves (a
+   `DateSelector` like `Today`/`LastWatchedDate`/`DateAdd` needs its own
+   pickable identity and, for `DateAdd`, its own `TimeSpan` parameter input).
+3. **Extending `parseAtomicCondition`** (or adding a parallel parse branch)
+   to recurse into `Left`/`Right` instead of rejecting any entry that has
+   them — this is the check at `filterTree.ts`: `if (!entry || entry.Left ||
+   entry.Right) return unsupported(condition);`. The recursive parse needs
+   its own termination rule for selector chains (e.g. `DateDiff(DateAdd(Today,
+   ...), ...)` is itself a `Function` composed of other `Function`/`Selector`
+   nodes) — decide how deep to support before falling back to
+   `UnsupportedNode` again.
+4. **Extending `buildLeafValue`** to reconstruct the nested `Left`/`Right`
+   `FilterCondition` from the new `LeafValue` shape.
+5. **A new leaf widget** (e.g. `DateComparisonCriteria.tsx` +
+   `DateComparisonCriteriaModal.tsx`) following the existing card + edit-modal
+   pattern (§4), with real UI controls for: picking the comparison operator,
+   picking/building the `Left` selector chain, and entering constant
+   operands (a duration input for `TimeSpan` parameters, etc.).
+6. **Registering the new kind** in `FilterLeaf.tsx`'s dispatch switch.
+7. Deciding whether/how to surface it in `AddCriteriaModal` given it's
+   `Group: "Logic"`/`"Function"`, not `"Info"` (see §8b).
+
+Steps 1–4 are a meaningful data-model and parser change, not a leaf-widget
+add — plan for it as such, and get explicit product sign-off first (§6).

--- a/src/components/Collection/Filter/AddCriteriaModal.tsx
+++ b/src/components/Collection/Filter/AddCriteriaModal.tsx
@@ -6,23 +6,22 @@ import Button from '@/components/Input/Button';
 import Select from '@/components/Input/Select';
 import ModalPanel from '@/components/Panels/ModalPanel';
 import { useFilterExpressionsQuery } from '@/core/react-query/filter/queries';
-import { addFilterCriteria, selectActiveCriteria } from '@/core/slices/collection';
+import { addLeaf, selectUsedExpressionsInGroup } from '@/core/slices/collection';
 import { useDispatch, useSelector } from '@/core/store';
 
-import type { FilterExpression } from '@/core/types/api/filter';
-
 type Props = {
-  show: boolean;
+  groupId: string;
   onClose: () => void;
+  show: boolean;
 };
 
-const AddCriteriaModal = ({ onClose, show }: Props) => {
+const AddCriteriaModal = ({ groupId, onClose, show }: Props) => {
   const dispatch = useDispatch();
   const allCriteria = useFilterExpressionsQuery(show).data;
-  const selectedKeys = useSelector(selectActiveCriteria);
-  const unusedCriteria = useMemo(() => filter(allCriteria, item => !selectedKeys.includes(item.Expression)), [
+  const usedKeys = useSelector(state => selectUsedExpressionsInGroup(state, groupId));
+  const unusedCriteria = useMemo(() => filter(allCriteria, item => !usedKeys.includes(item.Expression)), [
     allCriteria,
-    selectedKeys,
+    usedKeys,
   ]);
   const [newCriteria, setNewCriteria] = useState('');
 
@@ -32,8 +31,9 @@ const AddCriteriaModal = ({ onClose, show }: Props) => {
   };
 
   const handleSave = () => {
-    const filterExpression = filter(allCriteria, { Expression: newCriteria })[0] as FilterExpression;
-    dispatch(addFilterCriteria(filterExpression));
+    const filterExpression = filter(allCriteria, { Expression: newCriteria })[0];
+    if (!filterExpression) return;
+    dispatch(addLeaf({ entry: filterExpression, groupId }));
     handleClose();
   };
 

--- a/src/components/Collection/Filter/Criteria.tsx
+++ b/src/components/Collection/Filter/Criteria.tsx
@@ -2,46 +2,37 @@ import { useEffect, useMemo, useState } from 'react';
 import type { ReactNode } from 'react';
 import { mdiCircleEditOutline, mdiMinusCircleOutline } from '@mdi/js';
 import { Icon } from '@mdi/react';
+import cx from 'classnames';
 
 import MultiValueCriteriaModal from '@/components/Collection/Filter/MultiValueCriteriaModal';
 import TagCriteriaModal from '@/components/Collection/Filter/TagCriteriaModal';
-import { removeFilterCriteria, selectFilterMatch } from '@/core/slices/collection';
-import { useDispatch, useSelector } from '@/core/store';
 
-import type { FilterExpression } from '@/core/types/api/filter';
+import type { FilterExpression, LeafNode } from '@/core/types/api/filter';
 
-type ModalType = 'tag' | 'multivalue';
+type ModalType = 'multivalue' | 'tag';
 
 type Props = {
-  criteria: FilterExpression;
+  catalogEntry: FilterExpression;
+  node: LeafNode;
+  onRemove: () => void;
+  onToggleNegate?: () => void;
   parameterExists: boolean;
   transformedParameter: ReactNode;
   type: ModalType;
 };
 
-const getModalComponent = (type: ModalType) => {
-  switch (type) {
-    case 'multivalue':
-      return MultiValueCriteriaModal;
-    case 'tag':
-    default:
-      return TagCriteriaModal;
-  }
-};
+const getModalComponent = (type: ModalType) => (type === 'multivalue' ? MultiValueCriteriaModal : TagCriteriaModal);
 
-const ParameterList = ({ expression, value }: { expression: string, value: string }) => {
-  const filterMatch = useSelector(state => selectFilterMatch(state, expression));
+const ParameterList = ({ match, value }: { match: 'And' | 'Or', value: string }) => (
+  <div className="line-clamp-2">
+    <span className="pr-2 text-panel-text-important">{match === 'Or' ? 'In:' : 'All:'}</span>
+    {value}
+  </div>
+);
 
-  return (
-    <div className="line-clamp-2">
-      <span className="pr-2 text-panel-text-important">{filterMatch === 'Or' ? 'In:' : 'All:'}</span>
-      {value}
-    </div>
-  );
-};
-
-const Criteria = ({ criteria, parameterExists, transformedParameter, type }: Props) => {
-  const dispatch = useDispatch();
+const Criteria = (
+  { catalogEntry, node, onRemove, onToggleNegate, parameterExists, transformedParameter, type }: Props,
+) => {
   const [showModal, setShowModal] = useState(false);
 
   const openModal = () => {
@@ -52,23 +43,36 @@ const Criteria = ({ criteria, parameterExists, transformedParameter, type }: Pro
     setShowModal(false);
   };
 
-  const removeCriteria = () => {
-    dispatch(removeFilterCriteria(criteria));
-  };
-
   useEffect(() => {
     if (parameterExists) return;
     setShowModal(true);
   }, [parameterExists]);
 
   const Modal = useMemo(() => getModalComponent(type), [type]);
+  const match = node.value.kind === 'multi' || node.value.kind === 'multiPair' ? node.value.match : 'Or';
 
   return (
     <>
       <div className="flex flex-col">
         <div className="mb-3 flex items-center justify-between">
-          <div className="font-semibold">
-            {criteria.Name}
+          <div className="flex items-center gap-x-2 font-semibold">
+            {onToggleNegate && (
+              <span
+                className={cx(
+                  'cursor-pointer rounded-sm border px-1.5 text-xs',
+                  node.negate
+                    ? 'border-panel-icon-danger text-panel-icon-danger'
+                    : 'border-panel-border text-panel-text-important',
+                )}
+                onClick={onToggleNegate}
+                data-tooltip-id="tooltip"
+                data-tooltip-content="Toggle NOT"
+                data-tooltip-delay-show={500}
+              >
+                NOT
+              </span>
+            )}
+            {catalogEntry.Name}
           </div>
           <div className="flex gap-x-2">
             <div onClick={openModal}>
@@ -81,7 +85,7 @@ const Criteria = ({ criteria, parameterExists, transformedParameter, type }: Pro
                 data-tooltip-delay-show={500}
               />
             </div>
-            <div onClick={removeCriteria}>
+            <div onClick={onRemove}>
               <Icon
                 className="cursor-pointer text-panel-icon-danger"
                 path={mdiMinusCircleOutline}
@@ -100,17 +104,18 @@ const Criteria = ({ criteria, parameterExists, transformedParameter, type }: Pro
                 className="flex cursor-pointer rounded-lg border border-panel-border bg-panel-input px-4 py-3"
                 onClick={openModal}
               >
-                <ParameterList expression={criteria.Expression} value={transformedParameter} />
+                <ParameterList match={match} value={transformedParameter} />
               </div>
             )
             : transformedParameter}
         </div>
       </div>
       <Modal
-        criteria={criteria}
+        catalogEntry={catalogEntry}
+        node={node}
         show={showModal}
         onClose={closeModal}
-        removeCriteria={removeCriteria}
+        onRemove={onRemove}
       />
     </>
   );

--- a/src/components/Collection/Filter/Criteria.tsx
+++ b/src/components/Collection/Filter/Criteria.tsx
@@ -2,9 +2,9 @@ import { useEffect, useMemo, useState } from 'react';
 import type { ReactNode } from 'react';
 import { mdiCircleEditOutline, mdiMinusCircleOutline } from '@mdi/js';
 import { Icon } from '@mdi/react';
-import cx from 'classnames';
 
 import MultiValueCriteriaModal from '@/components/Collection/Filter/MultiValueCriteriaModal';
+import NotToggle from '@/components/Collection/Filter/NotToggle';
 import TagCriteriaModal from '@/components/Collection/Filter/TagCriteriaModal';
 
 import type { FilterExpression, LeafNode } from '@/core/types/api/filter';
@@ -56,22 +56,7 @@ const Criteria = (
       <div className="flex flex-col">
         <div className="mb-3 flex items-center justify-between">
           <div className="flex items-center gap-x-2 font-semibold">
-            {onToggleNegate && (
-              <span
-                className={cx(
-                  'cursor-pointer rounded-sm border px-1.5 text-xs',
-                  node.negate
-                    ? 'border-panel-icon-danger text-panel-icon-danger'
-                    : 'border-panel-border text-panel-text-important',
-                )}
-                onClick={onToggleNegate}
-                data-tooltip-id="tooltip"
-                data-tooltip-content="Toggle NOT"
-                data-tooltip-delay-show={500}
-              >
-                NOT
-              </span>
-            )}
+            {onToggleNegate && <NotToggle negate={node.negate} onToggle={onToggleNegate} />}
             {catalogEntry.Name}
           </div>
           <div className="flex gap-x-2">

--- a/src/components/Collection/Filter/DefaultCriteria.tsx
+++ b/src/components/Collection/Filter/DefaultCriteria.tsx
@@ -1,17 +1,17 @@
-import { useEffect } from 'react';
 import type { ChangeEvent } from 'react';
 import { mdiMinusCircleOutline } from '@mdi/js';
 import { Icon } from '@mdi/react';
 
 import Select from '@/components/Input/Select';
-import { addFilterCondition, removeFilterCriteria } from '@/core/slices/collection';
-import { useDispatch, useSelector } from '@/core/store';
+import { updateLeafValue } from '@/core/slices/collection';
+import { useDispatch } from '@/core/store';
 
-import type { RootState } from '@/core/store';
-import type { FilterExpression } from '@/core/types/api/filter';
+import type { FilterExpression, LeafNode } from '@/core/types/api/filter';
 
 type Props = {
-  criteria: FilterExpression;
+  catalogEntry: FilterExpression;
+  node: LeafNode;
+  onRemove: () => void;
 };
 
 const Options = ({ onClick }: { onClick: () => void }) => (
@@ -20,39 +20,24 @@ const Options = ({ onClick }: { onClick: () => void }) => (
   </div>
 );
 
-const DefaultCriteria = ({ criteria }: Props) => {
+const DefaultCriteria = ({ catalogEntry, node, onRemove }: Props) => {
   const dispatch = useDispatch();
-  const selectedCondition = useSelector(
-    (state: RootState) => {
-      const value: boolean | undefined = state.collection.filterConditions[criteria.Expression];
-      if (value !== undefined) {
-        return value ? '1' : '0';
-      }
-      return value;
-    },
-  );
-
-  useEffect(() => {
-    if (selectedCondition === undefined) {
-      dispatch(addFilterCondition({ [criteria.Expression]: true }));
-    }
-  }, [criteria.Expression, dispatch, selectedCondition]);
+  const value = node.value.kind === 'boolean' ? node.value.value : true;
 
   const changeValue = (event: ChangeEvent<HTMLSelectElement>) => {
-    dispatch(addFilterCondition({ [criteria.Expression]: event.currentTarget.value === '1' }));
-  };
-
-  const removeCriteria = () => {
-    dispatch(removeFilterCriteria(criteria));
+    dispatch(updateLeafValue({
+      nodeId: node.id,
+      value: { kind: 'boolean', value: event.currentTarget.value === '1' },
+    }));
   };
 
   return (
     <Select
-      id={criteria.Expression}
-      label={criteria.Name}
-      value={selectedCondition}
+      id={node.id}
+      label={catalogEntry.Name}
+      value={value ? '1' : '0'}
       onChange={changeValue}
-      options={<Options onClick={removeCriteria} />}
+      options={<Options onClick={onRemove} />}
     >
       <option value="1">True</option>
       <option value="0">False</option>

--- a/src/components/Collection/Filter/FilterGroup.tsx
+++ b/src/components/Collection/Filter/FilterGroup.tsx
@@ -1,0 +1,115 @@
+import { useState } from 'react';
+import type { ChangeEvent } from 'react';
+import { mdiFilterPlusOutline, mdiMinusCircleOutline, mdiPlusCircleMultipleOutline } from '@mdi/js';
+import { Icon } from '@mdi/react';
+import cx from 'classnames';
+import { map } from 'lodash';
+
+import AddCriteriaModal from '@/components/Collection/Filter/AddCriteriaModal';
+import FilterLeaf from '@/components/Collection/Filter/FilterLeaf';
+import UnsupportedCondition from '@/components/Collection/Filter/UnsupportedCondition';
+import Select from '@/components/Input/Select';
+import { addGroup, removeNode, setGroupOperator, setNegate } from '@/core/slices/collection';
+import { useDispatch } from '@/core/store';
+
+import type { FilterExpression, GroupNode } from '@/core/types/api/filter';
+
+type Props = {
+  catalog: FilterExpression[];
+  isRoot?: boolean;
+  node: GroupNode;
+};
+
+// Progressive disclosure: the root of a plain, non-negated AND tree - what "+ Add
+// condition" alone ever produces - renders bare, matching the flat sidebar this replaces.
+// Chrome (the Match ALL/ANY dropdown, NOT toggle) only shows up when it's either load-
+// bearing (a loaded preset whose root really is Or/negated) or the user explicitly opted
+// into nesting by adding a group, since a nested group's own join word is never optional.
+const FilterGroup = ({ catalog, isRoot = false, node }: Props) => {
+  const dispatch = useDispatch();
+  const [showAddCondition, setShowAddCondition] = useState(false);
+
+  const showChrome = !isRoot || node.operator === 'Or' || node.negate;
+
+  const changeOperator = (event: ChangeEvent<HTMLSelectElement>) => {
+    dispatch(setGroupOperator({ nodeId: node.id, operator: event.currentTarget.value as 'And' | 'Or' }));
+  };
+
+  const toggleNegate = () => dispatch(setNegate({ nodeId: node.id, negate: !node.negate }));
+  const removeGroup = () => dispatch(removeNode(node.id));
+  const addSubGroup = () => dispatch(addGroup({ groupId: node.id }));
+
+  return (
+    <div className={cx('flex flex-col gap-y-4', !isRoot && 'rounded-lg border border-panel-border p-4')}>
+      {showChrome && (
+        <div className="flex items-center justify-between gap-x-2">
+          <div className="flex items-center gap-x-2">
+            <span
+              className={cx(
+                'cursor-pointer rounded-sm border px-1.5 text-xs font-semibold',
+                node.negate
+                  ? 'border-panel-icon-danger text-panel-icon-danger'
+                  : 'border-panel-border text-panel-text-important',
+              )}
+              onClick={toggleNegate}
+              data-tooltip-id="tooltip"
+              data-tooltip-content="Toggle NOT"
+              data-tooltip-delay-show={500}
+            >
+              NOT
+            </span>
+            <Select id={`${node.id}-operator`} value={node.operator} onChange={changeOperator}>
+              <option value="And">Match All of the following</option>
+              <option value="Or">Match Any of the following</option>
+            </Select>
+          </div>
+          {!isRoot && (
+            <div onClick={removeGroup}>
+              <Icon
+                className="cursor-pointer text-panel-icon-danger"
+                path={mdiMinusCircleOutline}
+                size={1}
+                data-tooltip-id="tooltip"
+                data-tooltip-content="Remove Group"
+                data-tooltip-delay-show={500}
+              />
+            </div>
+          )}
+        </div>
+      )}
+
+      {map(node.children, (child) => {
+        if (child.kind === 'group') {
+          return <FilterGroup key={child.id} catalog={catalog} node={child} />;
+        }
+        if (child.kind === 'unsupported') {
+          return <UnsupportedCondition key={child.id} node={child} onRemove={() => dispatch(removeNode(child.id))} />;
+        }
+        const catalogEntry = catalog.find(entry => entry.Expression === child.expression);
+        if (!catalogEntry) return null;
+        return <FilterLeaf key={child.id} catalogEntry={catalogEntry} node={child} />;
+      })}
+
+      <div className="flex items-center gap-x-4">
+        <div
+          className="flex cursor-pointer items-center gap-x-2 font-semibold text-panel-text-primary"
+          onClick={() => setShowAddCondition(true)}
+        >
+          <Icon path={mdiFilterPlusOutline} size={0.85} />
+          Add condition
+        </div>
+        <div
+          className="flex cursor-pointer items-center gap-x-2 text-sm text-panel-text-important"
+          onClick={addSubGroup}
+        >
+          <Icon path={mdiPlusCircleMultipleOutline} size={0.75} />
+          Add group
+        </div>
+      </div>
+
+      <AddCriteriaModal groupId={node.id} show={showAddCondition} onClose={() => setShowAddCondition(false)} />
+    </div>
+  );
+};
+
+export default FilterGroup;

--- a/src/components/Collection/Filter/FilterGroup.tsx
+++ b/src/components/Collection/Filter/FilterGroup.tsx
@@ -7,6 +7,7 @@ import { map } from 'lodash';
 
 import AddCriteriaModal from '@/components/Collection/Filter/AddCriteriaModal';
 import FilterLeaf from '@/components/Collection/Filter/FilterLeaf';
+import NotToggle from '@/components/Collection/Filter/NotToggle';
 import UnsupportedCondition from '@/components/Collection/Filter/UnsupportedCondition';
 import Select from '@/components/Input/Select';
 import { addGroup, removeNode, setGroupOperator, setNegate } from '@/core/slices/collection';
@@ -44,20 +45,7 @@ const FilterGroup = ({ catalog, isRoot = false, node }: Props) => {
       {showChrome && (
         <div className="flex items-center justify-between gap-x-2">
           <div className="flex items-center gap-x-2">
-            <span
-              className={cx(
-                'cursor-pointer rounded-sm border px-1.5 text-xs font-semibold',
-                node.negate
-                  ? 'border-panel-icon-danger text-panel-icon-danger'
-                  : 'border-panel-border text-panel-text-important',
-              )}
-              onClick={toggleNegate}
-              data-tooltip-id="tooltip"
-              data-tooltip-content="Toggle NOT"
-              data-tooltip-delay-show={500}
-            >
-              NOT
-            </span>
+            <NotToggle negate={node.negate} onToggle={toggleNegate} />
             <Select id={`${node.id}-operator`} value={node.operator} onChange={changeOperator}>
               <option value="And">Match All of the following</option>
               <option value="Or">Match Any of the following</option>
@@ -90,7 +78,7 @@ const FilterGroup = ({ catalog, isRoot = false, node }: Props) => {
         return <FilterLeaf key={child.id} catalogEntry={catalogEntry} node={child} />;
       })}
 
-      <div className="flex items-center gap-x-4">
+      <div className="flex items-center justify-between">
         <div
           className="flex cursor-pointer items-center gap-x-2 font-semibold text-panel-text-primary"
           onClick={() => setShowAddCondition(true)}
@@ -99,7 +87,7 @@ const FilterGroup = ({ catalog, isRoot = false, node }: Props) => {
           Add condition
         </div>
         <div
-          className="flex cursor-pointer items-center gap-x-2 text-sm text-panel-text-important"
+          className="flex cursor-pointer items-center gap-x-2 font-semibold text-panel-text-primary"
           onClick={addSubGroup}
         >
           <Icon path={mdiPlusCircleMultipleOutline} size={0.75} />

--- a/src/components/Collection/Filter/FilterLeaf.tsx
+++ b/src/components/Collection/Filter/FilterLeaf.tsx
@@ -1,0 +1,33 @@
+import DefaultCriteria from '@/components/Collection/Filter/DefaultCriteria';
+import MultiValueCriteria from '@/components/Collection/Filter/MultiValueCriteria';
+import TagCriteria from '@/components/Collection/Filter/TagCriteria';
+import { removeNode, setNegate } from '@/core/slices/collection';
+import { useDispatch } from '@/core/store';
+
+import type { FilterExpression, LeafNode } from '@/core/types/api/filter';
+
+type Props = {
+  catalogEntry: FilterExpression;
+  node: LeafNode;
+};
+
+// Boolean leaves absorb Not into their True/False value, and tag leaves track exclusion
+// per tag - neither needs its own NOT toggle. Only multi/multiPair leaves can carry a
+// meaningful top-level negate (e.g. "year is NOT 2020 or 2021"), so only they get one.
+const FilterLeaf = ({ catalogEntry, node }: Props) => {
+  const dispatch = useDispatch();
+  const onRemove = () => dispatch(removeNode(node.id));
+  const onToggleNegate = () => dispatch(setNegate({ nodeId: node.id, negate: !node.negate }));
+
+  if (node.value.kind === 'tag') {
+    return <TagCriteria catalogEntry={catalogEntry} node={node} onRemove={onRemove} />;
+  }
+  if (node.value.kind === 'boolean') {
+    return <DefaultCriteria catalogEntry={catalogEntry} node={node} onRemove={onRemove} />;
+  }
+  return (
+    <MultiValueCriteria catalogEntry={catalogEntry} node={node} onRemove={onRemove} onToggleNegate={onToggleNegate} />
+  );
+};
+
+export default FilterLeaf;

--- a/src/components/Collection/Filter/FilterSidebar.tsx
+++ b/src/components/Collection/Filter/FilterSidebar.tsx
@@ -1,131 +1,127 @@
 import { useEffect, useState } from 'react';
-import type { MouseEventHandler } from 'react';
 import { useParams } from 'react-router';
-import { mdiContentSaveOutline, mdiFilterPlusOutline } from '@mdi/js';
-import { keys, map } from 'lodash';
+import { mdiContentSaveEditOutline, mdiContentSaveOutline } from '@mdi/js';
 
-import AddCriteriaModal from '@/components/Collection/Filter/AddCriteriaModal';
-import DefaultCriteria from '@/components/Collection/Filter/DefaultCriteria';
-import MultiValueCriteria from '@/components/Collection/Filter/MultiValueCriteria';
+import FilterGroup from '@/components/Collection/Filter/FilterGroup';
 import SavePresetModal from '@/components/Collection/Filter/SavePresetModal';
-import TagCriteria from '@/components/Collection/Filter/TagCriteria';
 import Button from '@/components/Input/Button';
 import IconButton from '@/components/Input/IconButton';
 import ShokoPanel from '@/components/Panels/ShokoPanel';
+import { useUpdateFilterMutation } from '@/core/react-query/filter/mutations';
+import { useAllFilterExpressionsQuery, useFilterQuery } from '@/core/react-query/filter/queries';
 import {
-  resetActiveFilter,
   resetFilter,
-  selectActiveCriteriaWithValues,
+  selectEditingFilterId,
+  selectFilterTree,
+  selectHasEditableContent,
   setActiveFilter,
+  setEditingFilterId,
 } from '@/core/slices/collection';
 import { useDispatch, useSelector } from '@/core/store';
-import { buildSidebarFilter } from '@/core/utilities/filter';
-
-import type { ButtonType } from '@/components/Input/Button.utils';
-import type { FilterExpression } from '@/core/types/api/filter';
-
-const CriteriaComponent = ({ criteria }: { criteria: FilterExpression }) => {
-  if (criteria.Expression === 'HasCustomTag' || criteria.Expression === 'HasTag') {
-    return <TagCriteria criteria={criteria} />;
-  }
-  if (criteria.PossibleParameters ?? criteria.PossibleParameterPairs) {
-    return <MultiValueCriteria criteria={criteria} />;
-  }
-  return <DefaultCriteria criteria={criteria} />;
-};
-
-const OptionButton = (
-  { buttonType, disabled, icon, onClick, tooltip }: {
-    buttonType?: ButtonType;
-    disabled?: boolean;
-    icon: string;
-    onClick: MouseEventHandler<HTMLButtonElement>;
-    tooltip?: string;
-  },
-) => (
-  <IconButton
-    icon={icon}
-    buttonType={buttonType ?? 'secondary'}
-    buttonSize="normal"
-    onClick={onClick}
-    tooltip={tooltip}
-    disabled={disabled}
-  />
-);
+import toast from '@/core/toast';
+import { buildFilterTree, createEmptyGroupNode } from '@/core/utilities/filterTree';
+import useNavigateVoid from '@/hooks/useNavigateVoid';
 
 type OptionsProps = {
-  showCriteriaModal: () => void;
+  canSaveChanges: boolean;
+  hasContent: boolean;
+  isSavingChanges: boolean;
+  onSaveChanges: () => void;
   showSavePresetModal: () => void;
 };
 
-const Options = ({ showCriteriaModal, showSavePresetModal }: OptionsProps) => {
-  const { filterId } = useParams();
-
-  const activeCriteriaWithValues = useSelector(selectActiveCriteriaWithValues);
-
-  const saveDisabled = filterId !== 'live' || keys(activeCriteriaWithValues).length === 0;
-  const saveDisabledReason = filterId !== 'live' ? 'Editing presets is currently unsupported' : '';
-
-  return (
-    <div className="flex gap-2">
-      <OptionButton
-        onClick={showSavePresetModal}
-        icon={mdiContentSaveOutline}
-        tooltip={saveDisabled ? saveDisabledReason : 'Save as preset'}
-        disabled={saveDisabled}
+const Options = ({ canSaveChanges, hasContent, isSavingChanges, onSaveChanges, showSavePresetModal }: OptionsProps) => (
+  <div className="flex gap-2">
+    {canSaveChanges && (
+      <IconButton
+        icon={mdiContentSaveEditOutline}
+        buttonType="secondary"
+        buttonSize="normal"
+        onClick={onSaveChanges}
+        tooltip="Save Changes"
+        disabled={!hasContent || isSavingChanges}
       />
-      <OptionButton onClick={showCriteriaModal} icon={mdiFilterPlusOutline} tooltip="Add condition" />
-    </div>
-  );
-};
+    )}
+    <IconButton
+      icon={mdiContentSaveOutline}
+      buttonType="secondary"
+      buttonSize="normal"
+      onClick={showSavePresetModal}
+      tooltip="Save as new preset"
+      disabled={!hasContent}
+    />
+  </div>
+);
 
 const FilterSidebar = () => {
-  const [criteriaModal, showCriteriaModal] = useState(false);
+  const { filterId, groupId } = useParams();
   const [savePresetModal, showSavePresetModal] = useState(false);
   const dispatch = useDispatch();
-  const selectedCriteria = useSelector(state => state.collection.filterCriteria);
-  const selectedConditions = useSelector(state => state.collection.filterConditions);
-  const selectedMatch = useSelector(state => state.collection.filterMatch);
-  const selectedTags = useSelector(state => state.collection.filterTags);
-  const selectedValues = useSelector(state => state.collection.filterValues);
-  const activeCriteriaWithValues = useSelector(selectActiveCriteriaWithValues);
+  const navigate = useNavigateVoid();
 
-  const isFilterValid = keys(selectedCriteria).length > 0
-    && keys(selectedCriteria).length === keys(activeCriteriaWithValues).length;
+  const tree = useSelector(selectFilterTree);
+  const editingFilterId = useSelector(selectEditingFilterId);
+  const hasContent = useSelector(selectHasEditableContent);
+  const catalog = useAllFilterExpressionsQuery().data ?? [];
 
-  const finalFilterExpression = isFilterValid
-    ? buildSidebarFilter(
-      Object.values(selectedCriteria),
-      {
-        filterConditions: selectedConditions,
-        filterMatch: selectedMatch,
-        filterTags: selectedTags,
-        filterValues: selectedValues,
-      },
-    )
-    : undefined;
+  const editingFilterQuery = useFilterQuery(editingFilterId ?? 0, !!editingFilterId);
+  const { isPending: isSavingChanges, mutate: updateFilter } = useUpdateFilterMutation();
+
+  // Only offer "Save Changes" while actually on the live editing buffer - every entry
+  // point that starts a fresh/unrelated live filter (Clear Filter, quick-filter jumps,
+  // opening the sidebar with no filterId) dispatches resetFilter() first, which clears
+  // editingFilterId, so this can't point at a preset the current buffer doesn't represent.
+  const canSaveChanges = !!editingFilterId && filterId === 'live';
 
   useEffect(() => {
-    if (isFilterValid && finalFilterExpression) dispatch(setActiveFilter(finalFilterExpression));
-    else dispatch(resetActiveFilter());
-  }, [dispatch, finalFilterExpression, isFilterValid]);
+    dispatch(setActiveFilter(buildFilterTree(tree) ?? null));
+  }, [dispatch, tree]);
+
+  const handleSaveChanges = () => {
+    if (!editingFilterId || !editingFilterQuery.data) return;
+    const { IDs, IsLocked: _IsLocked, Size: _Size, ...body } = editingFilterQuery.data;
+    updateFilter({
+      filterId: editingFilterId,
+      filter: { ...body, ParentID: IDs.ParentFilter ?? undefined, Expression: buildFilterTree(tree) },
+    }, {
+      onSuccess: () => {
+        toast.success('Preset updated!');
+        // Saving commits the edit and returns to the normal preset view. Only the "which
+        // preset am I editing" marker is cleared here, not the tree itself - the tree
+        // still accurately reflects what was just saved, so the sidebar (if left open)
+        // keeps showing the right conditions instead of going blank.
+        dispatch(setEditingFilterId(null));
+        navigate(
+          groupId
+            ? `/webui/collection/group/${groupId}/filter/${editingFilterId}`
+            : `/webui/collection/filter/${editingFilterId}`,
+        );
+      },
+      onError: () => toast.error('Failed to update preset!'),
+    });
+  };
+
+  const rootNode = tree ?? createEmptyGroupNode('And');
+  const title = canSaveChanges && editingFilterQuery.data?.Name
+    ? `Filter - Editing "${editingFilterQuery.data.Name}"`
+    : 'Filter';
 
   return (
     <ShokoPanel
-      title="Filter"
+      title={title}
       className="sticky top-24 ml-6 h-[calc(100vh-18rem)]! w-full"
       contentClassName="gap-y-6"
       options={
         <Options
-          showCriteriaModal={() => showCriteriaModal(true)}
+          canSaveChanges={canSaveChanges}
+          hasContent={hasContent}
+          isSavingChanges={isSavingChanges}
+          onSaveChanges={handleSaveChanges}
           showSavePresetModal={() => showSavePresetModal(true)}
         />
       }
     >
-      {map(
-        selectedCriteria,
-        item => <CriteriaComponent key={item.Expression} criteria={item} />,
-      )}
+      <FilterGroup catalog={catalog} node={rootNode} isRoot />
       <Button
         buttonType="danger"
         className="px-4 py-3"
@@ -133,11 +129,10 @@ const FilterSidebar = () => {
       >
         Clear Filter
       </Button>
-      <AddCriteriaModal show={criteriaModal} onClose={() => showCriteriaModal(false)} />
       <SavePresetModal
         show={savePresetModal}
         onClose={() => showSavePresetModal(false)}
-        filterCondition={finalFilterExpression}
+        filterCondition={buildFilterTree(tree)}
       />
     </ShokoPanel>
   );

--- a/src/components/Collection/Filter/MultiValueCriteria.tsx
+++ b/src/components/Collection/Filter/MultiValueCriteria.tsx
@@ -1,26 +1,33 @@
 import Criteria from '@/components/Collection/Filter/Criteria';
-import { selectFilterValues } from '@/core/slices/collection';
-import { useSelector } from '@/core/store';
 
-import type { RootState } from '@/core/store';
-import type { FilterExpression } from '@/core/types/api/filter';
+import type { FilterExpression, LeafNode } from '@/core/types/api/filter';
 
 type Props = {
-  criteria: FilterExpression;
+  catalogEntry: FilterExpression;
+  node: LeafNode;
+  onRemove: () => void;
+  onToggleNegate: () => void;
 };
 
 const capitalize = (value: string) => value.charAt(0).toUpperCase() + value.slice(1);
 
-const MultiValueCriteria = ({ criteria }: Props) => {
-  const selectedParameter = useSelector(
-    (state: RootState) => selectFilterValues(state, criteria),
-  );
+const getDisplayValues = (node: LeafNode): string[] => {
+  if (node.value.kind === 'multiPair') return node.value.values.map(([first, second]) => `${first}: ${second}`);
+  if (node.value.kind === 'multi') return node.value.values;
+  return [];
+};
+
+const MultiValueCriteria = ({ catalogEntry, node, onRemove, onToggleNegate }: Props) => {
+  const displayValues = getDisplayValues(node);
 
   return (
     <Criteria
-      criteria={criteria}
-      parameterExists={selectedParameter.length > 0}
-      transformedParameter={selectedParameter.map(capitalize).join(', ')}
+      catalogEntry={catalogEntry}
+      node={node}
+      onRemove={onRemove}
+      onToggleNegate={onToggleNegate}
+      parameterExists={displayValues.length > 0}
+      transformedParameter={displayValues.map(capitalize).join(', ')}
       type="multivalue"
     />
   );

--- a/src/components/Collection/Filter/MultiValueCriteriaModal.tsx
+++ b/src/components/Collection/Filter/MultiValueCriteriaModal.tsx
@@ -5,42 +5,67 @@ import { filter, map, pull } from 'lodash';
 import Button from '@/components/Input/Button';
 import Select from '@/components/Input/Select';
 import ModalPanel from '@/components/Panels/ModalPanel';
-import { selectFilterMatch, selectFilterValues, setFilterMatch, setFilterValues } from '@/core/slices/collection';
-import { useDispatch, useSelector } from '@/core/store';
+import { updateLeafValue } from '@/core/slices/collection';
+import { useDispatch } from '@/core/store';
 
-import type { RootState } from '@/core/store';
-import type { FilterExpression } from '@/core/types/api/filter';
+import type { FilterExpression, LeafNode, LeafValue } from '@/core/types/api/filter';
 
 type Props = {
-  criteria: FilterExpression;
-  show: boolean;
+  catalogEntry: FilterExpression;
+  node: LeafNode;
   onClose: () => void;
-  removeCriteria: () => void;
+  onRemove: () => void;
+  show: boolean;
 };
-const MultiValueCriteriaModal = ({ criteria, onClose, removeCriteria, show }: Props) => {
+
+// Pair values are joined into a single display string only for this picker's own list -
+// matched back against the catalog's original pair rather than re-split, so a value that
+// happens to contain ': ' can't be misinterpreted. The dispatched LeafValue always carries
+// real [string, string] tuples, never the joined string as the source of truth.
+const displayPair = (pair: string[]) => pair.join(': ');
+
+const MultiValueCriteriaModal = ({ catalogEntry, node, onClose, onRemove, show }: Props) => {
   const dispatch = useDispatch();
-  const selectedValues = useSelector(
-    (state: RootState) => selectFilterValues(state, criteria),
-  );
-  const [unsavedValues, setUnsavedValues] = useState([] as string[]);
+  const isPair = node.value.kind === 'multiPair';
+
+  const selectedDisplayValues = useMemo(() => {
+    if (node.value.kind === 'multiPair') return node.value.values.map(displayPair);
+    if (node.value.kind === 'multi') return node.value.values;
+    return [];
+  }, [node.value]);
+  const initialMatch = node.value.kind === 'multi' || node.value.kind === 'multiPair' ? node.value.match : 'Or';
+
+  const [unsavedValues, setUnsavedValues] = useState<string[]>([]);
+  const [match, setMatch] = useState<'And' | 'Or'>(initialMatch);
+
   const unusedValues = useMemo(
     () => {
-      // TODO: See delimiter TODO in buildFilter.ts
-      const possibleValues = criteria.PossibleParameters
-        ?? criteria.PossibleParameterPairs?.map(value => value.join(': '));
+      const possibleValues = catalogEntry.PossibleParameters
+        ?? catalogEntry.PossibleParameterPairs?.map(displayPair);
 
       return filter(
         possibleValues,
-        item => !selectedValues.includes(item) && !unsavedValues.includes(item),
+        item => !selectedDisplayValues.includes(item) && !unsavedValues.includes(item),
       );
     },
-    [criteria.PossibleParameters, criteria.PossibleParameterPairs, selectedValues, unsavedValues],
+    [catalogEntry.PossibleParameters, catalogEntry.PossibleParameterPairs, selectedDisplayValues, unsavedValues],
   );
-  const filterMatch = useSelector(state => selectFilterMatch(state, criteria.Expression));
 
-  const handleMatchChange = (event: ChangeEvent<HTMLSelectElement>) => {
-    dispatch(setFilterMatch({ [criteria.Expression]: event.target.value as 'Or' | 'And' }));
+  const buildValue = (displayValues: string[], matchValue: 'And' | 'Or'): LeafValue => {
+    if (isPair) {
+      return {
+        kind: 'multiPair',
+        match: matchValue,
+        values: displayValues.map((display): [string, string] => {
+          const pair = catalogEntry.PossibleParameterPairs?.find(candidate => displayPair(candidate) === display);
+          return pair ? [pair[0], pair[1]] : [display, ''];
+        }),
+      };
+    }
+    return { kind: 'multi', values: displayValues, match: matchValue };
   };
+
+  const handleMatchChange = (event: ChangeEvent<HTMLSelectElement>) => setMatch(event.target.value as 'And' | 'Or');
 
   const selectValue = (value: string) => {
     setUnsavedValues([...unsavedValues, value]);
@@ -50,19 +75,25 @@ const MultiValueCriteriaModal = ({ criteria, onClose, removeCriteria, show }: Pr
     if (unsavedValues.includes(value)) {
       setUnsavedValues(pull([...unsavedValues], value));
     }
-    if (selectedValues.includes(value)) {
-      dispatch(setFilterValues({ [criteria.Expression]: pull([...selectedValues], value) }));
+    if (selectedDisplayValues.includes(value)) {
+      dispatch(updateLeafValue({
+        nodeId: node.id,
+        value: buildValue(pull([...selectedDisplayValues], value), match),
+      }));
     }
   };
 
   const handleCancel = () => {
     setUnsavedValues([]);
-    if (selectedValues.length === 0) removeCriteria();
+    if (selectedDisplayValues.length === 0) onRemove();
     onClose();
   };
 
   const handleSave = () => {
-    dispatch(setFilterValues({ [criteria.Expression]: [...selectedValues, ...unsavedValues] }));
+    dispatch(updateLeafValue({
+      nodeId: node.id,
+      value: buildValue([...selectedDisplayValues, ...unsavedValues], match),
+    }));
     setUnsavedValues([]);
     onClose();
   };
@@ -72,11 +103,11 @@ const MultiValueCriteriaModal = ({ criteria, onClose, removeCriteria, show }: Pr
       show={show}
       size="sm"
       onRequestClose={handleCancel}
-      header={`Edit Condition - ${criteria.Name}`}
-      subHeader={criteria.Description}
+      header={`Edit Condition - ${catalogEntry.Name}`}
+      subHeader={catalogEntry.Description}
       fullHeight
     >
-      <Select id="match" onChange={handleMatchChange} value={filterMatch}>
+      <Select id="match" onChange={handleMatchChange} value={match}>
         <option value="Or">Match Any</option>
         <option value="And">Match All</option>
       </Select>
@@ -99,7 +130,7 @@ const MultiValueCriteriaModal = ({ criteria, onClose, removeCriteria, show }: Pr
         <div className="font-semibold">Selected Values</div>
         <div className="flex grow basis-0 overflow-y-auto rounded-lg bg-panel-input p-4">
           <div className="flex w-full flex-col gap-y-2 overflow-y-auto bg-panel-input">
-            {map([...selectedValues, ...unsavedValues], value => (
+            {map([...selectedDisplayValues, ...unsavedValues], value => (
               <div
                 onClick={() => {
                   removeValue(value);

--- a/src/components/Collection/Filter/NotToggle.tsx
+++ b/src/components/Collection/Filter/NotToggle.tsx
@@ -1,0 +1,23 @@
+import Button from '@/components/Input/Button';
+
+type Props = {
+  negate: boolean;
+  onToggle: () => void;
+};
+
+// Shared between leaf (Criteria.tsx) and group (FilterGroup.tsx) headers - a real Button
+// so it reads as an actual pressable toggle instead of a plain bordered label. Active
+// state uses "primary" (blue) rather than "danger" (red) - red reads as an error/disabled
+// cue rather than "this toggle is on".
+const NotToggle = ({ negate, onToggle }: Props) => (
+  <Button
+    buttonType={negate ? 'primary' : 'secondary'}
+    buttonSize="small"
+    onClick={onToggle}
+    tooltip="Toggle NOT"
+  >
+    NOT
+  </Button>
+);
+
+export default NotToggle;

--- a/src/components/Collection/Filter/TagCriteria.tsx
+++ b/src/components/Collection/Filter/TagCriteria.tsx
@@ -2,10 +2,8 @@ import { useMemo } from 'react';
 import { forEach } from 'lodash';
 
 import Criteria from '@/components/Collection/Filter/Criteria';
-import { selectFilterTags } from '@/core/slices/collection';
-import { useSelector } from '@/core/store';
 
-import type { FilterExpression } from '@/core/types/api/filter';
+import type { FilterExpression, LeafNode } from '@/core/types/api/filter';
 
 type TagLineProps = {
   title: string;
@@ -28,27 +26,32 @@ const Parameter = ({ excludedValues, includedValues }: { includedValues: string[
 );
 
 type Props = {
-  criteria: FilterExpression;
+  catalogEntry: FilterExpression;
+  node: LeafNode;
+  onRemove: () => void;
 };
 
-const TagCriteria = ({ criteria }: Props) => {
-  const selectedParameter = useSelector(state => selectFilterTags(state, criteria));
+const TagCriteria = ({ catalogEntry, node, onRemove }: Props) => {
   const [includedValues, excludedValues] = useMemo(() => {
     const included: string[] = [];
     const excluded: string[] = [];
-    forEach(selectedParameter, (tag) => {
-      if (tag.isExcluded) {
-        excluded.push(tag.Name);
-      } else {
-        included.push(tag.Name);
-      }
-    });
+    if (node.value.kind === 'tag') {
+      forEach(node.value.tags, (tag) => {
+        if (tag.isExcluded) {
+          excluded.push(tag.Name);
+        } else {
+          included.push(tag.Name);
+        }
+      });
+    }
     return [included, excluded];
-  }, [selectedParameter]);
+  }, [node.value]);
 
   return (
     <Criteria
-      criteria={criteria}
+      catalogEntry={catalogEntry}
+      node={node}
+      onRemove={onRemove}
       parameterExists={includedValues.length > 0 || excludedValues.length > 0}
       transformedParameter={<Parameter includedValues={includedValues} excludedValues={excludedValues} />}
       type="tag"

--- a/src/components/Collection/Filter/TagCriteriaModal.tsx
+++ b/src/components/Collection/Filter/TagCriteriaModal.tsx
@@ -10,18 +10,21 @@ import Button from '@/components/Input/Button';
 import Input from '@/components/Input/Input';
 import ModalPanel from '@/components/Panels/ModalPanel';
 import { useAniDBTagsQuery, useUserTagsQuery } from '@/core/react-query/tag/queries';
-import { selectFilterTags, setFilterTag } from '@/core/slices/collection';
-import { useDispatch, useSelector } from '@/core/store';
+import { updateLeafValue } from '@/core/slices/collection';
+import { useDispatch } from '@/core/store';
 
-import type { FilterExpression, FilterTag } from '@/core/types/api/filter';
+import type { FilterExpression, FilterTag, LeafNode } from '@/core/types/api/filter';
 import type { TagType } from '@/core/types/api/tags';
 
 type Props = {
-  criteria: FilterExpression;
-  show: boolean;
+  catalogEntry: FilterExpression;
+  node: LeafNode;
   onClose: () => void;
-  removeCriteria: () => void;
+  onRemove: () => void;
+  show: boolean;
 };
+
+const EMPTY_TAGS: FilterTag[] = [];
 
 const TagList = (
   { selectTag, unusedValues }: { selectTag: (name: string, select: boolean) => () => void, unusedValues: TagType[] },
@@ -88,21 +91,23 @@ const TagList = (
   );
 };
 
-const TagCriteriaModal = ({ criteria, onClose, removeCriteria, show }: Props) => {
+const TagCriteriaModal = ({ catalogEntry, node, onClose, onRemove, show }: Props) => {
   const dispatch = useDispatch();
   const anidbTagsQuery = useAniDBTagsQuery(
     { pageSize: 0, excludeDescriptions: true },
-    show && criteria.Expression === 'HasTag',
+    show && catalogEntry.Expression === 'HasTag',
   );
   const userTagsQuery = useUserTagsQuery(
     { pageSize: 0, excludeDescriptions: true },
-    show && criteria.Expression === 'HasCustomTag',
+    show && catalogEntry.Expression === 'HasCustomTag',
   );
-  const tags = criteria.Expression === 'HasTag' ? anidbTagsQuery.data : userTagsQuery.data;
+  const tags = catalogEntry.Expression === 'HasTag' ? anidbTagsQuery.data : userTagsQuery.data;
   const [search, setSearch] = useState('');
   // selectMode: included - true, excluded - false
   const [selectMode, setSelectMode] = useState<boolean>(true);
-  const selectedValues = useSelector(state => selectFilterTags(state, criteria));
+  // A TagCriteriaModal is only ever rendered for a tag-kind node; the fallback keeps a
+  // stable reference so it doesn't invalidate the useMemo hooks below on every render.
+  const selectedValues = node.value.kind === 'tag' ? node.value.tags : EMPTY_TAGS;
   const [unsavedValues, setUnsavedValues] = useState<FilterTag[]>([]);
   const unusedValues = useMemo(
     () =>
@@ -124,18 +129,24 @@ const TagCriteriaModal = ({ criteria, onClose, removeCriteria, show }: Props) =>
       setUnsavedValues(filter([...unsavedValues], item => item.Name !== tagName));
     }
     if (findIndex(selectedValues, { Name: tagName }) !== -1) {
-      dispatch(setFilterTag({ [criteria.Expression]: filter([...selectedValues], item => item.Name !== tagName) }));
+      dispatch(updateLeafValue({
+        nodeId: node.id,
+        value: { kind: 'tag', tags: filter([...selectedValues], item => item.Name !== tagName) },
+      }));
     }
   };
 
   const handleCancel = () => {
     setUnsavedValues([]);
-    if (selectedValues.length === 0) removeCriteria();
+    if (selectedValues.length === 0) onRemove();
     onClose();
   };
 
   const handleSave = () => {
-    dispatch(setFilterTag({ [criteria.Expression]: [...selectedValues, ...unsavedValues] }));
+    dispatch(updateLeafValue({
+      nodeId: node.id,
+      value: { kind: 'tag', tags: [...selectedValues, ...unsavedValues] },
+    }));
     setUnsavedValues([]);
     onClose();
   };
@@ -154,8 +165,8 @@ const TagCriteriaModal = ({ criteria, onClose, removeCriteria, show }: Props) =>
       show={show}
       size="sm"
       onRequestClose={handleCancel}
-      header={`Edit Condition - ${criteria.Name}`}
-      subHeader={criteria.Description}
+      header={`Edit Condition - ${catalogEntry.Name}`}
+      subHeader={catalogEntry.Description}
       fullHeight
     >
       <div className="flex grow basis-0 flex-col gap-y-4">

--- a/src/components/Collection/Filter/UnsupportedCondition.tsx
+++ b/src/components/Collection/Filter/UnsupportedCondition.tsx
@@ -1,0 +1,36 @@
+import { mdiMinusCircleOutline } from '@mdi/js';
+import { Icon } from '@mdi/react';
+
+import type { UnsupportedNode } from '@/core/types/api/filter';
+
+type Props = {
+  node: UnsupportedNode;
+  onRemove: () => void;
+};
+
+// Function calls and comparison operators over typed selectors (Today/DateAdd/DateDiff,
+// NumberGreaterThan, etc.) are a permanent product boundary, not a gap to close later -
+// see the "advanced logic" wording below, which deliberately avoids implying this will
+// become editable in a future update.
+const UnsupportedCondition = ({ node, onRemove }: Props) => (
+  <div className="flex flex-col">
+    <div className="mb-3 flex items-center justify-between">
+      <div className="font-semibold">{node.raw.Type}</div>
+      <div onClick={onRemove}>
+        <Icon
+          className="cursor-pointer text-panel-icon-danger"
+          path={mdiMinusCircleOutline}
+          size={1}
+          data-tooltip-id="tooltip"
+          data-tooltip-content="Remove Condition"
+          data-tooltip-delay-show={500}
+        />
+      </div>
+    </div>
+    <div className="rounded-lg border border-panel-border bg-panel-input px-4 py-3 text-panel-text-important">
+      This condition uses advanced logic that can&apos;t be edited here. It will be kept as-is when you save.
+    </div>
+  </div>
+);
+
+export default UnsupportedCondition;

--- a/src/components/Collection/SeriesInfo.tsx
+++ b/src/components/Collection/SeriesInfo.tsx
@@ -4,10 +4,10 @@ import cx from 'classnames';
 import { toNumber } from 'lodash';
 
 import { useSeriesOverviewQuery } from '@/core/react-query/webui/queries';
-import { resetFilter, setFilterValues } from '@/core/slices/collection';
+import { resetFilter } from '@/core/slices/collection';
 import { useDispatch } from '@/core/store';
 import { convertTimeSpanToMs, dayjs } from '@/core/util';
-import { addFilterCriteriaToStore } from '@/core/utilities/filter';
+import { startQuickFilter } from '@/core/utilities/filter';
 import useNavigateVoid from '@/hooks/useNavigateVoid';
 
 import type { SeriesType } from '@/core/types/api/series';
@@ -55,8 +55,7 @@ const SeriesInfo = ({ series }: SeriesInfoProps) => {
     if (!overview.FirstAirSeason) return;
     dispatch(resetFilter());
     const [season, year] = overview.FirstAirSeason.split(' ');
-    addFilterCriteriaToStore('InSeason').then(() => {
-      dispatch(setFilterValues({ InSeason: [`${year}: ${season}`] }));
+    startQuickFilter('InSeason', { kind: 'multiPair', values: [[year, season]], match: 'Or' }).then(() => {
       navigate('/webui/collection/filter/live');
     }).catch(console.error);
   };

--- a/src/components/Collection/TagButton.tsx
+++ b/src/components/Collection/TagButton.tsx
@@ -3,9 +3,9 @@ import { Icon } from '@mdi/react';
 import cx from 'classnames';
 
 import Button from '@/components/Input/Button';
-import { resetFilter, setFilterTag } from '@/core/slices/collection';
+import { resetFilter } from '@/core/slices/collection';
 import { useDispatch } from '@/core/store';
-import { addFilterCriteriaToStore } from '@/core/utilities/filter';
+import { startQuickFilter } from '@/core/utilities/filter';
 import useNavigateVoid from '@/hooks/useNavigateVoid';
 
 type Props = {
@@ -19,8 +19,7 @@ const TagButton = ({ tagType, text, type }: Props) => {
   const navigate = useNavigateVoid();
   const handleClick = () => {
     dispatch(resetFilter());
-    addFilterCriteriaToStore('HasTag').then(() => {
-      dispatch(setFilterTag({ HasTag: [{ Name: text, isExcluded: false }] }));
+    startQuickFilter('HasTag', { kind: 'tag', tags: [{ Name: text, isExcluded: false }] }).then(() => {
       navigate('/webui/collection/filter/live');
     }).catch(console.error);
   };

--- a/src/components/Collection/TitleOptions.tsx
+++ b/src/components/Collection/TitleOptions.tsx
@@ -6,6 +6,7 @@ import {
   mdiFormatListText,
   mdiMagnify,
   mdiPencil,
+  mdiPencilOutline,
   mdiViewGridOutline,
 } from '@mdi/js';
 import { useToggle } from 'usehooks-ts';
@@ -20,10 +21,12 @@ import type { CollectionGroupType } from '@/core/types/api/collection';
 import type { SeriesType } from '@/core/types/api/series';
 
 type Props = {
+  canEditFilter: boolean;
   groupSearch: string;
   isSeries: boolean;
   item: CollectionGroupType | SeriesType;
   mode: string;
+  onEditFilter: () => void;
   seriesSearch: string;
   setSearch: (event: ChangeEvent<HTMLInputElement>) => void;
   toggleFilterSidebar: () => void;
@@ -48,10 +51,12 @@ const OptionButton = (
 
 const TitleOptions = (props: Props) => {
   const {
+    canEditFilter,
     groupSearch,
     isSeries,
     item,
     mode,
+    onEditFilter,
     seriesSearch,
     setSearch,
     toggleFilterSidebar,
@@ -75,7 +80,9 @@ const TitleOptions = (props: Props) => {
         />
         {!isSeries && <OptionButton onClick={toggleFilterModal} icon={mdiFilterMenuOutline} tooltip="Filter Presets" />}
         {isSeries && <OptionButton onClick={editGroupModalCallback} icon={mdiPencil} tooltip="Edit Group" />}
-        <OptionButton onClick={toggleFilterSidebar} icon={mdiFilterOutline} tooltip="Filter" />
+        {canEditFilter
+          ? <OptionButton onClick={onEditFilter} icon={mdiPencilOutline} tooltip="Edit Filter" />
+          : <OptionButton onClick={toggleFilterSidebar} icon={mdiFilterOutline} tooltip="Filter" />}
         <OptionButton
           onClick={toggleMode}
           icon={mode === 'poster' ? mdiFormatListText : mdiViewGridOutline}

--- a/src/core/react-query/filter/mutations.ts
+++ b/src/core/react-query/filter/mutations.ts
@@ -16,3 +16,17 @@ export const useDeleteFilterMutation = () =>
     mutationFn: (filterId: string) => axios.delete(`Filter/${filterId}`),
     onSuccess: () => invalidateQueries(['filter']),
   });
+
+export const useUpdateFilterMutation = () =>
+  useMutation({
+    mutationFn: ({ filter, filterId }: { filter: CreateOrUpdateFilterType, filterId: number }) =>
+      axios.put(`Filter/${filterId}`, filter),
+    // Scoped to what actually changed - unlike invalidateQueries(['filter']) elsewhere in
+    // this file, this must not also match ['filter', 'expression', 'all'], which is cached
+    // with staleTime: Infinity specifically to avoid refetching the (large, rarely-changing)
+    // expression catalog.
+    onSuccess: (_data, { filterId }) => {
+      invalidateQueries(['filter', 'all']);
+      invalidateQueries(['filter', 'single', filterId]);
+    },
+  });

--- a/src/core/react-query/filter/queries.ts
+++ b/src/core/react-query/filter/queries.ts
@@ -43,6 +43,18 @@ export const useFilterExpressionsQuery = (enabled = true) =>
     staleTime: Infinity, // This query does not return different results each time, so we can cache it forever.
   });
 
+// Unfiltered catalog (all groups, not just "Info") - needed to look up the display name/
+// widget shape for a leaf parsed out of an existing preset, which may reference an
+// expression outside the "Info" group even though AddCriteriaModal only offers Info-group
+// expressions when adding a new condition. Shares the same query cache as the query above.
+export const useAllFilterExpressionsQuery = (enabled = true) =>
+  useQuery<FilterExpression[]>({
+    queryKey: ['filter', 'expression', 'all'],
+    queryFn: () => axios.get('Filter/Expressions'),
+    enabled,
+    staleTime: Infinity,
+  });
+
 export const useFilteredSeriesInfiniteQuery = (
   { filterCriteria, ...params }: FilteredSeriesRequestType,
   enabled = true,

--- a/src/core/slices/collection.ts
+++ b/src/core/slices/collection.ts
@@ -1,145 +1,146 @@
 import { createSelector, createSlice } from '@reduxjs/toolkit';
-import { filter, keys } from 'lodash';
+
+import {
+  createEmptyGroupNode,
+  createLeafNode,
+  findGroupById,
+  findNodeById,
+  removeNodeById,
+} from '@/core/utilities/filterTree';
 
 import type { RootState } from '@/core/store';
-import type { FilterCondition, FilterExpression, FilterTag } from '@/core/types/api/filter';
+import type { FilterCondition, FilterExpression, GroupNode, LeafValue } from '@/core/types/api/filter';
 import type { PayloadAction } from '@reduxjs/toolkit';
 
 /*
 Sidebar filter
 
-Naming these needs some improvements.
-Uses expressions received from server:
-filterCriteria - when user selects an expression it is copied here, then passed into relevant controls
+tree - the editable AND/OR/NOT condition tree, id-addressed so the same expression can
+appear more than once (e.g. two independent InYear conditions in different groups).
+Always a single root GroupNode once anything has been added; null means no filter.
 
-Values for the condition that user selected, key is criteria.Expression, split by type, technically could be a single array
-filterConditions - DefaultCriteria
-filterValues - MultiValueCriteria
-filterTags - TagCriteria
+activeFilter - the FilterCondition actually sent to the server, derived from `tree` via
+buildFilterTree() and cached here so Collection.tsx doesn't need to recompute/import the
+tree utilities itself; null if the filter is inactive/empty.
 
-activeFilter - actual filter expression is generated from all the values it is put here, if it is null filter is not active
+editingFilterId - set when `tree` was populated by loading an existing saved preset for
+editing (see Collection.tsx's Edit action), so the sidebar knows it's safe to offer
+"Save Changes" against that specific preset rather than only "Save as new preset". Cleared
+on resetFilter so stale/unrelated live-filter edits can never be silently PUT to a preset
+they don't actually represent.
 */
 
 type State = {
-  filterCriteria: Record<string, FilterExpression>;
-  filterConditions: Record<string, boolean>;
-  filterValues: Record<string, string[]>;
-  filterTags: Record<string, FilterTag[]>;
-  filterMatch: Record<string, 'Or' | 'And'>;
   activeFilter: FilterCondition | null;
+  editingFilterId: number | null;
+  tree: GroupNode | null;
 };
 
-const initialState = {
-  filterCriteria: {},
-  filterConditions: {},
-  filterValues: {},
-  filterTags: {},
-  filterMatch: {},
+const initialState: State = {
   activeFilter: null,
-} as State;
+  editingFilterId: null,
+  tree: null,
+};
 
 const collectionSlice = createSlice({
   name: 'collection',
   initialState,
   reducers: {
-    addFilterCriteria(sliceState, action: PayloadAction<FilterExpression>) {
-      const expression = action.payload;
-      sliceState.filterCriteria[expression.Expression] = expression;
-    },
-    removeFilterCriteria(sliceState, action: PayloadAction<FilterExpression>) {
-      const { Expression } = action.payload;
-      delete sliceState.filterCriteria[Expression];
-      if (sliceState.filterConditions[Expression] !== undefined) {
-        delete sliceState.filterConditions[Expression];
-      }
-      if (sliceState.filterValues[Expression] !== undefined) {
-        delete sliceState.filterValues[Expression];
-      }
-      if (sliceState.filterTags[Expression] !== undefined) {
-        delete sliceState.filterTags[Expression];
-      }
-      if (sliceState.filterMatch[Expression] !== undefined) {
-        delete sliceState.filterMatch[Expression];
-      }
+    setTree(sliceState, action: PayloadAction<GroupNode | null>) {
+      sliceState.tree = action.payload;
     },
     resetFilter() {
       return initialState;
     },
-    addFilterCondition(sliceState, action: PayloadAction<Record<string, boolean>>) {
-      sliceState.filterConditions = { ...sliceState.filterConditions, ...action.payload };
+    addLeaf(sliceState, action: PayloadAction<{ entry: FilterExpression, groupId?: string }>) {
+      const { entry, groupId } = action.payload;
+      const leaf = createLeafNode(entry);
+      sliceState.tree ??= createEmptyGroupNode('And');
+      const target = (groupId ? findGroupById(sliceState.tree, groupId) : null) ?? sliceState.tree;
+      target.children.push(leaf);
     },
-    setFilterValues(sliceState, action: PayloadAction<Record<string, string[]>>) {
-      sliceState.filterValues = { ...sliceState.filterValues, ...action.payload };
+    addGroup(sliceState, action: PayloadAction<{ groupId?: string } | undefined>) {
+      const groupId = action.payload?.groupId;
+      const newGroup = createEmptyGroupNode('And');
+      sliceState.tree ??= createEmptyGroupNode('And');
+      const target = (groupId ? findGroupById(sliceState.tree, groupId) : null) ?? sliceState.tree;
+      target.children.push(newGroup);
     },
-    setFilterTag(sliceState, action: PayloadAction<Record<string, FilterTag[]>>) {
-      sliceState.filterTags = action.payload;
+    removeNode(sliceState, action: PayloadAction<string>) {
+      if (!sliceState.tree) return;
+      if (sliceState.tree.id === action.payload) {
+        sliceState.tree = null;
+        return;
+      }
+      removeNodeById(sliceState.tree, action.payload);
     },
-    setFilterMatch(sliceState, action: PayloadAction<Record<string, 'Or' | 'And'>>) {
-      sliceState.filterMatch = { ...sliceState.filterMatch, ...action.payload };
+    setGroupOperator(sliceState, action: PayloadAction<{ nodeId: string, operator: 'And' | 'Or' }>) {
+      if (!sliceState.tree) return;
+      const node = findNodeById(sliceState.tree, action.payload.nodeId);
+      if (node?.kind === 'group') node.operator = action.payload.operator;
     },
-    setActiveFilter(sliceState, action: PayloadAction<FilterCondition>) {
+    setNegate(sliceState, action: PayloadAction<{ negate: boolean, nodeId: string }>) {
+      if (!sliceState.tree) return;
+      const node = findNodeById(sliceState.tree, action.payload.nodeId);
+      if (node && node.kind !== 'unsupported') node.negate = action.payload.negate;
+    },
+    updateLeafValue(sliceState, action: PayloadAction<{ nodeId: string, value: LeafValue }>) {
+      if (!sliceState.tree) return;
+      const node = findNodeById(sliceState.tree, action.payload.nodeId);
+      if (node?.kind === 'leaf') node.value = action.payload.value;
+    },
+    setActiveFilter(sliceState, action: PayloadAction<FilterCondition | null>) {
       sliceState.activeFilter = action.payload;
     },
-    resetActiveFilter(sliceState) {
-      sliceState.activeFilter = null;
+    setEditingFilterId(sliceState, action: PayloadAction<number | null>) {
+      sliceState.editingFilterId = action.payload;
     },
   },
 });
 
 export const {
-  addFilterCondition,
-  addFilterCriteria,
-  removeFilterCriteria,
-  resetActiveFilter,
+  addGroup,
+  addLeaf,
+  removeNode,
   resetFilter,
   setActiveFilter,
-  setFilterMatch,
-  setFilterTag,
-  setFilterValues,
+  setEditingFilterId,
+  setGroupOperator,
+  setNegate,
+  setTree,
+  updateLeafValue,
 } = collectionSlice.actions;
 
-export const selectFilterTags = createSelector(
+export const selectFilterTree = (state: RootState) => state.collection.tree;
+
+export const selectEditingFilterId = (state: RootState) => state.collection.editingFilterId;
+
+export const selectNodeById = createSelector(
   [
-    (state: RootState) => state.collection,
-    (_, criteria: FilterExpression) => criteria.Expression,
+    (state: RootState) => state.collection.tree,
+    (_: RootState, nodeId: string) => nodeId,
   ],
-  (values, expression) => values.filterTags[expression] ?? [],
+  (tree, nodeId) => (tree ? findNodeById(tree, nodeId) : null),
 );
 
-export const selectFilterValues = createSelector(
-  [
-    (state: RootState) => state.collection,
-    (_, criteria: FilterExpression) => criteria.Expression,
-  ],
-  (values, expression) => values.filterValues[expression] ?? [],
+export const selectHasEditableContent = createSelector(
+  [(state: RootState) => state.collection.tree],
+  tree => !!tree && tree.children.length > 0,
 );
 
-export const selectActiveCriteria = createSelector(
+// Used by AddCriteriaModal to avoid offering an expression already present as a direct
+// (non-nested) leaf of the group the user is adding to.
+export const selectUsedExpressionsInGroup = createSelector(
   [
-    (state: RootState) => state.collection,
+    (state: RootState) => state.collection.tree,
+    (_: RootState, groupId: string) => groupId,
   ],
-  values => keys(values.filterCriteria),
-);
-
-export const selectActiveCriteriaWithValues = createSelector(
-  [
-    (state: RootState) => state.collection.filterConditions,
-    (state: RootState) => state.collection.filterValues,
-    (state: RootState) => state.collection.filterTags,
-  ],
-  (filterConditions, filterValues, filterTags) => [
-    ...keys(filter(filterConditions, item => item !== undefined)),
-    ...keys(filter(filterValues, item => item.length > 0)),
-    ...keys(filter(filterTags, item => item.length > 0)),
-  ],
-);
-
-export const selectFilterMatch = createSelector(
-  [
-    (state: RootState) => state.collection.filterMatch,
-    (_, expression: string) => expression,
-  ],
-  (filterMatch, expression) => filterMatch[expression] ?? 'Or',
+  (tree, groupId) => {
+    if (!tree) return [];
+    const group = tree.id === groupId ? tree : findGroupById(tree, groupId);
+    if (!group) return [];
+    return group.children.filter(child => child.kind === 'leaf').map(child => child.expression);
+  },
 );
 
 export default collectionSlice.reducer;

--- a/src/core/types/api/filter.ts
+++ b/src/core/types/api/filter.ts
@@ -1,28 +1,6 @@
-export type ExpressionType =
-  | 'And'
-  | 'Not'
-  | 'Or'
-  | 'AniDBIDsSelector'
-  | 'AllContains'
-  | 'AllRegexMatches'
-  | 'AnyContains'
-  | 'AnyEquals'
-  | 'AnyFuzzyMatches'
-  | 'AnyRegexMatches'
-  | 'HasUnwatchedEpisodes'
-  | 'HasWatchedEpisodes'
-  | 'NameSelector'
-  | 'NamesSelector'
-  | 'StringContains'
-  | 'StringEndsWith'
-  | 'StringEquals'
-  | 'StringFuzzyMatches'
-  | 'StringNotEquals'
-  | 'StringRegexMatches'
-  | 'StringStartsWith'
-  | 'HasTag'
-  | 'HasCustomTag'
-  | 'HasFuzzyName';
+// The server's catalog (`GET Filter/Expressions`) has ~200 expression types and is the
+// actual source of truth at runtime - a hardcoded union here can't be kept in sync with it.
+export type ExpressionType = string;
 
 type SortingType =
   | 'AddedDate'
@@ -105,3 +83,37 @@ export type FilterType = {
   IsLocked: boolean;
   Size: number;
 } & BaseFilterType;
+
+// Editable UI representation of a FilterCondition tree. Leaves reuse the existing
+// widget kinds (boolean/multi/multiPair/tag); anything else (Function calls, comparison
+// operators over selectors) is preserved verbatim as an UnsupportedNode rather than
+// dropped or partially interpreted.
+export type LeafValue =
+  | { kind: 'boolean', value: boolean }
+  | { kind: 'multi', values: string[], match: 'And' | 'Or' }
+  | { kind: 'multiPair', values: [string, string][], match: 'And' | 'Or' }
+  | { kind: 'tag', tags: FilterTag[] };
+
+export type LeafNode = {
+  id: string;
+  kind: 'leaf';
+  expression: string;
+  negate: boolean;
+  value: LeafValue;
+};
+
+export type GroupNode = {
+  id: string;
+  kind: 'group';
+  operator: 'And' | 'Or';
+  negate: boolean;
+  children: TreeNode[];
+};
+
+export type UnsupportedNode = {
+  id: string;
+  kind: 'unsupported';
+  raw: FilterCondition;
+};
+
+export type TreeNode = LeafNode | GroupNode | UnsupportedNode;

--- a/src/core/utilities/filter.ts
+++ b/src/core/utilities/filter.ts
@@ -1,19 +1,11 @@
-import { filter } from 'lodash';
-
 import { axios } from '@/core/axios';
 import { transformFilterExpressions } from '@/core/react-query/filter/helpers';
 import queryClient from '@/core/react-query/queryClient';
-import { addFilterCriteria } from '@/core/slices/collection';
+import { setTree } from '@/core/slices/collection';
 import store from '@/core/store';
+import { createLeafNode, generateNodeId } from '@/core/utilities/filterTree';
 
-import type { ExpressionType, FilterCondition, FilterExpression, FilterTag } from '@/core/types/api/filter';
-
-type SidebarFilterState = {
-  filterConditions: Record<string, boolean>;
-  filterMatch: Record<string, 'Or' | 'And'>;
-  filterTags: Record<string, FilterTag[]>;
-  filterValues: Record<string, string[]>;
-};
+import type { FilterCondition, FilterExpression, LeafValue } from '@/core/types/api/filter';
 
 export const buildFilter = (filters: FilterCondition[]): FilterCondition => {
   if (filters.length > 1) {
@@ -26,94 +18,10 @@ export const buildFilter = (filters: FilterCondition[]): FilterCondition => {
   return filters[0];
 };
 
-const buildTagCondition = (
-  condition: FilterTag,
-  type: ExpressionType,
-): FilterCondition => (condition.isExcluded
-  ? { Type: 'Not', Left: { Type: type, Parameter: condition.Name } }
-  : { Type: type, Parameter: condition.Name });
-const buildSidebarFilterConditionTag = (conditionValues: FilterTag[], type: ExpressionType): FilterCondition => {
-  if (conditionValues.length > 1) {
-    return {
-      Type: 'And',
-      Left: buildTagCondition(conditionValues[0], type),
-      Right: buildSidebarFilterConditionTag(conditionValues.slice(1), type),
-    };
-  }
-  return buildTagCondition(conditionValues[0], type);
-};
-const buildSidebarFilterConditionMultivalue = (
-  conditionValues: string[],
-  type: ExpressionType,
-  operator: 'Or' | 'And' = 'And',
-): FilterCondition => {
-  if (conditionValues.length > 1) {
-    return {
-      Type: operator,
-      Left: { Type: type, Parameter: conditionValues[0] },
-      Right: buildSidebarFilterConditionMultivalue(conditionValues.slice(1), type),
-    };
-  }
-  return { Type: type, Parameter: conditionValues[0] };
-};
-
-const buildSidebarFilterConditionMultivaluePair = (
-  conditionValues: string[][],
-  type: ExpressionType,
-  operator: 'Or' | 'And' = 'And',
-): FilterCondition => {
-  if (conditionValues.length > 1) {
-    return {
-      Type: operator,
-      Left: { Type: type, Parameter: conditionValues[0][0], SecondParameter: conditionValues[0][1] },
-      Right: buildSidebarFilterConditionMultivaluePair(conditionValues.slice(1), type),
-    };
-  }
-  return { Type: type, Parameter: conditionValues[0][0], SecondParameter: conditionValues[0][1] };
-};
-
-const buildSidebarFilterCondition = (
-  currentFilter: FilterExpression,
-  sidebarFilterState: SidebarFilterState,
-): FilterCondition => {
-  if (currentFilter.Expression === 'HasCustomTag' || currentFilter.Expression === 'HasTag') {
-    const tagValues = sidebarFilterState.filterTags[currentFilter.Expression];
-    return buildSidebarFilterConditionTag(tagValues, currentFilter.Expression);
-  }
-  if (currentFilter?.PossibleParameterPairs) {
-    // TODO: Using ': ' as a delimiter, but this might need to be changed in the future.
-    // Currently only In Season expression has possible parameter pairs.
-    const filterValues = sidebarFilterState.filterValues[currentFilter.Expression].map(
-      value => value.split(': '),
-    );
-    const filterMatch = sidebarFilterState.filterMatch[currentFilter.Expression] ?? 'Or';
-    return buildSidebarFilterConditionMultivaluePair(filterValues, currentFilter.Expression, filterMatch);
-  }
-  if (currentFilter?.PossibleParameters ?? currentFilter?.Parameter === 'Number') {
-    const filterValues = sidebarFilterState.filterValues[currentFilter.Expression];
-    const filterMatch = sidebarFilterState.filterMatch[currentFilter.Expression] ?? 'Or';
-    return buildSidebarFilterConditionMultivalue(filterValues, currentFilter.Expression, filterMatch);
-  }
-
-  const value = sidebarFilterState.filterConditions[currentFilter.Expression] ?? true;
-  return value ? { Type: currentFilter.Expression } : { Type: 'Not', Left: { Type: currentFilter.Expression } };
-};
-
-export const buildSidebarFilter = (
-  filters: FilterExpression[],
-  sidebarFilterState: SidebarFilterState,
-): FilterCondition => {
-  if (filters.length > 1) {
-    return {
-      Type: 'And',
-      Left: buildSidebarFilterCondition(filters[0], sidebarFilterState),
-      Right: buildSidebarFilter(filters.slice(1), sidebarFilterState),
-    };
-  }
-  return buildSidebarFilterCondition(filters[0], sidebarFilterState);
-};
-
-export const addFilterCriteriaToStore = async (newCriteria: string) => {
+// Replaces the entire sidebar filter with a single condition, used by "quick filter"
+// entry points elsewhere in the app (e.g. clicking a tag, or a dashboard stat) that jump
+// straight to the live collection filter pre-populated with one criterion.
+export const startQuickFilter = async (expressionType: string, valueOverride?: LeafValue) => {
   const allCriteria = transformFilterExpressions(
     await queryClient.fetchQuery<FilterExpression[]>(
       {
@@ -123,6 +31,11 @@ export const addFilterCriteriaToStore = async (newCriteria: string) => {
       },
     ),
   );
-  const filterExpression = filter(allCriteria, { Expression: newCriteria })[0] as FilterExpression;
-  store.dispatch(addFilterCriteria(filterExpression));
+  const entry = allCriteria.find(item => item.Expression === expressionType);
+  if (!entry) return;
+
+  const leaf = createLeafNode(entry);
+  if (valueOverride) leaf.value = valueOverride;
+
+  store.dispatch(setTree({ id: generateNodeId(), kind: 'group', operator: 'And', negate: false, children: [leaf] }));
 };

--- a/src/core/utilities/filterTree.ts
+++ b/src/core/utilities/filterTree.ts
@@ -1,0 +1,288 @@
+import type {
+  FilterCondition,
+  FilterExpression,
+  GroupNode,
+  LeafNode,
+  LeafValue,
+  TreeNode,
+  UnsupportedNode,
+} from '@/core/types/api/filter';
+
+let fallbackIdCounter = 0;
+export const generateNodeId = (): string => {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') return crypto.randomUUID();
+  fallbackIdCounter += 1;
+  return `node-${fallbackIdCounter}`;
+};
+
+// Tag-style expressions have a bespoke editor (separate AniDB/user tag search endpoints,
+// include/exclude UI) that can't be derived from catalog metadata alone — their possible
+// values come from useAniDBTagsQuery/useUserTagsQuery, not the catalog's PossibleParameters.
+const TAG_LIKE_EXPRESSIONS = new Set(['HasTag', 'HasCustomTag']);
+
+// Single source of truth for widget selection, replacing the two independent hardcoded
+// heuristics that used to live in Criteria.tsx and buildSidebarFilterCondition.
+export const getWidgetKind = (entry: FilterExpression): 'boolean' | 'multi' | 'multiPair' | 'tag' => {
+  if (TAG_LIKE_EXPRESSIONS.has(entry.Expression)) return 'tag';
+  if (entry.PossibleParameterPairs) return 'multiPair';
+  if (entry.PossibleParameters ?? entry.Parameter === 'Number') return 'multi';
+  return 'boolean';
+};
+
+export const createLeafNode = (entry: FilterExpression): LeafNode => {
+  const base = { id: generateNodeId(), kind: 'leaf' as const, expression: entry.Expression, negate: false };
+  switch (getWidgetKind(entry)) {
+    case 'tag':
+      return { ...base, value: { kind: 'tag', tags: [] } };
+    case 'multiPair':
+      return { ...base, value: { kind: 'multiPair', values: [], match: 'Or' } };
+    case 'multi':
+      return { ...base, value: { kind: 'multi', values: [], match: 'Or' } };
+    case 'boolean':
+    default:
+      return { ...base, value: { kind: 'boolean', value: true } };
+  }
+};
+
+export const createEmptyGroupNode = (operator: 'And' | 'Or' = 'And'): GroupNode => ({
+  id: generateNodeId(),
+  kind: 'group',
+  operator,
+  negate: false,
+  children: [],
+});
+
+const unsupported = (condition: FilterCondition): UnsupportedNode => ({
+  id: generateNodeId(),
+  kind: 'unsupported',
+  raw: condition,
+});
+
+// Parses one atomic (non-And/Or) condition, unwrapping a single leading Not if present.
+// Function calls and comparison operators over typed selectors (anything with a Left or
+// Right slot per the catalog) are permanently out of scope for the editable widgets and
+// become UnsupportedNode, preserved byte-for-byte.
+const parseAtomicCondition = (condition: FilterCondition, catalog: FilterExpression[]): TreeNode => {
+  const negated = condition.Type === 'Not';
+  const inner = negated ? condition.Left : condition;
+  if (!inner) return unsupported(condition);
+
+  const entry = catalog.find(item => item.Expression === inner.Type);
+  if (!entry || entry.Left || entry.Right) return unsupported(condition);
+
+  const id = generateNodeId();
+  switch (getWidgetKind(entry)) {
+    case 'tag': {
+      if (inner.Parameter === undefined) return unsupported(condition);
+      return {
+        id,
+        kind: 'leaf',
+        expression: inner.Type,
+        negate: false,
+        value: { kind: 'tag', tags: [{ Name: inner.Parameter, isExcluded: negated }] },
+      };
+    }
+    case 'multiPair': {
+      if (inner.Parameter === undefined || inner.SecondParameter === undefined) return unsupported(condition);
+      return {
+        id,
+        kind: 'leaf',
+        expression: inner.Type,
+        negate: negated,
+        value: { kind: 'multiPair', values: [[inner.Parameter, inner.SecondParameter]], match: 'Or' },
+      };
+    }
+    case 'multi': {
+      if (inner.Parameter === undefined) return unsupported(condition);
+      return {
+        id,
+        kind: 'leaf',
+        expression: inner.Type,
+        negate: negated,
+        value: { kind: 'multi', values: [inner.Parameter], match: 'Or' },
+      };
+    }
+    case 'boolean':
+    default:
+      // Not is absorbed into the True/False value itself here, mirroring the existing
+      // DefaultCriteria widget - a boolean leaf never needs its own negate chip.
+      return { id, kind: 'leaf', expression: inner.Type, negate: false, value: { kind: 'boolean', value: !negated } };
+  }
+};
+
+// Only leaves of the same expression AND the same mergeable value kind combine - and only
+// when neither is itself negated, since a negated multi/multiPair value can't be folded
+// into a shared value list without losing its per-value Not semantics.
+const mergeKey = (node: TreeNode): string | null => {
+  if (node.kind !== 'leaf') return null;
+  if (node.value.kind === 'tag') return `tag:${node.expression}`;
+  if ((node.value.kind === 'multi' || node.value.kind === 'multiPair') && !node.negate) {
+    return `${node.value.kind}:${node.expression}`;
+  }
+  return null;
+};
+
+const mergeTwoLeaves = (first: LeafNode, second: LeafNode, operator: 'And' | 'Or'): LeafNode => {
+  if (first.value.kind === 'tag' && second.value.kind === 'tag') {
+    return { ...first, value: { kind: 'tag', tags: [...first.value.tags, ...second.value.tags] } };
+  }
+  if (first.value.kind === 'multi' && second.value.kind === 'multi') {
+    return {
+      ...first,
+      value: { kind: 'multi', values: [...first.value.values, ...second.value.values], match: operator },
+    };
+  }
+  if (first.value.kind === 'multiPair' && second.value.kind === 'multiPair') {
+    return {
+      ...first,
+      value: { kind: 'multiPair', values: [...first.value.values, ...second.value.values], match: operator },
+    };
+  }
+  return first;
+};
+
+// Folds sibling leaves of the same expression produced by chaining multiple values under
+// one operator (e.g. HasTag('a') And HasTag('b')) back into the single multi-value widget
+// row that produced them, instead of showing one row per value.
+const mergeGroupChildren = (children: TreeNode[], operator: 'And' | 'Or'): TreeNode[] => {
+  const merged: TreeNode[] = [];
+  children.forEach((child) => {
+    const key = mergeKey(child);
+    const existingIndex = key === null ? -1 : merged.findIndex(item => mergeKey(item) === key);
+    if (existingIndex === -1) {
+      merged.push(child);
+    } else {
+      merged[existingIndex] = mergeTwoLeaves(merged[existingIndex] as LeafNode, child as LeafNode, operator);
+    }
+  });
+  return merged;
+};
+
+// Self-recursive: `collect` (flattening a same-operator chain) closes over the outer
+// `parseNode` binding, which is already fully assigned by the time `collect` is ever
+// invoked (it only runs when parseNode itself is called) - this keeps the mutual
+// recursion self-contained instead of two top-level consts forward-referencing each other.
+const parseNode = (condition: FilterCondition, catalog: FilterExpression[]): TreeNode => {
+  if (condition.Type === 'And' || condition.Type === 'Or') {
+    if (!condition.Left || !condition.Right) return unsupported(condition);
+    const { Type: operator } = condition;
+
+    const collect = (node: FilterCondition): TreeNode[] => {
+      if (node.Type === operator && node.Left && node.Right) {
+        return [...collect(node.Left), ...collect(node.Right)];
+      }
+      return [parseNode(node, catalog)];
+    };
+
+    const children = mergeGroupChildren(collect(condition), operator);
+    if (children.length === 1) return children[0];
+    return { id: generateNodeId(), kind: 'group', operator, negate: false, children };
+  }
+
+  if (condition.Type === 'Not' && (condition.Left?.Type === 'And' || condition.Left?.Type === 'Or')) {
+    const innerGroup = parseNode(condition.Left, catalog);
+    if (innerGroup.kind === 'unsupported') return unsupported(condition);
+    return { ...innerGroup, negate: !innerGroup.negate };
+  }
+
+  return parseAtomicCondition(condition, catalog);
+};
+
+// Total: always succeeds. The root of the tree is always a GroupNode (possibly with a
+// single child) so Redux state has one uniform shape to render/mutate, even when the
+// underlying preset's root isn't itself a plain And (e.g. a single-condition or Or-rooted
+// preset gets wrapped as the sole child of an implicit top-level And container).
+export const parseFilterTree = (
+  condition: FilterCondition | undefined,
+  catalog: FilterExpression[],
+): GroupNode | null => {
+  if (!condition) return null;
+
+  const node = parseNode(condition, catalog);
+  if (node.kind === 'group' && node.operator === 'And' && !node.negate) return node;
+  return { id: generateNodeId(), kind: 'group', operator: 'And', negate: false, children: [node] };
+};
+
+const buildGroupChain = (conditions: FilterCondition[], operator: 'And' | 'Or'): FilterCondition => {
+  if (conditions.length > 1) {
+    return { Type: operator, Left: conditions[0], Right: buildGroupChain(conditions.slice(1), operator) };
+  }
+  return conditions[0];
+};
+
+const buildLeafValue = (expression: string, value: LeafValue): FilterCondition => {
+  switch (value.kind) {
+    case 'boolean':
+      return value.value ? { Type: expression } : { Type: 'Not', Left: { Type: expression } };
+    case 'multi':
+      return buildGroupChain(value.values.map(param => ({ Type: expression, Parameter: param })), value.match);
+    case 'multiPair':
+      return buildGroupChain(
+        value.values.map(([param, secondParam]) => ({
+          Type: expression,
+          Parameter: param,
+          SecondParameter: secondParam,
+        })),
+        value.match,
+      );
+    case 'tag':
+      return buildGroupChain(
+        value.tags.map(tag => (
+          tag.isExcluded
+            ? { Type: 'Not', Left: { Type: expression, Parameter: tag.Name } }
+            : { Type: expression, Parameter: tag.Name }
+        )),
+        'And',
+      );
+    default:
+      return { Type: expression };
+  }
+};
+
+const buildNode = (node: TreeNode): FilterCondition => {
+  if (node.kind === 'unsupported') return node.raw;
+
+  if (node.kind === 'group') {
+    const built = buildGroupChain(node.children.map(buildNode), node.operator);
+    return node.negate ? { Type: 'Not', Left: built } : built;
+  }
+
+  const built = buildLeafValue(node.expression, node.value);
+  return node.negate ? { Type: 'Not', Left: built } : built;
+};
+
+// Inverse of parseFilterTree. A null/empty tree omits Expression entirely rather than
+// sending an empty group, matching filters like the server's default "All" preset.
+export const buildFilterTree = (node: GroupNode | null): FilterCondition | undefined => {
+  if (!node || node.children.length === 0) return undefined;
+  return buildNode(node);
+};
+
+// Shared tree-navigation helpers used by both the Redux slice (id-addressed mutations)
+// and selectors (e.g. "which expressions are already used in this group").
+export const findNodeById = (node: TreeNode, nodeId: string): TreeNode | null => {
+  if (node.id === nodeId) return node;
+  if (node.kind === 'group') {
+    for (const child of node.children) {
+      const found = findNodeById(child, nodeId);
+      if (found) return found;
+    }
+  }
+  return null;
+};
+
+export const findGroupById = (node: TreeNode, groupId: string): GroupNode | null => {
+  const found = findNodeById(node, groupId);
+  return found?.kind === 'group' ? found : null;
+};
+
+export const removeNodeById = (root: GroupNode, nodeId: string): void => {
+  const index = root.children.findIndex(child => child.id === nodeId);
+  if (index !== -1) {
+    root.children.splice(index, 1);
+    return;
+  }
+  root.children.forEach((child) => {
+    if (child.kind === 'group') removeNodeById(child, nodeId);
+  });
+};

--- a/src/pages/collection/Collection.tsx
+++ b/src/pages/collection/Collection.tsx
@@ -25,6 +25,7 @@ import { useSettingsQuery } from '@/core/react-query/settings/queries';
 import { useGroupViewQuery } from '@/core/react-query/webui/queries';
 import { resetFilter, setEditingFilterId, setTree } from '@/core/slices/collection';
 import { useDispatch, useSelector } from '@/core/store';
+import toast from '@/core/toast';
 import { buildFilter } from '@/core/utilities/filter';
 import { parseFilterTree } from '@/core/utilities/filterTree';
 import useFlattenListResult from '@/hooks/useFlattenListResult';
@@ -135,7 +136,14 @@ const Collection = () => {
   const canEditFilter = !!filterId && !isLiveFilter;
   const handleEditFilter = () => {
     if (!canEditFilter || !filterQuery.data) return;
-    dispatch(setTree(parseFilterTree(filterQuery.data.Expression, catalogQuery.data ?? [])));
+    if (!catalogQuery.data) {
+      // Without the catalog, every leaf would fail its lookup and get misclassified as
+      // permanently unsupported instead of just not being ready yet - refuse to parse
+      // rather than silently corrupting the loaded tree.
+      toast.error('Could not load filter expressions, try again.');
+      return;
+    }
+    dispatch(setTree(parseFilterTree(filterQuery.data.Expression, catalogQuery.data)));
     dispatch(setEditingFilterId(toNumber(filterId)));
     // Absolute path: unlike handleFilterSidebarToggle (called when no filterId is present
     // yet, so a relative 'filter/live' correctly appends), we're navigating away from a

--- a/src/pages/collection/Collection.tsx
+++ b/src/pages/collection/Collection.tsx
@@ -13,6 +13,7 @@ import EditSeriesModal from '@/components/Collection/Series/EditSeriesModal';
 import TimelineSidebar from '@/components/Collection/TimelineSidebar';
 import TitleOptions from '@/components/Collection/TitleOptions';
 import {
+  useAllFilterExpressionsQuery,
   useFilterQuery,
   useFilteredGroupSeries,
   useFilteredGroupsInfiniteQuery,
@@ -22,9 +23,10 @@ import { resetQueries } from '@/core/react-query/queryClient';
 import { usePatchSettingsMutation } from '@/core/react-query/settings/mutations';
 import { useSettingsQuery } from '@/core/react-query/settings/queries';
 import { useGroupViewQuery } from '@/core/react-query/webui/queries';
-import { resetFilter } from '@/core/slices/collection';
+import { resetFilter, setEditingFilterId, setTree } from '@/core/slices/collection';
 import { useDispatch, useSelector } from '@/core/store';
 import { buildFilter } from '@/core/utilities/filter';
+import { parseFilterTree } from '@/core/utilities/filterTree';
 import useFlattenListResult from '@/hooks/useFlattenListResult';
 import useNavigateVoid from '@/hooks/useNavigateVoid';
 
@@ -128,6 +130,19 @@ const Collection = () => {
   }, [activeFilterFromStore, filterId]);
   const filterQuery = useFilterQuery(toNumber(filterId!), !!filterId && !isLiveFilter);
   const groupQuery = useGroupQuery(toNumber(groupId!), isSeries);
+  const catalogQuery = useAllFilterExpressionsQuery(!!filterId && !isLiveFilter);
+
+  const canEditFilter = !!filterId && !isLiveFilter;
+  const handleEditFilter = () => {
+    if (!canEditFilter || !filterQuery.data) return;
+    dispatch(setTree(parseFilterTree(filterQuery.data.Expression, catalogQuery.data ?? [])));
+    dispatch(setEditingFilterId(toNumber(filterId)));
+    // Absolute path: unlike handleFilterSidebarToggle (called when no filterId is present
+    // yet, so a relative 'filter/live' correctly appends), we're navigating away from a
+    // URL that already has a /filter/:filterId segment - a relative navigate would nest
+    // under it instead of replacing it.
+    navigate(isSeries ? `/webui/collection/group/${groupId}/filter/live` : '/webui/collection/filter/live');
+  };
 
   const settings = useSettingsQuery().data;
   const viewSetting = settings.WebUI_Settings.collection.view;
@@ -147,8 +162,11 @@ const Collection = () => {
   };
 
   useEffect(() => {
-    if (filterId === 'live') setShowFilterSidebar(true);
-    if (!filterId) setShowFilterSidebar(false);
+    // The sidebar's own toggle button is hidden while viewing a saved preset (its
+    // controls - Add condition, Clear Filter - don't apply until you're actually editing
+    // it via the Edit Filter action), so make sure it can't be left open with no way to
+    // close it from there.
+    setShowFilterSidebar(filterId === 'live');
   }, [filterId, setShowFilterSidebar]);
 
   const { mutate: patchSettings } = usePatchSettingsMutation();
@@ -251,10 +269,12 @@ const Collection = () => {
             searchQuery={isSeries ? seriesSearch : groupSearch}
           />
           <TitleOptions
+            canEditFilter={canEditFilter}
             groupSearch={groupSearch}
             isSeries={isSeries}
             item={item}
             mode={mode}
+            onEditFilter={handleEditFilter}
             seriesSearch={seriesSearch}
             setSearch={setSearch}
             toggleFilterSidebar={handleFilterSidebarToggle}

--- a/src/pages/dashboard/panels/CollectionStats.tsx
+++ b/src/pages/dashboard/panels/CollectionStats.tsx
@@ -5,7 +5,7 @@ import ShokoPanel from '@/components/Panels/ShokoPanel';
 import { useDashbordStatsQuery } from '@/core/react-query/dashboard/queries';
 import { resetFilter } from '@/core/slices/collection';
 import { useDispatch, useSelector } from '@/core/store';
-import { addFilterCriteriaToStore } from '@/core/utilities/filter';
+import { startQuickFilter } from '@/core/utilities/filter';
 import useNavigateVoid from '@/hooks/useNavigateVoid';
 
 const Item = (
@@ -15,7 +15,7 @@ const Item = (
   const navigate = useNavigateVoid();
   const handleMissingFilter = (filterName: string) => {
     dispatch(resetFilter());
-    addFilterCriteriaToStore(filterName).then(() => {
+    startQuickFilter(filterName).then(() => {
       navigate('/webui/collection/filter/live');
     }).catch(console.error);
   };


### PR DESCRIPTION
## Summary
- Filter state moves from a flat map to a recursive AND/OR/NOT tree matching the shape of the server's expression format, enabling arbitrary nesting and negation (not just flat AND) instead of the old implicit-AND-only model.
- Saved filter presets can now be loaded back into the sidebar and edited in place ("Edit Filter" action), then saved back to the existing preset — previously editing was disabled entirely since there was no way to parse a saved condition tree back into UI state.
- Conditions the UI can't represent (date/comparison-based expressions) are preserved read-only rather than dropped, so editing part of a preset never corrupts the rest.
- Sidebar UI stays visually unchanged for the common flat-AND case; AND/OR/NOT controls only appear when actually needed.