### PR TITLE
Simplify link-with-providers workflow

### DIFF
--- a/docs/LinkFilesWithProviders.md
+++ b/docs/LinkFilesWithProviders.md
@@ -26,6 +26,9 @@ src/hooks/utilities/
 src/core/utilities/
   releaseInfoHelpers.ts          Pure helpers: createLinksFromFiles, mergeReleaseInfo
 
+src/core/types/utilities/
+  link-files-with-providers.ts    ManualLinkType, ManualLinkProviderType, LinkStateType
+
 src/components/Utilities/Unrecognized/LinkFilesWithProvider/
   LinkCard.tsx                    Per-link card (state-driven styling, selection)
   ProviderName.tsx               Status text per state
@@ -37,7 +40,7 @@ src/components/Utilities/Unrecognized/LinkFilesWithProvider/
 ## Key Types
 
 ```ts
-type LinkStateType = 'pre-init' | 'init' | 'searching' | 'ready' | 'submitting' | 'submitted' | 'fetching';
+type LinkStateType = 'init' | 'searching' | 'ready' | 'submitting' | 'submitted' | 'fetching';
 
 type ManualLinkProviderType = { id: string; enabled: boolean };
 
@@ -54,12 +57,11 @@ Each link's `state` field drives the entire workflow — the component never dir
 
 ## State Groups
 
-Three constants replace repeated arrays across the component:
+Two constants replace repeated arrays across the component:
 
 | Name | Values | Guards |
 |---|---|---|
-| `BUSY_STATES` | `searching, submitting, fetching` | Blocks removal; Escape cancels active work |
-| `NOT_SELECTABLE_STATES` | `pre-init` + `BUSY_STATES` | Blocks select-all |
+| `BUSY_STATES` | `searching, submitting, fetching` | Blocks removal and select-all; Escape cancels active work |
 | `EDITABLE_STATES` | `ready, init` | Enables search, provider update |
 
 ## State Machine
@@ -75,13 +77,7 @@ flowchart TD
     FetchResult -- Yes --> Ready[ready]
     FetchResult -- No or error --> Init[init]
 
-    Imported -- No --> PreInit[pre-init]
-    PreInit --> OfflineImporter{Offline Importer available?}
-    OfflineImporter -- No --> Providers{Providers enabled?}
-    OfflineImporter -- Yes --> Preview[Offline Importer preview]
-    Preview -- Non-null result --> Providers
-    Preview -- Error --> Providers
-    Preview -- Null result --> PreInit
+    Imported -- No --> Providers{Providers enabled?}
 
     Providers -- Yes --> Searching[searching]
     Providers -- No --> Init
@@ -100,7 +96,6 @@ flowchart TD
 
 | State | UI | Meaning |
 |---|---|---|
-| `pre-init` | `opacity-65 cursor-wait` | Seeding metadata via Offline Importer |
 | `init` | `text-warning` | Waiting for user to configure providers |
 | `searching` | `animate-pulse cursor-wait` | AutoPreview in progress |
 | `fetching` | `animate-pulse cursor-wait` | Fetching existing release info for already-linked files |
@@ -110,25 +105,12 @@ flowchart TD
 
 ### Process Handlers
 
-All handlers are `useEffectEvent` callbacks inside `useLinkWorkflow`. Each gates on a guard Set (`inFlight.current.*`) to prevent duplicate in-flight API calls, adds the link ID before calling, and normally removes it in `finally`.
-
-### `processPreInit`
-
-1. Checks if any provider is enabled
-2. Looks up the "Offline Importer" provider by name via `providerMap`
-3. If no Offline Importer exists → transitions directly to `searching` or `init`
-4. Otherwise calls `GET ReleaseInfo/Provider/{id}/Preview/By-Release?id=match://<path>` to seed file metadata
-5. On a non-null success: stores the seed release → `searching` or `init`
-6. On error: → `searching` or `init`
-
-If the preview returns null, the current implementation leaves the link in `pre-init` after clearing its guard.
-
-**State outcome**: `hasProvidersEnabled ? 'searching' : 'init'`
+All handlers are `useEffectEvent` callbacks inside `useLinkWorkflow`. Each gates on a guard Set (`inFlight.current.*`) to prevent duplicate in-flight API calls, adds the link ID before calling, and removes it in `finally`.
 
 ### `processSearch`
 
 1. Filters enabled providers from `link.providers`
-2. If none enabled → bails (guard NOT cleared; stays `searching` until providers are added)
+2. If none enabled → clears the guard and → `init`
 3. Calls `POST ReleaseInfo/File/{id}/AutoPreview?providerIDs=...`
 4. On null result → `init`
 5. On data → merges result via `mergeReleaseInfo(incoming, link.release)` → `ready`
@@ -155,7 +137,7 @@ Flips busy states back to idle when the user presses Escape: `submitting` → `r
 
 Converts `FileType[]` into `Record<number, ManualLinkType>`:
 
-1. Sorts files by the first accessible location's `RelativePath` (natural sort, case-insensitive, numeric, ignoring punctuation)
+1. Sorts files by `RelativePath` of the first accessible location (falling back to the first location) — natural, case-insensitive, numeric, ignoring punctuation
 2. For each file, builds a seed `ReleaseInfoType`:
    - `OriginalFilename` from last path segment
    - `ProviderName: 'User'`, `Source: Unknown`
@@ -163,25 +145,24 @@ Converts `FileType[]` into `Record<number, ManualLinkType>`:
    - `Released` date from `MediaInfo.Encoded` or `file.Created`
 3. Checks `file.Imported`:
    - **truthy** → `providers: []`, `state: 'fetching'` (will call GET ReleaseInfo)
-   - **falsy** → `providers` from settings, `state: 'pre-init'`
+   - **falsy** → `providers` from settings, `state: 'searching'` (if any provider is enabled) or `'init'`
 
 ### `mergeReleaseInfo(incoming, original)`
 
-Merges AutoPreview result into the user's seed release. Preserves user-set fields (`Source`, `FileSize`, `OriginalFilename`, flags) via nullish coalescing, enforces `Version >= 1`, and appends `+User` to `ProviderName` if not already present.
+Merges AutoPreview result into the user's seed release. Preserves user-set fields via nullish coalescing (`FileSize`, `OriginalFilename`, `IsChaptered`, `IsCensored`, `IsCreditless`, `Group`), restores `Source` from the original only when the incoming `Source` is `Unknown`, enforces `Version >= 1`, and appends `+User` to `ProviderName` if not already present.
 
 ## API Endpoints
 
 | Endpoint | Method | Used by | Purpose |
 |---|---|---|---|
 | `ReleaseInfo/Provider` | GET | Component | Fetch available providers |
-| `ReleaseInfo/Provider/{id}/Preview/By-Release?id=match://<path>` | GET | `processPreInit` | Seed metadata from Offline Importer |
 | `ReleaseInfo/File/{id}/AutoPreview?providerIDs=...` | POST | `processSearch` | Search enabled providers |
 | `ReleaseInfo/File/{id}` | GET | `processLinked` | Fetch existing release info |
 | `ReleaseInfo/File/{id}` | POST | `processSubmit` | Submit release info |
 
 ## Supporting Components
 
-- **`LinkCard`** — Per-link card. Border color reflects state (`submitted` → important, `searching`/`submitting` → primary, `ready` → warning). Click-to-select disabled for `NOT_SELECTABLE_STATES`.
-- **`ProviderName`** — Status text per state (`"Retrieving existing release info..."` for `fetching`, etc.). Appends "(Edited by User)" when `ProviderName` contains `+User`.
-- **`Menu`** — Action bar. "Search for Release Info" enables when any selected link is in `['ready', 'init', 'fetching']`. Hotkeys: `S` search, `E` edit, `A` select-all, `D` remove, `Q` submit.
-- **`TitleOptions`** — Header showing `{submitted} / {submitted + pending} Submitted | {total} Files | {selected} Selected`. Only `ready` and `submitting` count as pending; `init`, `searching`, `fetching`, and `pre-init` do not.
+- **`LinkCard`** — Per-link card. Border color reflects state (`submitted` → important, `searching`/`submitting` → primary, `ready` → warning). Click-to-select disabled for busy states (`searching`/`submitting`/`fetching`).
+- **`ProviderName`** — Status text per state (`"Retrieving existing release info..."` for `fetching`, etc.). Appends "(Edited by User)" when `ProviderName` starts with `User+` or ends with `+User`.
+- **`Menu`** — Action bar. "Search for Release Info" enables when any selected link is in `['ready', 'init', 'fetching']`; "Remove Selected" and "Submit Selected" render conditionally. The "Edit Release Info" button (`E`) is a disabled placeholder. Hotkeys are registered on the page: `S` search, `A` select-all, `D` remove, `Q` submit, `Esc` cancel, `Enter` submit.
+- **`TitleOptions`** — Header showing `{submitted} / {submitted + pending} Submitted | {total} Files | {selected} Selected`. Only `ready` and `submitting` count as pending; `init`, `searching`, and `fetching` do not.

--- a/docs/LinkFilesWithProviders.md
+++ b/docs/LinkFilesWithProviders.md
@@ -149,7 +149,7 @@ Converts `FileType[]` into `Record<number, ManualLinkType>`:
 
 ### `mergeReleaseInfo(incoming, original)`
 
-Merges AutoPreview result into the user's seed release. Preserves user-set fields via nullish coalescing (`FileSize`, `OriginalFilename`, `IsChaptered`, `IsCensored`, `IsCreditless`, `Group`), restores `Source` from the original only when the incoming `Source` is `Unknown`, enforces `Version >= 1`, and appends `+User` to `ProviderName` if not already present.
+Merges AutoPreview result into the user's seed release. Preserves user-set fields via nullish coalescing (`FileSize`, `OriginalFilename`, `IsChaptered`, `IsCensored`, `IsCreditless`, `Group`), restores `Source` from the original only when the incoming `Source` is `Unknown`, enforces `Version >= 1`, and appends `+User` to `ProviderName` unless it is already `'User'` or already contains `+User`.
 
 ## API Endpoints
 

--- a/src/components/Utilities/Unrecognized/LinkFilesWithProvider/AutoSearchReleaseModal.tsx
+++ b/src/components/Utilities/Unrecognized/LinkFilesWithProvider/AutoSearchReleaseModal.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo } from 'react';
 import type { ChangeEvent } from 'react';
 import { useHotkeys } from 'react-hotkeys-hook';
-import { mdiInformationVariantCircleOutline } from '@mdi/js';
+import { mdiInformationVariantCircleOutline, mdiLoading } from '@mdi/js';
 import { Icon } from '@mdi/react';
 import { useImmer } from 'use-immer';
 
@@ -119,55 +119,62 @@ const AutoSearchReleaseModal = (props: Props) => {
           </span>
         </div>
         <div className="mt-2 flex min-h-10 rounded-lg border border-panel-border bg-panel-input px-4 py-2">
-          <DnDList onDragEnd={onDragEnd}>
-            {providers.map((provider, index) => (
-              {
-                key: provider.id,
-                item: (
-                  <Checkbox
-                    autoFocus={index === 0}
-                    id={provider.id}
-                    isChecked={provider.enabled}
-                    onChange={handleToggle}
-                    labelRight
-                    justify
-                    className="grow"
-                    labelClassName="grow"
-                    label={
-                      <>
-                        <span className="flex grow gap-x-1.5">
-                          {providerMap[provider.id].Name}
-                          <span className="self-center text-xs opacity-65">
-                            (
-                            {providerMap[provider.id].Plugin.Name}
-                            )
+          {!providersQuery.isSuccess && (
+            <div className="flex grow items-center justify-center">
+              <Icon className="text-panel-text-primary" path={mdiLoading} size={1} spin={0.5} />
+            </div>
+          )}
+          {providersQuery.isSuccess && (
+            <DnDList onDragEnd={onDragEnd}>
+              {providers.map((provider, index) => (
+                {
+                  key: provider.id,
+                  item: (
+                    <Checkbox
+                      autoFocus={index === 0}
+                      id={provider.id}
+                      isChecked={provider.enabled}
+                      onChange={handleToggle}
+                      labelRight
+                      justify
+                      className="grow"
+                      labelClassName="grow"
+                      label={
+                        <>
+                          <span className="flex grow gap-x-1.5">
+                            {providerMap[provider.id].Name}
+                            <span className="self-center text-xs opacity-65">
+                              (
+                              {providerMap[provider.id].Plugin.Name}
+                              )
+                            </span>
                           </span>
-                        </span>
-                        <span className="flex gap-x-1">
-                          {/* Temporarily disabled until configuration modal is added */}
-                          {/* {providerMap[provider.id].Configuration && ( */}
-                          {/*   <Button */}
-                          {/*     id={`${provider.id}-config`} */}
-                          {/*     className="text-button-primary opacity-65 cursor-default" */}
-                          {/*   > */}
-                          {/*     <Icon path={mdiCog} size={1} /> */}
-                          {/*   </Button> */}
-                          {/* )} */}
-                          <Button
-                            id={`${provider.id}-info`}
-                            onClick={() => handleShowInfoModal(provider.id)}
-                            className="text-button-primary"
-                          >
-                            <Icon path={mdiInformationVariantCircleOutline} size={1} />
-                          </Button>
-                        </span>
-                      </>
-                    }
-                  />
-                ),
-              }
-            ))}
-          </DnDList>
+                          <span className="flex gap-x-1">
+                            {/* Temporarily disabled until configuration modal is added */}
+                            {/* {providerMap[provider.id].Configuration && ( */}
+                            {/*   <Button */}
+                            {/*     id={`${provider.id}-config`} */}
+                            {/*     className="text-button-primary opacity-65 cursor-default" */}
+                            {/*   > */}
+                            {/*     <Icon path={mdiCog} size={1} /> */}
+                            {/*   </Button> */}
+                            {/* )} */}
+                            <Button
+                              id={`${provider.id}-info`}
+                              onClick={() => handleShowInfoModal(provider.id)}
+                              className="text-button-primary"
+                            >
+                              <Icon path={mdiInformationVariantCircleOutline} size={1} />
+                            </Button>
+                          </span>
+                        </>
+                      }
+                    />
+                  ),
+                }
+              ))}
+            </DnDList>
+          )}
         </div>
         <div className="mt-1 text-sm text-panel-text opacity-65">
           Enabled providers in the manual linking process, in priority order.
@@ -186,7 +193,7 @@ const AutoSearchReleaseModal = (props: Props) => {
           onClick={handleSearch}
           buttonType="primary"
           className="px-5 py-2"
-          disabled={!providers.length}
+          disabled={!providersQuery.isSuccess || !providers.length}
           keybinding="Enter"
         >
           Search

--- a/src/components/Utilities/Unrecognized/LinkFilesWithProvider/AutoSearchReleaseModal.tsx
+++ b/src/components/Utilities/Unrecognized/LinkFilesWithProvider/AutoSearchReleaseModal.tsx
@@ -15,7 +15,7 @@ import { hideProviderInfo, showProviderInfo } from '@/core/slices/modals/provide
 import { useDispatch, useSelector } from '@/core/store';
 import useToggleModalKeybinds from '@/hooks/useToggleModalKeybinds';
 
-import type { ManualLinkProviderType } from '@/core/types/utilities/unrecognized-utility';
+import type { ManualLinkProviderType } from '@/core/types/utilities/link-files-with-providers';
 import type { DropResult } from '@hello-pangea/dnd';
 
 type Props = {
@@ -30,7 +30,7 @@ const AutoSearchReleaseModal = (props: Props) => {
   const dispatch = useDispatch();
   const { show: showProviderInfoModal } = useSelector(state => state.modals.providerInfo);
 
-  const providersQuery = useReleaseInfoProvidersQuery(true);
+  const providersQuery = useReleaseInfoProvidersQuery(true, show);
   const providerMap = useMemo(() => {
     if (!providersQuery.data) return {};
     return Object.fromEntries(providersQuery.data.map(provider => [provider.ID, provider]));

--- a/src/components/Utilities/Unrecognized/LinkFilesWithProvider/LinkCard.tsx
+++ b/src/components/Utilities/Unrecognized/LinkFilesWithProvider/LinkCard.tsx
@@ -5,7 +5,7 @@ import CrossReference from './CrossReference';
 import ProviderName from './ProviderName';
 import VideoMetadata from './VideoMetadata';
 
-import type { ManualLinkType } from '@/core/types/utilities/unrecognized-utility';
+import type { ManualLinkType } from '@/core/types/utilities/link-files-with-providers';
 
 type Props = {
   link: ManualLinkType;
@@ -14,7 +14,6 @@ type Props = {
 };
 
 const linkStateClassMap = {
-  'pre-init': 'opacity-65 cursor-wait',
   init: '',
   searching: 'animate-pulse cursor-wait',
   ready: 'cursor-pointer',
@@ -24,7 +23,6 @@ const linkStateClassMap = {
 } as const;
 
 const selectionDisabledStates = [
-  'pre-init',
   'searching',
   'submitting',
   'fetching',

--- a/src/components/Utilities/Unrecognized/LinkFilesWithProvider/Menu.tsx
+++ b/src/components/Utilities/Unrecognized/LinkFilesWithProvider/Menu.tsx
@@ -2,7 +2,7 @@ import { mdiMagnify, mdiPencil, mdiSelectAll, mdiSelection, mdiSelectionRemove, 
 
 import MenuButton from '@/components/Utilities/Unrecognized/MenuButton';
 
-import type { ManualLinkType } from '@/core/types/utilities/unrecognized-utility';
+import type { ManualLinkType } from '@/core/types/utilities/link-files-with-providers';
 
 type Props = {
   linkCount: number;

--- a/src/components/Utilities/Unrecognized/LinkFilesWithProvider/ProviderName.tsx
+++ b/src/components/Utilities/Unrecognized/LinkFilesWithProvider/ProviderName.tsx
@@ -1,14 +1,10 @@
-import type { ManualLinkType } from '@/core/types/utilities/unrecognized-utility';
+import type { ManualLinkType } from '@/core/types/utilities/link-files-with-providers';
 
 type Props = {
   link: ManualLinkType;
 };
 
 const linkStateAttributes = {
-  'pre-init': {
-    className: 'opacity-65',
-    text: 'Initializing metadata...',
-  },
   init: {
     className: 'text-panel-text-warning',
     text: 'Waiting for user action',

--- a/src/components/Utilities/Unrecognized/LinkFilesWithProvider/TitleOptions.tsx
+++ b/src/components/Utilities/Unrecognized/LinkFilesWithProvider/TitleOptions.tsx
@@ -1,6 +1,6 @@
 import { countBy } from 'lodash';
 
-import type { LinkStateType, ManualLinkType } from '@/core/types/utilities/unrecognized-utility';
+import type { LinkStateType, ManualLinkType } from '@/core/types/utilities/link-files-with-providers';
 
 const TitleOptions = ({ links, selectedCount }: { links: ManualLinkType[], selectedCount: number }) => {
   const countByStatus = countBy(links, link => link.state) as Record<LinkStateType, number>;

--- a/src/components/Utilities/Unrecognized/LinkFilesWithProvider/VideoMetadata.tsx
+++ b/src/components/Utilities/Unrecognized/LinkFilesWithProvider/VideoMetadata.tsx
@@ -1,6 +1,6 @@
 import { ReleaseSource } from '@/core/types/api/file';
 
-import type { ManualLinkType } from '@/core/types/utilities/unrecognized-utility';
+import type { ManualLinkType } from '@/core/types/utilities/link-files-with-providers';
 
 const parseReleaseSource = (releaseSource: ReleaseSource) => {
   switch (releaseSource) {

--- a/src/core/react-query/release-info/mutations.ts
+++ b/src/core/react-query/release-info/mutations.ts
@@ -37,15 +37,6 @@ export const useAutoPreviewReleaseInfoForFileByIdMutation = () =>
     },
   });
 
-export const usePreviewReleaseInfoByProviderIdMutation = () =>
-  useMutation<ReleaseInfoType, unknown, { id: string, providerId: string }>({
-    mutationFn: ({ id, providerId }) =>
-      axios.get(`ReleaseInfo/Provider/${providerId}/Preview/By-Release`, { params: { id } }),
-    scope: {
-      id: 'release-info',
-    },
-  });
-
 export const useReleaseInfoByFileIdMutation = () =>
   useMutation<ReleaseInfoType | null, unknown, number>({
     mutationFn: fileId => axios.get(`ReleaseInfo/File/${fileId}`),

--- a/src/core/react-query/release-info/queries.ts
+++ b/src/core/react-query/release-info/queries.ts
@@ -4,9 +4,10 @@ import { axios } from '@/core/axios';
 
 import type { ReleaseProviderInfoType } from '@/core/react-query/release-info/types';
 
-export const useReleaseInfoProvidersQuery = (noStale = false) =>
+export const useReleaseInfoProvidersQuery = (noStale = false, enabled = true) =>
   useQuery<ReleaseProviderInfoType[]>({
     queryKey: ['release-info', 'providers', noStale],
     queryFn: () => axios.get('ReleaseInfo/Provider'),
     staleTime: noStale ? Infinity : 1000,
+    enabled,
   });

--- a/src/core/types/api/settings.ts
+++ b/src/core/types/api/settings.ts
@@ -1,7 +1,7 @@
 import type { Layout } from 'react-grid-layout';
 
 import type { ReleaseChannelType } from '@/core/types/api/init';
-import type { ManualLinkProviderType } from '@/core/types/utilities/unrecognized-utility';
+import type { ManualLinkProviderType } from '@/core/types/utilities/link-files-with-providers';
 
 export type SettingsDatabaseType = {
   MySqliteDirectory: string;

--- a/src/core/types/utilities/link-files-with-providers.ts
+++ b/src/core/types/utilities/link-files-with-providers.ts
@@ -1,6 +1,6 @@
 import type { FileType, ReleaseInfoType } from '@/core/types/api/file';
 
-export type LinkStateType = 'pre-init' | 'init' | 'searching' | 'ready' | 'submitting' | 'submitted' | 'fetching';
+export type LinkStateType = 'init' | 'searching' | 'ready' | 'submitting' | 'submitted' | 'fetching';
 
 export type ManualLinkProviderType = {
   id: string;

--- a/src/core/util.ts
+++ b/src/core/util.ts
@@ -15,7 +15,7 @@ import type { CollectionGroupType } from './types/api/collection';
 import type { EpisodeType } from './types/api/episode';
 import type { FileType } from './types/api/file';
 import type { SeriesType } from './types/api/series';
-import type { ManualLinkType } from './types/utilities/unrecognized-utility';
+import type { ManualLinkType } from './types/utilities/link-files-with-providers';
 import type { ShokoError } from '@/core/types/api';
 import type { SeriesWithCandidatesType } from '@/core/types/api/release-management';
 import type { AxiosError } from 'axios';

--- a/src/core/utilities/releaseInfoHelpers.ts
+++ b/src/core/utilities/releaseInfoHelpers.ts
@@ -3,7 +3,7 @@ import { produce } from 'immer';
 import { ReleaseSource } from '@/core/types/api/file';
 
 import type { FileType, ReleaseInfoType } from '@/core/types/api/file';
-import type { ManualLinkProviderType, ManualLinkType } from '@/core/types/utilities/unrecognized-utility';
+import type { ManualLinkProviderType, ManualLinkType } from '@/core/types/utilities/link-files-with-providers';
 
 let lastLinkId = 0;
 const generateLinkId = () => {
@@ -47,6 +47,7 @@ const createLinksFromFiles = (files: FileType[], providers: ManualLinkProviderTy
     });
   });
 
+  const hasEnabledProviders = providers.some(provider => provider.enabled);
   const newLinks: Record<number, ManualLinkType> = {};
   sortedFiles.forEach((file) => {
     const now = new Date().toISOString();
@@ -78,7 +79,7 @@ const createLinksFromFiles = (files: FileType[], providers: ManualLinkProviderTy
         id: linkId,
         file,
         providers,
-        state: 'pre-init',
+        state: hasEnabledProviders ? 'searching' : 'init',
         release,
       };
     }

--- a/src/core/utilities/releaseInfoHelpers.ts
+++ b/src/core/utilities/releaseInfoHelpers.ts
@@ -1,6 +1,7 @@
 import { produce } from 'immer';
 
 import { ReleaseSource } from '@/core/types/api/file';
+import { dayjs } from '@/core/util';
 
 import type { FileType, ReleaseInfoType } from '@/core/types/api/file';
 import type { ManualLinkProviderType, ManualLinkType } from '@/core/types/utilities/link-files-with-providers';
@@ -50,7 +51,7 @@ const createLinksFromFiles = (files: FileType[], providers: ManualLinkProviderTy
   const hasEnabledProviders = providers.some(provider => provider.enabled);
   const newLinks: Record<number, ManualLinkType> = {};
   sortedFiles.forEach((file) => {
-    const now = new Date().toISOString();
+    const now = dayjs().toISOString();
     const release: ReleaseInfoType = {
       OriginalFilename: file.Locations?.[0]?.RelativePath.split(/[/\\]/g).pop(),
       ProviderName: 'User',

--- a/src/hooks/useRowSelection.ts
+++ b/src/hooks/useRowSelection.ts
@@ -6,7 +6,7 @@ import type { EpisodeType } from '@/core/types/api/episode';
 import type { FileType } from '@/core/types/api/file';
 import type { SeriesWithCandidatesType } from '@/core/types/api/release-management';
 import type { SeriesType } from '@/core/types/api/series';
-import type { ManualLinkType } from '@/core/types/utilities/unrecognized-utility';
+import type { ManualLinkType } from '@/core/types/utilities/link-files-with-providers';
 
 type RowType = EpisodeType | FileType | SeriesType | ManualLinkType | SeriesWithCandidatesType;
 

--- a/src/hooks/utilities/useLinkWorkflow.ts
+++ b/src/hooks/utilities/useLinkWorkflow.ts
@@ -3,67 +3,28 @@ import { forEach } from 'lodash';
 
 import {
   useAutoPreviewReleaseInfoForFileByIdMutation,
-  usePreviewReleaseInfoByProviderIdMutation,
   useReleaseInfoByFileIdMutation,
   useSubmitReleaseInfoForFileByIdMutation,
 } from '@/core/react-query/release-info/mutations';
 import { mergeReleaseInfo } from '@/core/utilities/releaseInfoHelpers';
 
-import type { ManualLinkType } from '@/core/types/utilities/unrecognized-utility';
+import type { ManualLinkType } from '@/core/types/utilities/link-files-with-providers';
 import type { Updater } from 'use-immer';
 
 const useLinkWorkflow = (
   links: ManualLinkType[],
   setLinks: Updater<Record<number, ManualLinkType>>,
-  providerMap: Record<string, { ID: string, Name: string }>,
   initialized: boolean,
 ) => {
-  const { mutateAsync: previewReleaseInfo } = usePreviewReleaseInfoByProviderIdMutation();
   const { mutateAsync: searchReleaseInfo } = useAutoPreviewReleaseInfoForFileByIdMutation();
   const { mutateAsync: submitReleaseInfo } = useSubmitReleaseInfoForFileByIdMutation();
   const { mutateAsync: fetchReleaseInfo } = useReleaseInfoByFileIdMutation();
 
   // useRef avoids re-renders — these Sets track in-flight API calls (bookkeeping only, not UI state)
   const inFlight = useRef({
-    initializing: new Set<number>(),
     searching: new Set<number>(),
     submitting: new Set<number>(),
     fetching: new Set<number>(),
-  });
-
-  const processPreInit = useEffectEvent((link: ManualLinkType) => {
-    if (inFlight.current.initializing.has(link.id)) return;
-    inFlight.current.initializing.add(link.id);
-
-    const hasProvidersEnabled = link.providers.some(provider => provider.enabled);
-    const offlineImporterProviderId = link.providers.find(
-      provider => providerMap[provider.id]?.Name === 'Offline Importer',
-    )?.id;
-
-    if (!offlineImporterProviderId) {
-      setLinks((draft) => {
-        draft[link.id].state = hasProvidersEnabled ? 'searching' : 'init';
-      });
-      return;
-    }
-
-    const path = link.file.Locations.find(location => location.AbsolutePath)?.AbsolutePath
-      ?? link.file.Locations?.[0]?.RelativePath ?? '';
-
-    previewReleaseInfo({ id: `match://${path}`, providerId: offlineImporterProviderId })
-      .then((data) => {
-        if (!data) return;
-        setLinks((draft) => {
-          draft[link.id].release = data;
-          draft[link.id].state = hasProvidersEnabled ? 'searching' : 'init';
-        });
-      })
-      .catch(() => {
-        setLinks((draft) => {
-          draft[link.id].state = hasProvidersEnabled ? 'searching' : 'init';
-        });
-      })
-      .finally(() => inFlight.current.initializing.delete(link.id));
   });
 
   const processSearch = useEffectEvent((link: ManualLinkType) => {
@@ -73,7 +34,13 @@ const useLinkWorkflow = (
     const enabledReleaseProviders = link.providers
       .filter(provider => provider.enabled)
       .map(provider => provider.id);
-    if (!enabledReleaseProviders.length) return;
+    if (!enabledReleaseProviders.length) {
+      inFlight.current.searching.delete(link.id);
+      setLinks((draft) => {
+        draft[link.id].state = 'init';
+      });
+      return;
+    }
 
     searchReleaseInfo({ fileId: link.file.ID, providerIDs: enabledReleaseProviders })
       .then((data) => {
@@ -145,9 +112,7 @@ const useLinkWorkflow = (
     if (!initialized || !links.length) return;
 
     links.forEach((link) => {
-      if (link.state === 'pre-init') {
-        processPreInit(link);
-      } else if (link.state === 'searching') {
+      if (link.state === 'searching') {
         processSearch(link);
       } else if (link.state === 'submitting') {
         processSubmit(link);
@@ -158,7 +123,6 @@ const useLinkWorkflow = (
   }, [initialized, links]);
 
   useEffect(() => () => {
-    inFlight.current.initializing.clear();
     inFlight.current.searching.clear();
     inFlight.current.submitting.clear();
     inFlight.current.fetching.clear();

--- a/src/pages/utilities/LinkFilesWithProviders.tsx
+++ b/src/pages/utilities/LinkFilesWithProviders.tsx
@@ -34,6 +34,7 @@ const LinkFilesWithProviders = () => {
   const selectedFiles = (useLocation().state as { selectedRows?: FileType[] })?.selectedRows ?? [];
 
   const settings = useSettingsQuery().data;
+  // settingsRevision is 0 on initialData; it only becomes > 0 after the real fetch resolves
   const isSettingsLoaded = settings.WebUI_Settings.settingsRevision > 0;
   const [linksDict, setLinks] = useImmer<Record<number, ManualLinkType>>({});
   const links = Object.values(linksDict);

--- a/src/pages/utilities/LinkFilesWithProviders.tsx
+++ b/src/pages/utilities/LinkFilesWithProviders.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useEffectEvent, useMemo, useRef, useState } from 'react';
+import { useEffect, useEffectEvent, useRef, useState } from 'react';
 import type { KeyboardEvent, MouseEvent } from 'react';
 import { useHotkeys } from 'react-hotkeys-hook';
 import { useLocation } from 'react-router';
@@ -16,7 +16,6 @@ import AutoSearchReleaseModal from '@/components/Utilities/Unrecognized/LinkFile
 import LinkCard from '@/components/Utilities/Unrecognized/LinkFilesWithProvider/LinkCard';
 import Menu from '@/components/Utilities/Unrecognized/LinkFilesWithProvider/Menu';
 import TitleOptions from '@/components/Utilities/Unrecognized/LinkFilesWithProvider/TitleOptions';
-import { useReleaseInfoProvidersQuery } from '@/core/react-query/release-info/queries';
 import { useSettingsQuery } from '@/core/react-query/settings/queries';
 import { handleShiftSelect } from '@/core/util';
 import createLinksFromFiles from '@/core/utilities/releaseInfoHelpers';
@@ -25,10 +24,9 @@ import useRowSelection from '@/hooks/useRowSelection';
 import useLinkWorkflow from '@/hooks/utilities/useLinkWorkflow';
 
 import type { FileType } from '@/core/types/api/file';
-import type { ManualLinkProviderType, ManualLinkType } from '@/core/types/utilities/unrecognized-utility';
+import type { ManualLinkProviderType, ManualLinkType } from '@/core/types/utilities/link-files-with-providers';
 
 const BUSY_STATES = new Set(['searching', 'submitting', 'fetching']);
-const NOT_SELECTABLE_STATES = new Set(['pre-init', ...BUSY_STATES]);
 const EDITABLE_STATES = new Set(['ready', 'init']);
 
 const LinkFilesWithProviders = () => {
@@ -36,12 +34,7 @@ const LinkFilesWithProviders = () => {
   const selectedFiles = (useLocation().state as { selectedRows?: FileType[] })?.selectedRows ?? [];
 
   const settings = useSettingsQuery().data;
-  const releaseProvidersQuery = useReleaseInfoProvidersQuery(true);
-  const providerMap = useMemo(() => {
-    if (!releaseProvidersQuery.data) return {};
-    return Object.fromEntries(releaseProvidersQuery.data.map(provider => [provider.ID, provider]));
-  }, [releaseProvidersQuery.data]);
-
+  const isSettingsLoaded = settings.WebUI_Settings.settingsRevision > 0;
   const [linksDict, setLinks] = useImmer<Record<number, ManualLinkType>>({});
   const links = Object.values(linksDict);
   const [initialized, setInitialized] = useState(false);
@@ -50,7 +43,7 @@ const LinkFilesWithProviders = () => {
   const [confirmCancel, setConfirmCancel] = useState(false);
 
   const initializeLinks = useEffectEvent(() => {
-    if (!releaseProvidersQuery.data) return;
+    if (!isSettingsLoaded) return;
     setLinks(createLinksFromFiles(selectedFiles, settings.WebUI_Settings.releaseInfoProviders ?? []));
     setInitialized(true);
   });
@@ -60,9 +53,9 @@ const LinkFilesWithProviders = () => {
   }, [initialized, links, navigate]);
 
   useEffect(() => {
-    if (!releaseProvidersQuery.isSuccess) return;
+    if (!isSettingsLoaded) return;
     initializeLinks();
-  }, [releaseProvidersQuery.isSuccess]);
+  }, [isSettingsLoaded]);
 
   const scrollRef = useRef<HTMLDivElement>(null);
   const virtualizer = useVirtualizer({
@@ -97,7 +90,7 @@ const LinkFilesWithProviders = () => {
     navigate(-1);
   };
 
-  const { cancelActiveWork } = useLinkWorkflow(links, setLinks, providerMap, initialized);
+  const { cancelActiveWork } = useLinkWorkflow(links, setLinks, initialized);
 
   const handleCancel = () => {
     if (links.some(link => BUSY_STATES.has(link.state))) {
@@ -134,11 +127,7 @@ const LinkFilesWithProviders = () => {
     if (selectedRows.length === links.length) {
       setRowSelection({});
     } else {
-      if (
-        links.some(
-          link => NOT_SELECTABLE_STATES.has(link.state),
-        )
-      ) {
+      if (links.some(link => BUSY_STATES.has(link.state))) {
         return;
       }
 


### PR DESCRIPTION
## Summary

Cleanup pass on the Link Files With Providers utility.

- Remove the `pre-init` state — it only existed for Offline Importer seeding. `createLinksFromFiles` now sets `searching`/`init` directly, and the synchronous `processPreInit` + `initializing` guard are gone.
- Drop the Offline Importer preview mutation (`usePreviewReleaseInfoByProviderIdMutation`) and its `ReleaseInfo/Provider/{id}/Preview/By-Release` call.
- Lazy-load release providers — `useReleaseInfoProvidersQuery` gains an `enabled` param; `AutoSearchReleaseModal` fetches providers on open instead of at page load, with a loading state and Search disabled until the query succeeds. The page now gates link initialization on `settingsRevision > 0` (settings loaded) rather than the providers query.
- `processSearch` bail now clears its in-flight guard and falls back to `init`.
- Simplify state groups — remove redundant `NOT_SELECTABLE_STATES` (now identical to `BUSY_STATES`); hoist `providers.some()` out of the per-file loop.
- Rename `unrecognized-utility.ts` → `link-files-with-providers.ts` (it only holds the link types).
- Move `LinkFilesWithProviders.md` into `docs/` and refresh it to match the new behavior.
- Use `dayjs` for link timestamps instead of `new Date()`.

## Verification

- `pnpm lint` passes (dprint + oxlint + stylelint)
- `tsc --noEmit` clean
