### PR TITLE
Migrate preferred image actions to series-scoped endpoints

### DIFF
--- a/src/components/Collection/Series/ImageUploadModal.tsx
+++ b/src/components/Collection/Series/ImageUploadModal.tsx
@@ -13,9 +13,10 @@ import { useUploadSeriesImageMutation } from '@/core/react-query/series/mutation
 import toast from '@/core/toast';
 import useToggleModalKeybinds from '@/hooks/useToggleModalKeybinds';
 
-import type { CrossReferenceImageType, ImageTabType } from '@/core/types/api/image';
+import type { ImageEntityType } from '@/core/types/api/common';
+import type { ImageTabType } from '@/core/types/api/image';
 
-const tabLabelMap: Record<ImageTabType, { label: string, serverType: CrossReferenceImageType }> = {
+const tabLabelMap: Record<ImageTabType, { label: string, serverType: ImageEntityType }> = {
   Posters: { label: 'Poster', serverType: 'Primary' },
   Backdrops: { label: 'Backdrop', serverType: 'Backdrop' },
   Logos: { label: 'Logo', serverType: 'Logo' },

--- a/src/components/Collection/SeriesTopPanel.tsx
+++ b/src/components/Collection/SeriesTopPanel.tsx
@@ -34,7 +34,7 @@ const SeriesTopPanel = ({ series }: { series: SeriesType }) => {
 
   const postersQuery = useSeriesImageCrossReferencesQuery(
     toNumber(seriesId) ?? 0,
-    { imageType: 'Poster', isAvailable: true, pageSize: 30 },
+    { imageType: 'Primary', isAvailable: true, pageSize: 30 },
     !!seriesId && showRandomPoster,
   );
 

--- a/src/core/react-query/image-management/mutations.ts
+++ b/src/core/react-query/image-management/mutations.ts
@@ -3,22 +3,6 @@ import { useMutation } from '@tanstack/react-query';
 import { axios } from '@/core/axios';
 import { invalidateQueries } from '@/core/react-query/queryClient';
 
-export const useSetPreferredImageMutation = () =>
-  useMutation({
-    mutationFn: (xrefId: number) => axios.put(`Image/Management/CrossReference/${xrefId}/Preferred`),
-    onSuccess: () => {
-      invalidateQueries(['image-management', 'cross-references']);
-    },
-  });
-
-export const useUnsetPreferredImageMutation = () =>
-  useMutation({
-    mutationFn: (xrefId: number) => axios.delete(`Image/Management/CrossReference/${xrefId}/Preferred`),
-    onSuccess: () => {
-      invalidateQueries(['image-management', 'cross-references']);
-    },
-  });
-
 export const useDeleteImageCrossReferenceMutation = () =>
   useMutation({
     mutationFn: (xrefId: number) => axios.delete(`Image/Management/CrossReference/${xrefId}`),

--- a/src/core/react-query/image-management/types.ts
+++ b/src/core/react-query/image-management/types.ts
@@ -1,6 +1,7 @@
 import type { PaginationType } from '@/core/types/api';
+import type { ImageEntityType } from '@/core/types/api/common';
 
 export type SeriesImageCrossReferencesRequestType = {
-  imageType: string;
+  imageType: ImageEntityType;
   isAvailable?: boolean;
 } & PaginationType;

--- a/src/core/react-query/image/queries.ts
+++ b/src/core/react-query/image/queries.ts
@@ -2,10 +2,10 @@ import { useQuery } from '@tanstack/react-query';
 
 import { axios } from '@/core/axios';
 
-import type { ImageTypeEnum } from '@/core/types/api/common';
+import type { ImageEntityType } from '@/core/types/api/common';
 import type { RandomImageMetadataResultType } from '@/core/types/api/image';
 
-export const useRandomImageMetadataQuery = (imageType: ImageTypeEnum) =>
+export const useRandomImageMetadataQuery = (imageType: ImageEntityType) =>
   useQuery<RandomImageMetadataResultType>({
     queryKey: ['image', 'random', imageType],
     queryFn: () => axios.get(`Image/Random/${imageType}/Metadata`),

--- a/src/core/react-query/series/mutations.ts
+++ b/src/core/react-query/series/mutations.ts
@@ -11,6 +11,7 @@ import type {
   UploadSeriesImageRequestType,
   WatchSeriesEpisodesRequestType,
 } from '@/core/react-query/series/types';
+import type { ImageEntityType } from '@/core/types/api/common';
 import type { SeriesAniDBSearchResult } from '@/core/types/api/series';
 
 export const useDeleteSeriesMutation = () =>
@@ -135,5 +136,23 @@ export const useUploadSeriesImageMutation = () =>
     },
     onSuccess: (_, { seriesId }) => {
       invalidateQueries(['image-management', 'cross-references', seriesId]);
+    },
+  });
+
+export const useSetSeriesPreferredImageMutation = (seriesId: number, imageType: ImageEntityType) =>
+  useMutation({
+    mutationFn: (ID: string) => axios.put(`Series/${seriesId}/Images/${imageType}`, { ID }),
+    onSuccess: () => {
+      invalidateQueries(['image-management', 'cross-references', seriesId]);
+      invalidateQueries(['series']);
+    },
+  });
+
+export const useUnsetSeriesPreferredImageMutation = (seriesId: number, imageType: ImageEntityType) =>
+  useMutation({
+    mutationFn: () => axios.delete(`Series/${seriesId}/Images/${imageType}`),
+    onSuccess: () => {
+      invalidateQueries(['image-management', 'cross-references', seriesId]);
+      invalidateQueries(['series']);
     },
   });

--- a/src/core/react-query/series/types.ts
+++ b/src/core/react-query/series/types.ts
@@ -1,8 +1,7 @@
 import type { IncludeOnlyFilterType } from '@/core/react-query/types';
 import type { PaginationType } from '@/core/types/api';
-import type { DataSourceType } from '@/core/types/api/common';
+import type { DataSourceType, ImageEntityType } from '@/core/types/api/common';
 import type { EpisodeTypeEnum } from '@/core/types/api/episode';
-import type { CrossReferenceImageType } from '@/core/types/api/image';
 
 type SeriesEpisodesBaseRequestType = {
   includeMissing?: IncludeOnlyFilterType;
@@ -70,7 +69,7 @@ export type RefreshSeriesAniDBInfoRequestType = {
 
 export type UploadSeriesImageRequestType = {
   file: File;
-  imageType: CrossReferenceImageType;
+  imageType: ImageEntityType;
   seriesId: number;
 };
 

--- a/src/core/types/api/common.ts
+++ b/src/core/types/api/common.ts
@@ -6,7 +6,7 @@ export type ImageLinkType = {
 
 export type ImageType = ImageLinkType & {
   Source: ImageSourceType;
-  Type: ImageTypeEnum;
+  Type: ImageEntityType;
   ID: number;
   PrimaryUID: string;
   Preferred: boolean;
@@ -20,6 +20,7 @@ export type ImagesType = {
   Backdrops: ImageType[];
   Banners: ImageType[];
   Logos: ImageType[];
+  Discs: ImageType[];
 };
 
 export type EpisodeImagesType = ImagesType & {
@@ -28,15 +29,7 @@ export type EpisodeImagesType = ImagesType & {
 
 export type ImageSourceType = 'AniDB' | 'TMDB' | 'Shoko' | 'User';
 
-export const enum ImageTypeEnum {
-  Poster = 'Poster',
-  Banner = 'Banner',
-  Thumb = 'Thumb',
-  Backdrop = 'Backdrop',
-  Character = 'Character',
-  Staff = 'Staff',
-  Static = 'Static',
-}
+export type ImageEntityType = 'None' | 'Primary' | 'Backdrop' | 'Banner' | 'Logo' | 'Disc';
 
 export type RatingType = {
   Value: number;

--- a/src/core/types/api/image.ts
+++ b/src/core/types/api/image.ts
@@ -1,9 +1,8 @@
-import type { ImageLinkType, ImageSourceType, ImageTypeEnum, RatingType } from './common';
+import type { ImageEntityType, ImageLinkType, ImageSourceType, RatingType } from './common';
 
 export type RandomImageMetadataResultType = {
   Source: string;
-  Type: ImageTypeEnum;
-  ID: string;
+  Type: ImageEntityType;
   UID: string;
   Available: boolean;
   Preferred: boolean;
@@ -31,15 +30,13 @@ export type ImageSlimType = ImageLinkType & {
   Height?: number;
 };
 
-export type CrossReferenceImageType = 'Primary' | 'Backdrop' | 'Banner' | 'Logo' | 'Disc';
-
 export type ImageCrossReferenceType = {
   /** The cross-reference ID — used for set-preferred mutations. */
   ID: number;
   ImageID: string;
   /** The primary image's UUID for the associated entity. */
   PrimaryImageID: string;
-  ImageType: CrossReferenceImageType;
+  ImageType: ImageEntityType;
   ImageSource: ImageSourceType;
   EntityID: string;
   EntityType: string;

--- a/src/pages/collection/series/SeriesImages.tsx
+++ b/src/pages/collection/series/SeriesImages.tsx
@@ -14,22 +14,22 @@ import ConfirmationPromptModal from '@/components/Dialogs/ConfirmationPromptModa
 import Button from '@/components/Input/Button';
 import MultiStateButton from '@/components/Input/MultiStateButton';
 import ShokoPanel from '@/components/Panels/ShokoPanel';
-import {
-  useDeleteImageCrossReferenceMutation,
-  useSetPreferredImageMutation,
-  useUnsetPreferredImageMutation,
-} from '@/core/react-query/image-management/mutations';
+import { useDeleteImageCrossReferenceMutation } from '@/core/react-query/image-management/mutations';
 import { useSeriesImageCrossReferencesQuery } from '@/core/react-query/image-management/queries';
-import { invalidateQueries } from '@/core/react-query/queryClient';
+import {
+  useSetSeriesPreferredImageMutation,
+  useUnsetSeriesPreferredImageMutation,
+} from '@/core/react-query/series/mutations';
 import toast from '@/core/toast';
 import { pxPerRem } from '@/core/util';
 import useFlattenListResult from '@/hooks/useFlattenListResult';
 import useNavigateVoid from '@/hooks/useNavigateVoid';
 
 import type { SeriesContextType } from '@/components/Collection/constants';
+import type { ImageEntityType } from '@/core/types/api/common';
 import type { ImageCrossReferenceType, ImageTabType } from '@/core/types/api/image';
 
-const tabToImageTypeMap: Record<ImageTabType, string> = {
+const tabToImageTypeMap: Record<ImageTabType, ImageEntityType> = {
   Posters: 'Primary',
   Backdrops: 'Backdrop',
   Logos: 'Logo',
@@ -74,8 +74,8 @@ const SeriesImages = () => {
   const [selectedImage, setSelectedImage] = useState<ImageCrossReferenceType | null>(null);
   const imageLabel = tabType.slice(0, -1);
 
-  const { mutate: setPreferred } = useSetPreferredImageMutation();
-  const { mutate: unsetPreferred } = useUnsetPreferredImageMutation();
+  const { mutate: setPreferred } = useSetSeriesPreferredImageMutation(series.IDs.ID, tabToImageTypeMap[tabType]);
+  const { mutate: unsetPreferred } = useUnsetSeriesPreferredImageMutation(series.IDs.ID, tabToImageTypeMap[tabType]);
   const { mutateAsync: deleteImage } = useDeleteImageCrossReferenceMutation();
   const [showUploadModal, toggleUploadModal] = useToggle(false);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
@@ -86,17 +86,23 @@ const SeriesImages = () => {
 
   const handleTogglePreferredImage = () => {
     if (!selectedImage) return;
-    const isPreferred = selectedImage.IsPreferred;
-    const mutate = isPreferred ? unsetPreferred : setPreferred;
-    const action = isPreferred ? 'unset' : 'set';
-    mutate(selectedImage.ID, {
-      onSuccess: () => {
-        invalidateQueries(['series']);
-        toast.success(`Preferred ${imageLabel} has been ${action}.`);
-        setSelectedImage(null);
-      },
-      onError: () => toast.error(`Failed to ${action} preferred ${imageLabel}.`),
-    });
+    if (selectedImage.IsPreferred) {
+      unsetPreferred(undefined, {
+        onSuccess: () => {
+          toast.success(`Preferred ${imageLabel} has been unset.`);
+          setSelectedImage(null);
+        },
+        onError: () => toast.error(`Failed to unset preferred ${imageLabel}.`),
+      });
+    } else {
+      setPreferred(selectedImage.ImageID, {
+        onSuccess: () => {
+          toast.success(`Preferred ${imageLabel} has been set.`);
+          setSelectedImage(null);
+        },
+        onError: () => toast.error(`Failed to set preferred ${imageLabel}.`),
+      });
+    }
   };
 
   const handleDeleteImage = async () => {

--- a/src/pages/login/LoginPage.tsx
+++ b/src/pages/login/LoginPage.tsx
@@ -22,7 +22,6 @@ import { useLoginMutation } from '@/core/react-query/auth/mutations';
 import { useRandomImageMetadataQuery } from '@/core/react-query/image/queries';
 import { useServerStatusQuery, useVersionQuery } from '@/core/react-query/init/queries';
 import { useSelector } from '@/core/store';
-import { ImageTypeEnum } from '@/core/types/api/common';
 import useNavigateVoid from '@/hooks/useNavigateVoid';
 
 const LoginPage = () => {
@@ -45,7 +44,7 @@ const LoginPage = () => {
   const versionQuery = useVersionQuery();
   const { isPending: isLoginPending, mutate: login } = useLoginMutation();
   const serverStatusQuery = useServerStatusQuery(pollingInterval);
-  const imageMetadataQuery = useRandomImageMetadataQuery(ImageTypeEnum.Backdrop);
+  const imageMetadataQuery = useRandomImageMetadataQuery('Backdrop');
 
   const setRedirect = () => {
     if (seriesId === 0) return;

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -77,7 +77,7 @@ export default defineConfig(async () => {
 async function setupEnv(isDebug) {
   const gitHash = childProcess.execSync("git log --pretty=format:'%h' -n 1").toString().replace(/["']/g, '');
   const appVersion = pkg.version;
-  const minimumServerVersion = '6.0.0-dev.401';
+  const minimumServerVersion = '6.0.0-dev.408';
 
   process.env.VITE_GITHASH = gitHash;
   process.env.VITE_APPVERSION = appVersion;


### PR DESCRIPTION
## Summary

Fixes preferred-image actions on the Series Images page so setting a linked (inherited) image as preferred creates a direct series preference — visible to both the WebUI and external clients (Shokofin, Shoko Relay) — instead of mutating the linked entity's cross-reference in place.

This migrates the actions from the generic cross-reference endpoints to the new series-scoped endpoints, and adopts the server's new `ImageEntityType` enum.

## Changes

### Preferred image actions

- `Set As Preferred` now calls `PUT /Series/{seriesId}/Images/{imageType}` with the image UUID (`{ ID }`).
- `Unset Preferred` now calls `DELETE /Series/{seriesId}/Images/{imageType}`.
- Removed `useSetPreferredImageMutation` / `useUnsetPreferredImageMutation` (the old `Image/Management/CrossReference/{id}/Preferred` endpoints).
- Hoisted query invalidation (`series` + `cross-references`) into the mutations; restored success/error toasts.

### Image types

- Replaced the legacy `ImageTypeEnum` with `ImageEntityType` (`None | Primary | Backdrop | Banner | Logo | Disc`).
- Removed the redundant `CrossReferenceImageType` in favour of `ImageEntityType`.
- `SeriesTopPanel` poster filter updated from `Poster` → `Primary`.
- Added `Discs` to `ImagesType` to match the server's `Images` DTO.

### Versioning

- Bumped minimum server version to `6.0.0-dev.408`.

## Dependencies

Requires Shoko Server `6.0.0-dev.408` (image system refactor, ShokoServer#1402).

Closes #1428
