### PR TITLE
refactor: convert enums to string unions

### DIFF
--- a/src/components/Collection/Files/FilesOverview.tsx
+++ b/src/components/Collection/Files/FilesOverview.tsx
@@ -3,12 +3,12 @@ import prettyBytes from 'pretty-bytes';
 
 import ShokoPanel from '@/components/Panels/ShokoPanel';
 
-import type { EpisodeTypeEnum } from '@/core/types/api/episode';
+import type { EpisodeTypeValues } from '@/core/types/api/episode';
 import type { WebuiSeriesFileSummaryOverview, WebuiSeriesFileSummarySourceCount } from '@/core/types/api/webui';
 
 type FileTypeSummaryProps = {
   sources: WebuiSeriesFileSummarySourceCount[];
-  type: EpisodeTypeEnum;
+  type: EpisodeTypeValues;
 };
 const FileTypeSummary = ({ sources, type }: FileTypeSummaryProps) => {
   const typeCount = sources.reduce((prev, curr) => (prev + curr.Count), 0);

--- a/src/components/Collection/Series/ImageUploadModal.tsx
+++ b/src/components/Collection/Series/ImageUploadModal.tsx
@@ -13,10 +13,10 @@ import { useUploadSeriesImageMutation } from '@/core/react-query/series/mutation
 import toast from '@/core/toast';
 import useToggleModalKeybinds from '@/hooks/useToggleModalKeybinds';
 
-import type { ImageEntityType } from '@/core/types/api/common';
+import type { ImageEntityValues } from '@/core/types/api/common';
 import type { ImageTabType } from '@/core/types/api/image';
 
-const tabLabelMap: Record<ImageTabType, { label: string, serverType: ImageEntityType }> = {
+const tabLabelMap: Record<ImageTabType, { label: string, serverType: ImageEntityValues }> = {
   Posters: { label: 'Poster', serverType: 'Primary' },
   Backdrops: { label: 'Backdrop', serverType: 'Backdrop' },
   Logos: { label: 'Logo', serverType: 'Logo' },

--- a/src/components/Collection/TimelineSidebar.tsx
+++ b/src/components/Collection/TimelineSidebar.tsx
@@ -2,7 +2,6 @@ import { Link } from 'react-router';
 
 import BackgroundImagePlaceholderDiv from '@/components/BackgroundImagePlaceholderDiv';
 import ShokoPanel from '@/components/Panels/ShokoPanel';
-import { SeriesTypeEnum } from '@/core/types/api/series';
 import { dayjs, getMainPoster } from '@/core/util';
 
 import type { SeriesType } from '@/core/types/api/series';
@@ -10,8 +9,8 @@ import type { SeriesType } from '@/core/types/api/series';
 const TimelineItem = ({ series }: { series: SeriesType }) => {
   const mainPoster = getMainPoster(series);
   let seriesType = series.AniDB?.Type as string | undefined;
-  if (seriesType === SeriesTypeEnum.TVSpecial) seriesType = 'TV Special';
-  else if (seriesType === SeriesTypeEnum.MusicVideo) seriesType = 'Music Video';
+  if (seriesType === 'TVSpecial') seriesType = 'TV Special';
+  else if (seriesType === 'MusicVideo') seriesType = 'Music Video';
 
   return (
     <div className="flex gap-x-3" key={series.IDs.ID}>

--- a/src/components/Collection/Tmdb/MatchRating.tsx
+++ b/src/components/Collection/Tmdb/MatchRating.tsx
@@ -1,8 +1,8 @@
 import cx from 'classnames';
 
-import type { MatchRatingType } from '@/core/types/api/episode';
+import type { MatchRatingValues } from '@/core/types/api/episode';
 
-const getAbbreviation = (rating?: MatchRatingType) => {
+const getAbbreviation = (rating?: MatchRatingValues) => {
   switch (rating) {
     case 'DateAndTitleMatches':
       return ['DT', 'Date & Title'];
@@ -28,7 +28,7 @@ const getAbbreviation = (rating?: MatchRatingType) => {
 type Props = {
   isDisabled: boolean;
   isOdd: boolean;
-  rating?: MatchRatingType;
+  rating?: MatchRatingValues;
 };
 
 const MatchRating = ({ isDisabled, isOdd, rating }: Props) => (

--- a/src/components/Collection/Tmdb/TmdbLinkSelectPanel.tsx
+++ b/src/components/Collection/Tmdb/TmdbLinkSelectPanel.tsx
@@ -12,8 +12,8 @@ import { useSettingsQuery } from '@/core/react-query/settings/queries';
 import { useTmdbRefreshMutation } from '@/core/react-query/tmdb/mutations';
 import { useTmdbAutoSearchQuery, useTmdbSearchQuery } from '@/core/react-query/tmdb/queries';
 import toast from '@/core/toast';
-import { SeriesTypeEnum } from '@/core/types/api/series';
 
+import type { AnimeTypeValues } from '@/core/types/api/series';
 import type { TmdbSearchResultType } from '@/core/types/api/tmdb';
 
 type SearchResultRowProps = {
@@ -49,12 +49,12 @@ const SearchResultRow = ({ linkType, result, selectLink }: SearchResultRowProps)
   );
 };
 
-const TmdbLinkSelectPanel = ({ seriesType }: { seriesType?: SeriesTypeEnum }) => {
+const TmdbLinkSelectPanel = ({ seriesType }: { seriesType?: AnimeTypeValues }) => {
   const { seriesId } = useParams();
 
   const [, setSearchParams] = useSearchParams();
 
-  const [linkType, setLinkType] = useState<'Show' | 'Movie'>(seriesType === SeriesTypeEnum.Movie ? 'Movie' : 'Show');
+  const [linkType, setLinkType] = useState<'Show' | 'Movie'>(seriesType === 'Movie' ? 'Movie' : 'Show');
   const [selectedId, setSelectedId] = useState(0);
   const [searchText, setSearchText] = useState('');
   const [debouncedSearch] = useDebounceValue(searchText, 200);

--- a/src/components/Collection/Tmdb/TopPanel.tsx
+++ b/src/components/Collection/Tmdb/TopPanel.tsx
@@ -9,7 +9,7 @@ import ShokoPanel from '@/components/Panels/ShokoPanel';
 import ItemCount from '@/components/Utilities/ItemCount';
 import useNavigateVoid from '@/hooks/useNavigateVoid';
 
-import type { MatchRatingType } from '@/core/types/api/episode';
+import type { MatchRatingValues } from '@/core/types/api/episode';
 import type { TmdbEpisodeXrefType } from '@/core/types/api/tmdb';
 
 type Props = {
@@ -39,7 +39,7 @@ const TopPanel = (props: Props) => {
   const matchRatingCounts = useMemo(
     () => (flatXrefs ? countBy(flatXrefs, 'Rating') : {}),
     [flatXrefs],
-  ) as Record<MatchRatingType, number>;
+  ) as Record<MatchRatingValues, number>;
 
   return (
     <ShokoPanel

--- a/src/components/Dialogs/TmdbShowSettingsModal.tsx
+++ b/src/components/Dialogs/TmdbShowSettingsModal.tsx
@@ -7,7 +7,6 @@ import Button from '@/components/Input/Button';
 import ModalPanel from '@/components/Panels/ModalPanel';
 import { useSetPreferredTmdbShowOrderingMutation } from '@/core/react-query/tmdb/mutations';
 import { useTmdbShowOrderingQuery } from '@/core/react-query/tmdb/queries';
-import { AlternateOrderingTypeEnum } from '@/core/react-query/tmdb/types';
 import toast from '@/core/toast';
 
 type Props = {
@@ -17,14 +16,14 @@ type Props = {
 };
 
 const orderingDescriptionMap = {
-  [AlternateOrderingTypeEnum.Unknown]: ' (Unknown)',
-  [AlternateOrderingTypeEnum.OriginalAirDate]: ' (Original Air Date)',
-  [AlternateOrderingTypeEnum.Absolute]: ' (Absolute)',
-  [AlternateOrderingTypeEnum.DVD]: ' (DVD)',
-  [AlternateOrderingTypeEnum.Digital]: ' (Digital)',
-  [AlternateOrderingTypeEnum.StoryArc]: ' (Story Arc)',
-  [AlternateOrderingTypeEnum.Production]: ' (Production)',
-  [AlternateOrderingTypeEnum.TV]: ' (TV)',
+  Unknown: ' (Unknown)',
+  OriginalAirDate: ' (Original Air Date)',
+  Absolute: ' (Absolute)',
+  DVD: ' (DVD)',
+  Digital: ' (Digital)',
+  StoryArc: ' (Story Arc)',
+  Production: ' (Production)',
+  TV: ' (TV)',
   default: '',
 } as const;
 

--- a/src/components/Input/SelectEpisodeList.tsx
+++ b/src/components/Input/SelectEpisodeList.tsx
@@ -6,15 +6,16 @@ import { Icon } from '@mdi/react';
 import cx from 'classnames';
 import { find, toInteger } from 'lodash';
 
-import { EpisodeTypeEnum } from '@/core/types/api/episode';
 import { getEpisodePrefix } from '@/core/utilities/getEpisodePrefix';
 
 import Input from './Input';
 
+import type { EpisodeTypeValues } from '@/core/types/api/episode';
+
 type Option = {
   label: string;
   value: number;
-  type: EpisodeTypeEnum;
+  type: EpisodeTypeValues;
   number?: number;
   AirDate: string;
   disabled?: boolean;
@@ -73,7 +74,7 @@ const SelectButton = (
             </>
           )}
           {selected.label}
-          {selected?.type !== EpisodeTypeEnum.Episode && (
+          {selected?.type !== 'Episode' && (
             <span className="mx-2 rounded-lg border border-panel-border bg-panel-background px-1 py-0.5 text-sm text-panel-text">
               {selected.type}
             </span>

--- a/src/components/Layout/AniDBBanDetectionItem.tsx
+++ b/src/components/Layout/AniDBBanDetectionItem.tsx
@@ -3,7 +3,6 @@ import { mdiInformationOutline, mdiOpenInNew } from '@mdi/js';
 import Icon from '@mdi/react';
 
 import ModalPanel from '@/components/Panels/ModalPanel';
-import { AniDBBanTypeEnum } from '@/core/signalr/types';
 import { dayjs } from '@/core/util';
 
 import type { AniDBBanItemType } from '@/core/signalr/types';
@@ -16,7 +15,7 @@ type Props = {
 const AniDBBanDetectionItem = ({ banStatus, type }: Props) => {
   const [showModal, setModalOpen] = useState(false);
 
-  const banType = type === 'HTTP' ? AniDBBanTypeEnum.HTTPBan : AniDBBanTypeEnum.UDPBan;
+  const banType = type === 'HTTP' ? 'HTTPBan' : 'UDPBan';
 
   if (banStatus.UpdateType !== banType || !banStatus.Value) {
     return null;

--- a/src/components/Layout/TopNav.tsx
+++ b/src/components/Layout/TopNav.tsx
@@ -45,7 +45,6 @@ import { useCheckNetworkConnectivityMutation } from '@/core/react-query/settings
 import { useSettingsQuery } from '@/core/react-query/settings/queries';
 import { useCurrentUserQuery } from '@/core/react-query/user/queries';
 import { useServerUpdateCheckQuery, useWebuiUpdateCheckQuery } from '@/core/react-query/webui/queries';
-import { NetworkAvailabilityEnum } from '@/core/signalr/types';
 import { useDispatch, useSelector } from '@/core/store';
 import { getUiVersion, isDebug } from '@/core/util';
 
@@ -102,8 +101,8 @@ const TopNav = () => {
   const [showServerUpdateModal, setShowServerUpdateModal] = useState(false);
   const [showWebuiUpdateModal, setShowWebuiUpdateModal] = useState(false);
 
-  const isOffline = !(networkStatus === NetworkAvailabilityEnum.Internet
-    || networkStatus === NetworkAvailabilityEnum.PartialInternet);
+  const isOffline = !(networkStatus === 'Internet'
+    || networkStatus === 'PartialInternet');
 
   const closeModalsAndSubmenus = (event?: MouseEvent<HTMLAnchorElement>, id?: string) => {
     if (layoutEditMode && event) {

--- a/src/components/Settings/HashingAndReleaseSettings/ReleaseManagementSettings.tsx
+++ b/src/components/Settings/HashingAndReleaseSettings/ReleaseManagementSettings.tsx
@@ -7,10 +7,10 @@ import InputSmall from '@/components/Input/InputSmall';
 import SelectSmall from '@/components/Input/SelectSmall';
 import { signalLabels } from '@/core/utilities/releaseManagementHelpers';
 
-import type { ReleaseComparisonPreferencesType, SignalType } from '@/core/types/api/settings';
+import type { ReleaseComparisonPreferencesType, ReleaseSignalTypeValues } from '@/core/types/api/settings';
 import type { DropResult } from '@hello-pangea/dnd';
 
-const ALL_SIGNALS = Object.keys(signalLabels) as SignalType[];
+const ALL_SIGNALS = Object.keys(signalLabels) as ReleaseSignalTypeValues[];
 
 type Props = {
   preferences: ReleaseComparisonPreferencesType;
@@ -80,10 +80,10 @@ const ReleaseManagementSettings = ({ onChange, preferences }: Props) => {
               id="rm-episode-type-scope"
               value={preferences.EpisodeTypeScope}
               onChange={event =>
-                updateSetting('EpisodeTypeScope', event.target.value as 'AllTogether' | 'PerEpisodeType')}
+                updateSetting('EpisodeTypeScope', event.target.value as 'KeepTogether' | 'BestPerType')}
             >
-              <option value="AllTogether">All Together</option>
-              <option value="PerEpisodeType">Per Episode Type</option>
+              <option value="KeepTogether">All Together</option>
+              <option value="BestPerType">Per Episode Type</option>
             </SelectSmall>
           </div>
           <div className="text-xs opacity-65">

--- a/src/components/Utilities/LinkFilesWithProvider/CrossReference.tsx
+++ b/src/components/Utilities/LinkFilesWithProvider/CrossReference.tsx
@@ -2,7 +2,6 @@ import type { MouseEvent } from 'react';
 
 import { useEpisodeAniDBQuery } from '@/core/react-query/episode/queries';
 import { useSeriesAniDBQuery } from '@/core/react-query/series/queries';
-import { EpisodeTypeEnum } from '@/core/types/api/episode';
 import { getAnidbAnimeLink, getAnidbEpisodeLink } from '@/core/util';
 import { getEpisodePrefix } from '@/core/utilities/getEpisodePrefix';
 
@@ -25,7 +24,7 @@ const CrossReference = ({ xref }: { xref: ReleaseCrossReferenceType }) => {
         <>
           <span className="text-panel-text-important">
             {getEpisodePrefix(episodeQuery.data.Type)}
-            {episodeQuery.data.Type === EpisodeTypeEnum.Episode
+            {episodeQuery.data.Type === 'Episode'
               ? episodeQuery.data.EpisodeNumber.toString().padStart(2, '0')
               : episodeQuery.data.EpisodeNumber}
           </span>

--- a/src/components/Utilities/LinkFilesWithProvider/EditReleaseInfoModal.tsx
+++ b/src/components/Utilities/LinkFilesWithProvider/EditReleaseInfoModal.tsx
@@ -17,14 +17,11 @@ import AnimeSelectPanel from '@/components/Utilities/Unrecognized/AnimeSelectPan
 import { useGetSeriesAniDBMutation, useRefreshAniDBSeriesMutation } from '@/core/react-query/series/mutations';
 import { useSeriesAniDBEpisodesQuery, useSeriesAniDBQuery } from '@/core/react-query/series/queries';
 import toast from '@/core/toast';
-import { EpisodeTypeEnum } from '@/core/types/api/episode';
-import { ReleaseSource } from '@/core/types/api/file';
-import { SeriesTypeEnum } from '@/core/types/api/series';
 import { AUTO_MATCH_EPISODE_ID } from '@/core/utilities/releaseInfoHelpers';
 import useToggleModalKeybinds from '@/hooks/useToggleModalKeybinds';
 import useReleaseInfoForm from '@/hooks/utilities/useReleaseInfoForm';
 
-import type { ReleaseInfoType } from '@/core/types/api/file';
+import type { ReleaseInfoType, ReleaseSourceValues } from '@/core/types/api/file';
 import type { SeriesAniDBSearchResult } from '@/core/types/api/series';
 import type {
   CrossReferenceType,
@@ -45,17 +42,17 @@ type Props = {
 const sourceOptions = [
   <option key="mixed" value="" disabled>-</option>,
   ...[
-    ReleaseSource.Unknown,
-    ReleaseSource.Other,
-    ReleaseSource.TV,
-    ReleaseSource.DVD,
-    ReleaseSource.BluRay,
-    ReleaseSource.Web,
-    ReleaseSource.VHS,
-    ReleaseSource.VCD,
-    ReleaseSource.LaserDisc,
-    ReleaseSource.Camera,
-    ReleaseSource.Film,
+    'Unknown',
+    'Other',
+    'TV',
+    'DVD',
+    'BluRay',
+    'Web',
+    'VHS',
+    'VCD',
+    'LaserDisc',
+    'Camera',
+    'Film',
   ].map(source => (
     <option key={source} value={source}>
       {source}
@@ -104,20 +101,22 @@ const EditReleaseInfoModal = (props: Props) => {
 
   const episodeOptions = [
     ...(hasDifferent.episodes
-      ? [{
-        label: 'Multiple episodes selected',
-        value: 0,
-        type: EpisodeTypeEnum.Episode,
-        AirDate: '',
-        disabled: true,
-      }]
+      ? [
+        {
+          label: 'Multiple episodes selected',
+          value: 0,
+          type: 'Episode',
+          AirDate: '',
+          disabled: true,
+        } as const,
+      ]
       : []),
     {
       label: 'Auto-match (from filename)',
       value: AUTO_MATCH_EPISODE_ID,
-      type: EpisodeTypeEnum.Episode,
+      type: 'Episode',
       AirDate: '',
-    },
+    } as const,
     ...map(episodesQuery.data ?? [], episode => ({
       label: episode.Title,
       value: episode.ID,
@@ -139,7 +138,7 @@ const EditReleaseInfoModal = (props: Props) => {
       draft.series = false;
     });
 
-    if (series.Type !== SeriesTypeEnum.Unknown) {
+    if (series.Type !== 'Unknown') {
       setFormState((draft) => {
         draft.selectedSeriesId = series.ID;
         draft.selectedEpisodeId = AUTO_MATCH_EPISODE_ID;
@@ -201,7 +200,7 @@ const EditReleaseInfoModal = (props: Props) => {
   const handleSourceChange = (event: ChangeEvent<HTMLSelectElement>) => {
     markTouched('Source');
     setFormState((draft) => {
-      draft.source = event.target.value as ReleaseSource | '';
+      draft.source = event.target.value as ReleaseSourceValues | '';
     });
   };
 

--- a/src/components/Utilities/LinkFilesWithProvider/VideoMetadata.tsx
+++ b/src/components/Utilities/LinkFilesWithProvider/VideoMetadata.tsx
@@ -1,10 +1,9 @@
-import { ReleaseSource } from '@/core/types/api/file';
-
+import type { ReleaseSourceValues } from '@/core/types/api/file';
 import type { ManualLinkType } from '@/core/types/utilities/link-files-with-providers';
 
-const parseReleaseSource = (releaseSource: ReleaseSource) => {
+const parseReleaseSource = (releaseSource: ReleaseSourceValues) => {
   switch (releaseSource) {
-    case ReleaseSource.BluRay:
+    case 'BluRay':
       return 'Blu-Ray';
     default:
       return releaseSource;

--- a/src/components/Utilities/Renamer/AddFilesModal.tsx
+++ b/src/components/Utilities/Renamer/AddFilesModal.tsx
@@ -14,7 +14,6 @@ import { useFilteredSeriesInfiniteQuery } from '@/core/react-query/filter/querie
 import queryClient from '@/core/react-query/queryClient';
 import { addFiles } from '@/core/slices/utilities/renamer';
 import store from '@/core/store';
-import { FileSortCriteriaEnum } from '@/core/types/api/file';
 import useFlattenListResult from '@/hooks/useFlattenListResult';
 
 import type { ListResultType } from '@/core/types/api';
@@ -43,7 +42,7 @@ const addRecentlyImportedFiles = (pageSize: number) => {
       queryKey: ['files', 'recently-imported', pageSize],
       queryFn: () =>
         axios.get('File', {
-          params: { pageSize, exclude: ['Unrecognized'], sortOrder: [-FileSortCriteriaEnum.CreatedAt] },
+          params: { pageSize, exclude: ['Unrecognized'], sortOrder: ['-CreatedAt'] },
         }),
     },
   )

--- a/src/components/Utilities/UtilitiesTable.tsx
+++ b/src/components/Utilities/UtilitiesTable.tsx
@@ -4,7 +4,7 @@ import { mdiLoading, mdiMenuUp } from '@mdi/js';
 import { Icon } from '@mdi/react';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import cx from 'classnames';
-import { debounce, toNumber } from 'lodash';
+import { debounce } from 'lodash';
 
 import { criteriaMap } from '@/components/Utilities/constants';
 import { useSelector } from '@/core/store';
@@ -12,7 +12,7 @@ import { handleShiftSelect } from '@/core/util';
 
 import type { UtilityHeaderType } from '@/components/Utilities/constants';
 import type { EpisodeType } from '@/core/types/api/episode';
-import type { FileSortCriteriaEnum, FileType } from '@/core/types/api/file';
+import type { FileSortOrderValue, FileType } from '@/core/types/api/file';
 import type { SeriesType } from '@/core/types/api/series';
 import type { VirtualItem } from '@tanstack/react-virtual';
 import type { Updater } from 'use-immer';
@@ -23,9 +23,9 @@ type Props = {
   fetchNextPage?: () => Promise<unknown>;
   isFetchingNextPage?: boolean;
   rows: EpisodeType[] | FileType[] | SeriesType[];
-  setSortCriteria?: Dispatch<SetStateAction<FileSortCriteriaEnum>>;
+  setSortCriteria?: Dispatch<SetStateAction<FileSortOrderValue>>;
   skipSort?: boolean;
-  sortCriteria?: FileSortCriteriaEnum;
+  sortCriteria?: FileSortOrderValue;
   handleRowSelect?: (id: number, select: boolean) => void;
   rowSelection?: Record<number, boolean>;
   setRowSelection?: Updater<Record<number, boolean>>;
@@ -90,9 +90,9 @@ const HeaderItem = (
     className: string;
     id: string;
     name: string;
-    setSortCriteria?: Dispatch<SetStateAction<FileSortCriteriaEnum>>;
+    setSortCriteria?: Dispatch<SetStateAction<FileSortOrderValue>>;
     skipSort?: boolean;
-    sortCriteria?: FileSortCriteriaEnum;
+    sortCriteria?: FileSortOrderValue;
   },
 ) => {
   const {
@@ -117,20 +117,20 @@ const HeaderItem = (
     const criteria = criteriaMap[headerId];
     if (!criteria || !setSortCriteria) return;
 
-    setSortCriteria(prevCriteria => ((prevCriteria === criteria) ? -criteria : criteria));
+    setSortCriteria(prevCriteria => (prevCriteria === criteria ? `-${criteria}` : criteria));
   };
 
   const sortIndicator = (headerId: string) => {
     if (skipSort || !isCriteriaMapKey(headerId)) return null;
     const criteria = criteriaMap[headerId];
-    if (!criteria || !sortCriteria || Math.abs(sortCriteria) !== toNumber(criteria)) return null;
+    if (!criteria || !sortCriteria || (sortCriteria !== criteria && sortCriteria !== `-${criteria}`)) return null;
 
     return (
       <Icon
         path={mdiMenuUp}
         size={1}
         className="ml-2 inline text-panel-text-primary transition-transform"
-        rotate={toNumber(sortCriteria) === (criteria * -1) ? 180 : 0}
+        rotate={sortCriteria === `-${criteria}` ? 180 : 0}
       />
     );
   };

--- a/src/components/Utilities/constants.tsx
+++ b/src/components/Utilities/constants.tsx
@@ -2,7 +2,6 @@ import type { ReactNode } from 'react';
 import { find } from 'lodash';
 import prettyBytes from 'pretty-bytes';
 
-import { FileSortCriteriaEnum } from '@/core/types/api/file';
 import { dayjs } from '@/core/util';
 
 import type { EpisodeType } from '@/core/types/api/episode';
@@ -18,13 +17,13 @@ export type UtilityHeaderType<T extends EpisodeType | FileType | SeriesType | Re
 };
 
 export const criteriaMap = {
-  managedFolder: FileSortCriteriaEnum.ManagedFolderName,
-  filename: FileSortCriteriaEnum.FileName,
-  crc32: FileSortCriteriaEnum.CRC32,
-  size: FileSortCriteriaEnum.FileSize,
-  created: FileSortCriteriaEnum.CreatedAt,
+  managedFolder: 'ManagedFolderName',
+  filename: 'FileName',
+  crc32: 'CRC32',
+  size: 'FileSize',
+  created: 'CreatedAt',
   status: null,
-};
+} as const;
 
 export const getManagedFolderColumn = (managedFolders: ManagedFolderType[]): UtilityHeaderType<FileType> => ({
   id: 'managedFolder',

--- a/src/core/react-query/duplicate-files/types.ts
+++ b/src/core/react-query/duplicate-files/types.ts
@@ -1,10 +1,10 @@
 import type { PaginationType } from '@/core/types/api';
-import type { DataSourceType } from '@/core/types/api/common';
+import type { DataSourceTypeValues } from '@/core/types/api/common';
 
 export type DuplicateFilesSeriesRequestType = {
   collecting?: boolean;
   ignoreVariations?: boolean;
-  includeDataFrom?: DataSourceType[];
+  includeDataFrom?: DataSourceTypeValues[];
   onlyFinishedSeries?: boolean;
 } & PaginationType;
 
@@ -12,7 +12,7 @@ export type DuplicateFilesEpisodesRequestType = {
   collecting?: boolean;
   ignoreVariations?: boolean;
   includeAbsolutePaths?: boolean;
-  includeDataFrom?: DataSourceType[];
+  includeDataFrom?: DataSourceTypeValues[];
   includeFiles?: boolean;
   includeMediaInfo?: boolean;
 } & PaginationType;

--- a/src/core/react-query/filter/types.ts
+++ b/src/core/react-query/filter/types.ts
@@ -1,5 +1,5 @@
 import type { PaginationType } from '@/core/types/api';
-import type { DataSourceType } from '@/core/types/api/common';
+import type { DataSourceTypeValues } from '@/core/types/api/common';
 import type { CreateOrUpdateFilterType } from '@/core/types/api/filter';
 
 export type FilteredGroupsRequestType = {
@@ -11,7 +11,7 @@ export type FilteredGroupsRequestType = {
 export type FilteredGroupSeriesRequestType = {
   randomImages?: boolean;
   filterCriteria: CreateOrUpdateFilterType;
-  includeDataFrom?: DataSourceType[];
+  includeDataFrom?: DataSourceTypeValues[];
   recursive?: boolean;
   includeMissing?: boolean;
 };

--- a/src/core/react-query/image/queries.ts
+++ b/src/core/react-query/image/queries.ts
@@ -2,10 +2,10 @@ import { useQuery } from '@tanstack/react-query';
 
 import { axios } from '@/core/axios';
 
-import type { ImageEntityType } from '@/core/types/api/common';
+import type { ImageEntityValues } from '@/core/types/api/common';
 import type { RandomImageMetadataResultType } from '@/core/types/api/image';
 
-export const useRandomImageMetadataQuery = (imageType: ImageEntityType) =>
+export const useRandomImageMetadataQuery = (imageType: ImageEntityValues) =>
   useQuery<RandomImageMetadataResultType>({
     queryKey: ['image', 'random', imageType],
     queryFn: () => axios.get(`Image/Random/${imageType}/Metadata`),

--- a/src/core/react-query/missing-episodes/types.ts
+++ b/src/core/react-query/missing-episodes/types.ts
@@ -1,10 +1,10 @@
 import type { PaginationType } from '@/core/types/api';
-import type { DataSourceType } from '@/core/types/api/common';
+import type { DataSourceTypeValues } from '@/core/types/api/common';
 
 export type MissingEpisodesSeriesRequestType = {
   collecting?: boolean;
   ignoreVariations?: boolean;
-  includeDataFrom?: DataSourceType[];
+  includeDataFrom?: DataSourceTypeValues[];
   onlyFinishedSeries?: boolean;
 } & PaginationType;
 
@@ -12,7 +12,7 @@ export type MissingEpisodesRequestType = {
   collecting?: boolean;
   ignoreVariations?: boolean;
   includeAbsolutePaths?: boolean;
-  includeDataFrom?: DataSourceType[];
+  includeDataFrom?: DataSourceTypeValues[];
   includeFiles?: boolean;
   includeMediaInfo?: boolean;
 } & PaginationType;

--- a/src/core/react-query/series/mutations.ts
+++ b/src/core/react-query/series/mutations.ts
@@ -11,7 +11,7 @@ import type {
   UploadSeriesImageRequestType,
   WatchSeriesEpisodesRequestType,
 } from '@/core/react-query/series/types';
-import type { ImageEntityType } from '@/core/types/api/common';
+import type { ImageEntityValues } from '@/core/types/api/common';
 import type { SeriesAniDBSearchResult } from '@/core/types/api/series';
 
 export const useDeleteSeriesMutation = () =>
@@ -139,7 +139,7 @@ export const useUploadSeriesImageMutation = () =>
     },
   });
 
-export const useSetSeriesPreferredImageMutation = (seriesId: number, imageType: ImageEntityType) =>
+export const useSetSeriesPreferredImageMutation = (seriesId: number, imageType: ImageEntityValues) =>
   useMutation({
     mutationFn: (ID: string) => axios.put(`Series/${seriesId}/Images/${imageType}/Default`, { ID }),
     onSuccess: () => {
@@ -147,7 +147,7 @@ export const useSetSeriesPreferredImageMutation = (seriesId: number, imageType: 
     },
   });
 
-export const useUnsetSeriesPreferredImageMutation = (seriesId: number, imageType: ImageEntityType) =>
+export const useUnsetSeriesPreferredImageMutation = (seriesId: number, imageType: ImageEntityValues) =>
   useMutation({
     mutationFn: () => axios.delete(`Series/${seriesId}/Images/${imageType}/Default`),
     onSuccess: () => {

--- a/src/core/react-query/series/queries.ts
+++ b/src/core/react-query/series/queries.ts
@@ -16,7 +16,7 @@ import type {
 import type { DashboardRequestType, FileRequestType } from '@/core/react-query/types';
 import type { ListResultType } from '@/core/types/api';
 import type { CollectionGroupType } from '@/core/types/api/collection';
-import type { ImageEntityType, ImageType } from '@/core/types/api/common';
+import type { ImageEntityValues, ImageType } from '@/core/types/api/common';
 import type { AniDBEpisodeType, EpisodeType } from '@/core/types/api/episode';
 import type { FileType } from '@/core/types/api/file';
 import type {
@@ -43,7 +43,7 @@ export const useSeriesQuery = (
 
 export const useSeriesImagesInfiniteQuery = (
   seriesId: number,
-  imageType: ImageEntityType,
+  imageType: ImageEntityValues,
   params: SeriesImagesRequestType,
   enabled = true,
 ) =>

--- a/src/core/react-query/series/types.ts
+++ b/src/core/react-query/series/types.ts
@@ -1,14 +1,14 @@
 import type { IncludeOnlyFilterType } from '@/core/react-query/types';
 import type { PaginationType } from '@/core/types/api';
-import type { DataSourceType, ImageEntityType } from '@/core/types/api/common';
-import type { EpisodeTypeEnum } from '@/core/types/api/episode';
+import type { DataSourceTypeValues, ImageEntityValues } from '@/core/types/api/common';
+import type { EpisodeTypeValues } from '@/core/types/api/episode';
 
 type SeriesEpisodesBaseRequestType = {
   includeMissing?: IncludeOnlyFilterType;
   includeHidden?: IncludeOnlyFilterType;
   includeWatched?: IncludeOnlyFilterType;
   includeUnaired?: IncludeOnlyFilterType;
-  type?: EpisodeTypeEnum[];
+  type?: EpisodeTypeValues[];
   search?: string;
   fuzzy?: boolean;
 };
@@ -20,7 +20,7 @@ export type DeleteSeriesRequestType = {
 };
 
 export type SeriesRequestType = {
-  includeDataFrom?: DataSourceType[];
+  includeDataFrom?: DataSourceTypeValues[];
   randomImages?: boolean;
 };
 
@@ -28,7 +28,7 @@ export type SeriesAniDBEpisodesRequestType = SeriesEpisodesBaseRequestType & Pag
 
 export type SeriesEpisodesInfiniteRequestType =
   & {
-    includeDataFrom?: DataSourceType[];
+    includeDataFrom?: DataSourceTypeValues[];
     includeFiles?: boolean;
     includeAbsolutePaths?: boolean;
     includeMediaInfo?: boolean;
@@ -38,7 +38,7 @@ export type SeriesEpisodesInfiniteRequestType =
   & PaginationType;
 
 export type SeriesNextUpRequestType = {
-  includeDataFrom?: DataSourceType[];
+  includeDataFrom?: DataSourceTypeValues[];
   includeMissing?: boolean;
   onlyUnwatched?: boolean;
 };
@@ -69,7 +69,7 @@ export type RefreshSeriesAniDBInfoRequestType = {
 
 export type UploadSeriesImageRequestType = {
   file: File;
-  imageType: ImageEntityType;
+  imageType: ImageEntityValues;
   seriesId: number;
 };
 

--- a/src/core/react-query/settings/helpers.ts
+++ b/src/core/react-query/settings/helpers.ts
@@ -1,7 +1,6 @@
 import { merge, toNumber } from 'lodash';
 
 import { webuiSettingsPatches } from '@/core/patches';
-import { LanguageSource } from '@/core/types/api/settings';
 
 import type { SupportedLanguagesResponseType } from '@/core/react-query/settings/types';
 import type { SettingsServerType, SettingsType, WebUISettingsType } from '@/core/types/api/settings';
@@ -376,11 +375,11 @@ export const initialSettings: SettingsType = {
   Language: {
     UseSynonyms: false,
     SeriesTitleLanguageOrder: ['x-main'],
-    SeriesTitleSourceOrder: [LanguageSource.AniDB, LanguageSource.TMDB],
+    SeriesTitleSourceOrder: ['AniDB', 'TMDB'],
     EpisodeTitleLanguageOrder: ['en'],
-    EpisodeTitleSourceOrder: [LanguageSource.TMDB, LanguageSource.AniDB],
+    EpisodeTitleSourceOrder: ['TMDB', 'AniDB'],
     DescriptionLanguageOrder: ['en'],
-    DescriptionSourceOrder: [LanguageSource.TMDB, LanguageSource.AniDB],
+    DescriptionSourceOrder: ['TMDB', 'AniDB'],
   },
   Plex: {
     Server: '',
@@ -416,7 +415,7 @@ export const initialSettings: SettingsType = {
     AllowDeletion: true,
     AutoDeleteOnImport: false,
     PerFileDeletionForAiringSeries: false,
-    EpisodeTypeScope: 'AllTogether',
+    EpisodeTypeScope: 'KeepTogether',
   },
   LoadImageMetadata: false,
   Plugins: {

--- a/src/core/react-query/tmdb/types.ts
+++ b/src/core/react-query/tmdb/types.ts
@@ -60,7 +60,7 @@ export type TmdbShowOrderingInformationType = {
    * The alternate ordering type. Will not be set if the main ordering is
    * used.
    */
-  OrderingType?: AlternateOrderingTypeEnum;
+  OrderingType?: AlternateOrderingTypeValues;
 
   /**
    * English name of the ordering scheme.
@@ -98,13 +98,12 @@ export type TmdbShowOrderingInformationType = {
   InUse: boolean;
 };
 
-export const enum AlternateOrderingTypeEnum {
-  Unknown = 'Unknown',
-  OriginalAirDate = 'OriginalAirDate',
-  Absolute = 'Absolute',
-  DVD = 'DVD',
-  Digital = 'Digital',
-  StoryArc = 'StoryArc',
-  Production = 'Production',
-  TV = 'TV',
-}
+export type AlternateOrderingTypeValues =
+  | 'Unknown'
+  | 'OriginalAirDate'
+  | 'Absolute'
+  | 'DVD'
+  | 'Digital'
+  | 'StoryArc'
+  | 'Production'
+  | 'TV';

--- a/src/core/react-query/types.ts
+++ b/src/core/react-query/types.ts
@@ -1,9 +1,9 @@
 import type { PaginationType } from '@/core/types/api';
-import type { FileSortCriteriaEnum } from '@/core/types/api/file';
+import type { FileSortOrderValue } from '@/core/types/api/file';
 
 export type IncludeOnlyFilterType = 'true' | 'false' | 'only';
 
-type FileIncludeType =
+type FileIncludeValues =
   | 'Ignored'
   | 'MediaInfo'
   | 'ReleaseInfo'
@@ -11,13 +11,13 @@ type FileIncludeType =
   | 'AbsolutePaths'
   | 'ImportLimbo'
   | 'LocationUIDs';
-type FileExcludeType =
+type FileExcludeValues =
   | 'Watched'
   | 'Duplicates'
   | 'Unrecognized'
   | 'ManualLinks'
   | 'Variations';
-type FileIncludeOnlyType =
+type FileIncludeOnlyValues =
   | 'Watched'
   | 'Variations'
   | 'Duplicates'
@@ -27,10 +27,10 @@ type FileIncludeOnlyType =
   | 'ImportLimbo';
 
 export type FileRequestType = {
-  include?: FileIncludeType[];
-  exclude?: FileExcludeType[];
-  include_only?: FileIncludeOnlyType[];
-  sortOrder?: FileSortCriteriaEnum[];
+  include?: FileIncludeValues[];
+  exclude?: FileExcludeValues[];
+  include_only?: FileIncludeOnlyValues[];
+  sortOrder?: FileSortOrderValue[];
 } & PaginationType;
 
 export type DashboardRequestType = {

--- a/src/core/react-query/webui/mutations.ts
+++ b/src/core/react-query/webui/mutations.ts
@@ -2,12 +2,12 @@ import { useMutation } from '@tanstack/react-query';
 
 import { axios } from '@/core/axios';
 
-import type { ReleaseChannelType } from '@/core/types/api/init';
+import type { ReleaseChannelValues } from '@/core/types/api/init';
 import type { WebuiTheme } from '@/core/types/api/webui';
 
 export const useUpdateWebuiMutation = () =>
   useMutation({
-    mutationFn: (channel: ReleaseChannelType) => axios.post('WebUI/Update', null, { params: { channel } }),
+    mutationFn: (channel: ReleaseChannelValues) => axios.post('WebUI/Update', null, { params: { channel } }),
   });
 
 export const useWebuiUploadThemeMutation = () =>

--- a/src/core/react-query/webui/types.ts
+++ b/src/core/react-query/webui/types.ts
@@ -1,4 +1,4 @@
-import type { ReleaseChannelType } from '@/core/types/api/init';
+import type { ReleaseChannelValues } from '@/core/types/api/init';
 
 export type GroupViewRequestType = {
   GroupIDs: number[];
@@ -14,6 +14,6 @@ export type SeriesFileSummaryRequestType = {
 };
 
 export type UpdateCheckRequestType = {
-  channel: ReleaseChannelType;
+  channel: ReleaseChannelValues;
   force: boolean;
 };

--- a/src/core/signalr/signalr.ts
+++ b/src/core/signalr/signalr.ts
@@ -10,7 +10,6 @@ import { throttle } from 'lodash';
 
 import Events from '@/core/events';
 import { handleEvent } from '@/core/signalr/eventHandlers';
-import { AVDumpEventTypeEnum } from '@/core/signalr/types';
 import {
   resetQueueStatus,
   setFetched,
@@ -26,7 +25,7 @@ import type {
   AVDumpEventType,
   AVDumpRestoreType,
   AniDBBanItemType,
-  NetworkAvailabilityEnum,
+  NetworkAvailabilityValues,
   QueueStatusType,
   RestartRequiredType,
 } from '@/core/signalr/types';
@@ -90,7 +89,7 @@ const onRestartRequiredUpdate = (state: RestartRequiredType) => {
 
 // Network Events
 
-type NetworkAvailabilityType = { NetworkAvailability: NetworkAvailabilityEnum };
+type NetworkAvailabilityType = { NetworkAvailability: NetworkAvailabilityValues };
 const onNetworkChanged = (dispatch: typeof store.dispatch) => ({ NetworkAvailability }: NetworkAvailabilityType) =>
   dispatch(setNetworkStatus(NetworkAvailability));
 
@@ -102,11 +101,11 @@ const onAvDumpConnected = (dispatch: typeof store.dispatch) => (state: AVDumpRes
 
 const onAvDumpEvent = (dispatch: typeof store.dispatch) => (event: AVDumpEventType) => {
   switch (event.Type) {
-    case AVDumpEventTypeEnum.Started:
-    case AVDumpEventTypeEnum.Success:
-    case AVDumpEventTypeEnum.Failure:
-    case AVDumpEventTypeEnum.GenericException:
-    case AVDumpEventTypeEnum.InstallException:
+    case 'Started':
+    case 'Success':
+    case 'Failure':
+    case 'GenericException':
+    case 'InstallException':
       dispatch(updateAVDumpEvent(event));
       break;
 

--- a/src/core/signalr/types.ts
+++ b/src/core/signalr/types.ts
@@ -22,53 +22,28 @@ export type AniDBBanItemType = {
   Message: string;
   PauseTimeSecs: number;
   UpdateTime: string;
-  UpdateType: AniDBBanTypeEnum;
+  UpdateType: BanUpdateTypeValues;
   Value: boolean;
 };
 
-export const enum AniDBBanTypeEnum {
-  None = 0,
-  UDPBan = 1,
-  HTTPBan = 2,
-  InvalidSession = 3,
-  OverloadBackoff = 4,
-  WaitingOnResponse = 5,
-}
+export type BanUpdateTypeValues =
+  | 'None'
+  | 'UDPBan'
+  | 'HTTPBan'
+  | 'InvalidSession'
+  | 'OverloadBackoff'
+  | 'WaitingOnResponse'
+  | 'LoginFailed';
 
-export type AniDBBanType = {
-  http: AniDBBanItemType;
-  udp: AniDBBanItemType;
-};
-
-export const enum NetworkAvailabilityEnum {
-  /**
-   * Shoko was unable to find any network interfaces.
-   */
-  NoInterfaces = 'NoInterfaces',
-
-  /**
-   * Shoko was unable to find any local gateways to use.
-   */
-  NoGateways = 'NoGateways',
-
-  /**
-   * Shoko was able to find a local gateway.
-   */
-  LocalOnly = 'LocalOnly',
-
-  /**
-   * Shoko was able to connect to some internet endpoints in WAN.
-   */
-  PartialInternet = 'PartialInternet',
-
-  /**
-   * Shoko was able to connect to all internet endpoints in WAN.
-   */
-  Internet = 'Internet',
-}
+export type NetworkAvailabilityValues =
+  | 'NoInterfaces'
+  | 'NoGateways'
+  | 'LocalOnly'
+  | 'PartialInternet'
+  | 'Internet';
 
 export type AVDumpRestoreType = {
-  Type: AVDumpEventTypeEnum.Restore;
+  Type: 'Restore';
   SessionID: number;
   VideoIDs: number[];
   CommandID: number | null;
@@ -81,7 +56,7 @@ export type AVDumpRestoreType = {
 };
 
 export type AVDumpEventType = {
-  Type: AVDumpEventTypeEnum.Started;
+  Type: 'Started';
   SessionID: number;
   VideoIDs: number[];
   CommandID: number | null;
@@ -91,38 +66,38 @@ export type AVDumpEventType = {
   PendingCreqCount: number;
   StartedAt: string;
 } | {
-  Type: AVDumpEventTypeEnum.Progress;
+  Type: 'Progress';
   SessionID: number;
   Progress: number;
 } | {
-  Type: AVDumpEventTypeEnum.CreqUpdate;
+  Type: 'CreqUpdate';
   SessionID: number;
   SucceededCreqCount: number;
   FailedCreqCount: number;
   PendingCreqCount: number;
 } | {
-  Type: AVDumpEventTypeEnum.Message | AVDumpEventTypeEnum.Error | AVDumpEventTypeEnum.ED2KLink;
+  Type: 'Message' | 'Error' | 'ED2KLink';
   SessionID: number;
   Message: string;
 } | {
   Type:
-    | AVDumpEventTypeEnum.InstalledAVDump
-    | AVDumpEventTypeEnum.InstallingAVDump
-    | AVDumpEventTypeEnum.InvalidCredentials
-    | AVDumpEventTypeEnum.MissingApiKey
-    | AVDumpEventTypeEnum.Timeout;
+    | 'InstalledAVDump'
+    | 'InstallingAVDump'
+    | 'InvalidCredentials'
+    | 'MissingApiKey'
+    | 'Timeout';
 } | {
-  Type: AVDumpEventTypeEnum.InstallException;
+  Type: 'InstallException';
   Message: string;
   ExceptionStackTrace: string;
 } | {
-  Type: AVDumpEventTypeEnum.GenericException;
+  Type: 'GenericException';
   SessionID: number;
   Message: string;
   ExceptionStackTrace: string;
   StartedAt: string;
 } | {
-  Type: AVDumpEventTypeEnum.Failure;
+  Type: 'Failure';
   SessionID: number;
   VideoIDs: number[];
   CommandID: number | null;
@@ -133,7 +108,7 @@ export type AVDumpEventType = {
   StartedAt: string;
   EndedAt: string;
 } | {
-  Type: AVDumpEventTypeEnum.Success;
+  Type: 'Success';
   SessionID: number;
   VideoIDs: number[];
   CommandID: number | null;
@@ -145,25 +120,6 @@ export type AVDumpEventType = {
   StartedAt: string;
   EndedAt: string;
 };
-
-export const enum AVDumpEventTypeEnum {
-  Message = 'Message',
-  Error = 'Error',
-  Progress = 'Progress',
-  CreqUpdate = 'CreqUpdate',
-  ED2KLink = 'ED2KLink',
-  Started = 'Started',
-  Success = 'Success',
-  Failure = 'Failure',
-  Restore = 'Restore',
-  GenericException = 'GenericException',
-  MissingApiKey = 'MissingApiKey',
-  InvalidCredentials = 'InvalidCredentials',
-  Timeout = 'Timeout',
-  InstallingAVDump = 'InstallingAVDump',
-  InstalledAVDump = 'InstalledAVDump',
-  InstallException = 'InstallException',
-}
 
 export type SeriesUpdateEventType = {
   ShokoSeriesIDs: number[];

--- a/src/core/slices/mainpage.ts
+++ b/src/core/slices/mainpage.ts
@@ -1,16 +1,19 @@
 import { createSlice } from '@reduxjs/toolkit';
 
-import { NetworkAvailabilityEnum } from '@/core/signalr/types';
-
-import type { AniDBBanItemType, AniDBBanType, QueueStatusType } from '@/core/signalr/types';
+import type { AniDBBanItemType, NetworkAvailabilityValues, QueueStatusType } from '@/core/signalr/types';
 import type { SliceActions } from '@/core/types/util';
 import type { PayloadAction } from '@reduxjs/toolkit';
+
+type AniDBBanType = {
+  http: AniDBBanItemType;
+  udp: AniDBBanItemType;
+};
 
 type State = {
   fetched: Record<string, boolean>;
   queueStatus: QueueStatusType;
   banStatus: AniDBBanType;
-  networkStatus: NetworkAvailabilityEnum;
+  networkStatus: NetworkAvailabilityValues;
   layoutEditMode: boolean;
 };
 
@@ -28,15 +31,15 @@ const initialState: State = {
   queueStatus: initialQueueStatus,
   banStatus: {
     http: {
-      UpdateType: 2,
+      UpdateType: 'HTTPBan',
       Value: false,
     },
     udp: {
-      UpdateType: 1,
+      UpdateType: 'UDPBan',
       Value: false,
     },
   } as AniDBBanType,
-  networkStatus: NetworkAvailabilityEnum.Internet,
+  networkStatus: 'Internet',
   layoutEditMode: false,
 };
 
@@ -66,7 +69,7 @@ const mainpageSlice = createSlice({
     setLayoutEditMode(sliceState, action: PayloadAction<boolean>) {
       sliceState.layoutEditMode = action.payload;
     },
-    setNetworkStatus(sliceState, action: PayloadAction<NetworkAvailabilityEnum>) {
+    setNetworkStatus(sliceState, action: PayloadAction<NetworkAvailabilityValues>) {
       sliceState.networkStatus = action.payload;
     },
   },

--- a/src/core/slices/utilities/avdump.ts
+++ b/src/core/slices/utilities/avdump.ts
@@ -1,7 +1,6 @@
 import { createSlice } from '@reduxjs/toolkit';
 import { forEach } from 'lodash';
 
-import { AVDumpEventTypeEnum } from '@/core/signalr/types';
 import toast from '@/core/toast';
 
 import type { AVDumpEventType, AVDumpRestoreType } from '@/core/signalr/types';
@@ -31,7 +30,7 @@ const avdumpSlice = createSlice({
     updateAVDumpEvent(sliceState, action: PayloadAction<AVDumpEventType>) {
       const event = action.payload;
       switch (event.Type) {
-        case AVDumpEventTypeEnum.Started:
+        case 'Started':
           sliceState.sessions[event.SessionID] = {
             status: 'Running',
             fileIDs: event.VideoIDs,
@@ -42,7 +41,7 @@ const avdumpSlice = createSlice({
           });
           break;
 
-        case AVDumpEventTypeEnum.Success:
+        case 'Success':
           if (sliceState.sessions[event.SessionID]) {
             const session = sliceState.sessions[event.SessionID];
             session.status = 'Success';
@@ -50,7 +49,7 @@ const avdumpSlice = createSlice({
           }
           break;
 
-        case AVDumpEventTypeEnum.Failure:
+        case 'Failure':
           if (sliceState.sessions[event.SessionID]) {
             const session = sliceState.sessions[event.SessionID];
             session.status = 'Failed';
@@ -58,7 +57,7 @@ const avdumpSlice = createSlice({
           }
           break;
 
-        case AVDumpEventTypeEnum.GenericException:
+        case 'GenericException':
           if (sliceState.sessions[event.SessionID]) {
             const session = sliceState.sessions[event.SessionID];
             session.status = 'Failed';
@@ -66,7 +65,7 @@ const avdumpSlice = createSlice({
           }
           break;
 
-        case AVDumpEventTypeEnum.InstallException:
+        case 'InstallException':
           toast.error('AVDump failed to install!', event.Message);
           break;
 

--- a/src/core/types/api/common.ts
+++ b/src/core/types/api/common.ts
@@ -5,8 +5,8 @@ export type ImageLinkType = {
 };
 
 export type ImageType = ImageLinkType & {
-  Source: ImageSourceType;
-  Type: ImageEntityType;
+  Source: DataSourceValues;
+  Type: ImageEntityValues;
   ID: number;
   PrimaryUID: string;
   Preferred: boolean;
@@ -27,9 +27,7 @@ export type EpisodeImagesType = ImagesType & {
   Thumbnails?: ImageType[];
 };
 
-export type ImageSourceType = 'AniDB' | 'TMDB' | 'Shoko' | 'User';
-
-export type ImageEntityType = 'None' | 'Primary' | 'Backdrop' | 'Banner' | 'Logo' | 'Disc';
+export type ImageEntityValues = 'None' | 'Primary' | 'Backdrop' | 'Banner' | 'Logo' | 'Disc';
 
 export type RatingType = {
   Value: number;
@@ -45,4 +43,25 @@ export type LogLineType = {
   Level: string;
 };
 
-export type DataSourceType = 'AniDB' | 'TMDB' | 'MAL' | 'AniList' | 'Animeshon' | 'Kitsu';
+export type DataSourceValues =
+  | 'Plugin'
+  | 'LocallyGenerated'
+  | 'None'
+  | 'User'
+  | 'Shoko'
+  | 'AniDB'
+  | 'TMDB'
+  | 'TvDB'
+  | 'AniList'
+  | 'Animeshon'
+  | 'Kitsu'
+  | 'MAL'
+  | 'FanartTV'
+  | 'IMDB'
+  | 'OMDB'
+  | 'TraktTv'
+  | 'TPDB'
+  | 'MediUX'
+  | 'SimKL';
+
+export type DataSourceTypeValues = 'AniDB' | 'TMDB';

--- a/src/core/types/api/dashboard.ts
+++ b/src/core/types/api/dashboard.ts
@@ -1,5 +1,5 @@
 import type { ImageType } from './common';
-import type { EpisodeTypeEnum } from './episode';
+import type { EpisodeTypeValues } from './episode';
 
 export type DashboardSeriesSummaryType = {
   Series: number;
@@ -40,7 +40,7 @@ export type DashboardEpisodeDetailsType = {
   };
   Title: string;
   Number: number;
-  Type: EpisodeTypeEnum;
+  Type: EpisodeTypeValues;
   AirDate: string | null;
   Duration: string;
   ResumePosition: string | null;

--- a/src/core/types/api/episode.ts
+++ b/src/core/types/api/episode.ts
@@ -37,19 +37,18 @@ export type EpisodeTitleType = {
   Source: string;
 };
 
-export const enum EpisodeTypeEnum {
-  Unknown = 'Unknown',
-  Other = 'Other',
-  Episode = 'Episode',
-  Special = 'Special',
-  Trailer = 'Trailer',
-  Credits = 'Credits',
-  Parody = 'Parody',
-}
+export type EpisodeTypeValues =
+  | 'Unknown'
+  | 'Other'
+  | 'Episode'
+  | 'Special'
+  | 'Trailer'
+  | 'Credits'
+  | 'Parody';
 
 export type AniDBEpisodeType = {
   ID: number;
-  Type: EpisodeTypeEnum;
+  Type: EpisodeTypeValues;
   EpisodeNumber: number;
   AirDate: string | null;
   Title: string;
@@ -58,7 +57,7 @@ export type AniDBEpisodeType = {
   Rating: RatingType;
 };
 
-export type MatchRatingType =
+export type MatchRatingValues =
   | 'DateAndTitleKindaMatches'
   | 'DateAndTitleMatches'
   | 'DateKindaMatches'

--- a/src/core/types/api/file.ts
+++ b/src/core/types/api/file.ts
@@ -46,7 +46,7 @@ export type ReleaseInfoType = {
   IsCreditless?: boolean;
   IsChaptered?: boolean;
   IsCorrupted: boolean;
-  Source: ReleaseSource;
+  Source: ReleaseSourceValues;
   Group?: ReleaseGroupType;
   Hashes?: FileHashDigestType[];
   MediaInfo?: ReleaseMediaInfoType;
@@ -57,19 +57,18 @@ export type ReleaseInfoType = {
   Created: string;
 };
 
-export const enum ReleaseSource {
-  Unknown = 'Unknown',
-  Other = 'Other',
-  TV = 'TV',
-  DVD = 'DVD',
-  BluRay = 'BluRay',
-  Web = 'Web',
-  VHS = 'VHS',
-  VCD = 'VCD',
-  LaserDisc = 'LaserDisc',
-  Camera = 'Camera',
-  Film = 'Film',
-}
+export type ReleaseSourceValues =
+  | 'Unknown'
+  | 'Other'
+  | 'TV'
+  | 'DVD'
+  | 'BluRay'
+  | 'Web'
+  | 'VHS'
+  | 'VCD'
+  | 'LaserDisc'
+  | 'Camera'
+  | 'Film';
 
 export type ReleaseGroupType = {
   ID: string;
@@ -110,19 +109,6 @@ export type FileAVDumpType = {
   LastDumpedAt: string | null;
   LastVersion: string | null;
 };
-
-export const enum FileSourceEnum {
-  Unknown = 'Unknown',
-  Other = 'Other',
-  TV = 'TV',
-  DVD = 'DVD',
-  BluRay = 'BluRay',
-  Web = 'Web',
-  VHS = 'VHS',
-  VCD = 'VCD',
-  LaserDisc = 'LaserDisc',
-  Camera = 'Camera',
-}
 
 export type FileMediaInfoType = {
   Title: string;
@@ -227,22 +213,28 @@ export type FileMediaInfoChapterType = {
   Timestamp: string;
 };
 
-export enum FileSortCriteriaEnum {
-  None = 0,
-  ManagedFolderName = 1,
-  ManagedFolderID = 2,
-  AbsolutePath = 3,
-  RelativePath = 4,
-  FileSize = 5,
-  DuplicateCount = 6,
-  CreatedAt = 7,
-  ImportedAt = 8,
-  ViewedAt = 9,
-  WatchedAt = 10,
-  ED2K = 11,
-  MD5 = 12,
-  SHA1 = 13,
-  CRC32 = 14,
-  FileName = 15,
-  FileID = 16,
-}
+type FileSortCriteriaValues =
+  | 'None'
+  | 'ManagedFolderName'
+  | 'ManagedFolderID'
+  | 'AbsolutePath'
+  | 'RelativePath'
+  | 'FileSize'
+  | 'DuplicateCount'
+  | 'CreatedAt'
+  | 'ImportedAt'
+  | 'ViewedAt'
+  | 'WatchedAt'
+  | 'ED2K'
+  | 'MD5'
+  | 'SHA1'
+  | 'CRC32'
+  | 'FileName'
+  | 'FileID'
+  | 'ReleaseProviderName'
+  | 'ReleaseProviderID'
+  | 'ReleaseGroupName'
+  | 'ReleaseGroupShortName'
+  | 'ReleaseGroupID';
+
+export type FileSortOrderValue = FileSortCriteriaValues | `-${FileSortCriteriaValues}`;

--- a/src/core/types/api/image.ts
+++ b/src/core/types/api/image.ts
@@ -1,8 +1,8 @@
-import type { ImageEntityType } from './common';
+import type { ImageEntityValues } from './common';
 
 export type RandomImageMetadataResultType = {
   Source: string;
-  Type: ImageEntityType;
+  Type: ImageEntityValues;
   UID: string;
   Available: boolean;
   Preferred: boolean;

--- a/src/core/types/api/init.ts
+++ b/src/core/types/api/init.ts
@@ -14,11 +14,11 @@ export type ServerStatusType = {
   };
 };
 
-export type ReleaseChannelType = 'Auto' | 'Stable' | 'Dev';
+export type ReleaseChannelValues = 'Auto' | 'Stable' | 'Dev';
 
 export type ComponentVersionType = {
   Version: string;
-  ReleaseChannel: ReleaseChannelType | 'Debug';
+  ReleaseChannel: ReleaseChannelValues | 'Debug';
   ReleaseDate: string;
   Commit?: string;
   Tag?: string;

--- a/src/core/types/api/plugin-package.ts
+++ b/src/core/types/api/plugin-package.ts
@@ -1,4 +1,4 @@
-import type { ReleaseChannelType } from '@/core/types/api/init';
+import type { ReleaseChannelValues } from '@/core/types/api/init';
 import type { PackageThumbnailInfoType, PluginInfoType } from '@/core/types/api/plugin';
 
 export type PackageRepositoryInfoType = {
@@ -24,7 +24,7 @@ export type PackageReleaseInfoType = {
   Tag?: string;
   SourceRevision?: string;
   ReleasedAt: string;
-  Channel: ReleaseChannelType;
+  Channel: ReleaseChannelValues;
   ReleaseNotes?: string;
   IsInstalled: boolean;
   Archives?: PackageArchiveInfoType[];

--- a/src/core/types/api/plugin.ts
+++ b/src/core/types/api/plugin.ts
@@ -1,4 +1,4 @@
-import type { ReleaseChannelType } from '@/core/types/api/init';
+import type { ReleaseChannelValues } from '@/core/types/api/init';
 
 export type PackageThumbnailInfoType = {
   MimeType: string;
@@ -15,7 +15,7 @@ export type PluginInfoType = {
   AbstractionVersion: string;
   SourceRevision?: string;
   ReleaseTag?: string;
-  Channel: ReleaseChannelType;
+  Channel: ReleaseChannelValues;
   ReleasedAt: string;
   Authors?: string;
   RepositoryUrl?: string;

--- a/src/core/types/api/release-management.ts
+++ b/src/core/types/api/release-management.ts
@@ -1,7 +1,7 @@
-import type { EpisodeTypeEnum } from '@/core/types/api/episode';
+import type { EpisodeTypeValues } from '@/core/types/api/episode';
 
 export type EpisodeCoverageType = {
-  Type: EpisodeTypeEnum;
+  Type: EpisodeTypeValues;
   Number: number;
   GroupShortName?: string;
   /** PlaceIDs of every file covering this episode. Only populated on candidate-level `Episodes`; always empty on a file's own `Episodes`. More than one entry means multiple files legitimately cover this episode. */

--- a/src/core/types/api/series.ts
+++ b/src/core/types/api/series.ts
@@ -38,7 +38,7 @@ export type SeriesIDsType = {
 export type AniDBSeriesType = {
   ID: number;
   ShokoID?: number;
-  Type: SeriesTypeEnum;
+  Type: AnimeTypeValues;
   Restricted: boolean;
   Title: string;
   Titles: SeriesTitleType[];
@@ -49,37 +49,35 @@ export type AniDBSeriesType = {
   Rating: RatingType;
 };
 
-export const enum SeriesTypeEnum {
-  Unknown = 'Unknown',
-  Other = 'Other',
-  TV = 'TV',
-  TVSpecial = 'TVSpecial',
-  Web = 'Web',
-  Movie = 'Movie',
-  OVA = 'OVA',
-  MusicVideo = 'MusicVideo',
-}
+export type AnimeTypeValues =
+  | 'Unknown'
+  | 'Other'
+  | 'TV'
+  | 'TVSpecial'
+  | 'Web'
+  | 'Movie'
+  | 'OVA'
+  | 'MusicVideo';
 
-export const enum SeriesRelationTypeEnum {
-  Other = 'Other',
-  SameSetting = 'SameSetting',
-  AlternativeSetting = 'AlternativeSetting',
-  AlternativeVersion = 'AlternativeVersion',
-  SharedCharacters = 'SharedCharacters',
-  Prequel = 'Prequel',
-  MainStory = 'MainStory',
-  FullStory = 'FullStory',
-  Sequel = 'Sequel',
-  SideStory = 'SideStory',
-  Summary = 'Summary',
-}
+export type RelationTypeValues =
+  | 'Other'
+  | 'SameSetting'
+  | 'AlternativeSetting'
+  | 'AlternativeVersion'
+  | 'SharedCharacters'
+  | 'Prequel'
+  | 'MainStory'
+  | 'FullStory'
+  | 'Sequel'
+  | 'SideStory'
+  | 'Summary';
 
 export type SeriesAniDBSearchResult = {
   ID: number;
   Title: string;
   Titles: SeriesTitleType[];
   ShokoID: number | null;
-  Type: SeriesTypeEnum;
+  Type: AnimeTypeValues;
   EpisodeCount: number;
 };
 
@@ -141,7 +139,7 @@ export type SeriesRecommendedType = {
 export type SeriesAniDBRelatedType = {
   ID: number;
   ShokoID: number | null;
-  Type: SeriesTypeEnum;
+  Type: AnimeTypeValues;
   Title: string;
   Titles: SeriesTitleType[];
   Restricted: boolean;
@@ -149,13 +147,13 @@ export type SeriesAniDBRelatedType = {
   EpisodeCount: number | null;
   Rating: RatingType;
   UserApproval: RatingType;
-  Relation: SeriesRelationTypeEnum;
+  Relation: RelationTypeValues;
 };
 
 export type SeriesAniDBSimilarType = {
   ID: number;
   ShokoID: number | null;
-  Type: SeriesTypeEnum;
+  Type: AnimeTypeValues;
   Title: string;
   Titles: SeriesTitleType[];
   Restricted: boolean;
@@ -163,7 +161,7 @@ export type SeriesAniDBSimilarType = {
   EpisodeCount: number | null;
   Rating: RatingType;
   UserApproval: RatingType;
-  Relation: SeriesRelationTypeEnum;
+  Relation: RelationTypeValues;
 };
 
 export type SeriesRolePerson = {

--- a/src/core/types/api/settings.ts
+++ b/src/core/types/api/settings.ts
@@ -1,6 +1,7 @@
 import type { Layout } from 'react-grid-layout';
 
-import type { ReleaseChannelType } from '@/core/types/api/init';
+import type { DataSourceValues } from './common';
+import type { ReleaseChannelValues } from '@/core/types/api/init';
 import type { ManualLinkProviderType } from '@/core/types/utilities/link-files-with-providers';
 
 export type SettingsDatabaseType = {
@@ -246,11 +247,6 @@ export type SettingsTMDBType = {
   UserApiKey: string | null;
 };
 
-export const enum LanguageSource {
-  AniDB = 'AniDB',
-  TMDB = 'TMDB',
-}
-
 export type SettingsLanguageType = {
   /**
    * Use synonyms when selecting the preferred language from AniDB.
@@ -269,9 +265,9 @@ export type SettingsLanguageType = {
   /**
    * Series / group title source preference order.
    *
-   * @default [LanguageSource.AniDB, LanguageSource.TMDB]
+   * @default ['AniDB', 'TMDB']
    */
-  SeriesTitleSourceOrder: LanguageSource[];
+  SeriesTitleSourceOrder: DataSourceValues[];
 
   /**
    * Episode / season title language preference order.
@@ -283,9 +279,9 @@ export type SettingsLanguageType = {
   /**
    * Episode / season title source preference order.
    *
-   * @default [LanguageSource.TMDB, LanguageSource.AniDB]
+   * @default ['TMDB', 'AniDB']
    */
-  EpisodeTitleSourceOrder: LanguageSource[];
+  EpisodeTitleSourceOrder: DataSourceValues[];
 
   /**
    * Description language preference order.
@@ -297,9 +293,9 @@ export type SettingsLanguageType = {
   /**
    * Description source preference order.
    *
-   * @default [LanguageSource.TMDB, LanguageSource.AniDB]
+   * @default ['TMDB', 'AniDB']
    */
-  DescriptionSourceOrder: LanguageSource[];
+  DescriptionSourceOrder: DataSourceValues[];
 };
 
 export type SettingsPlexType = {
@@ -323,7 +319,7 @@ export type SettingsImportType = {
   VideoExtensions: string[];
 };
 
-export type SignalType =
+export type ReleaseSignalTypeValues =
   | 'Source'
   | 'Resolution'
   | 'VideoCodec'
@@ -341,10 +337,8 @@ export type SignalType =
   | 'GroupHomogeneity'
   | 'SubGroup';
 
-export type EpisodeTypeScopeType = 'AllTogether' | 'PerEpisodeType';
-
 export type ReleaseComparisonPreferencesType = {
-  SignalPriority: SignalType[];
+  SignalPriority: ReleaseSignalTypeValues[];
   SourceOrder: string[];
   ResolutionOrder: string[];
   VideoCodecOrder: string[];
@@ -356,7 +350,7 @@ export type ReleaseComparisonPreferencesType = {
   AllowDeletion: boolean;
   AutoDeleteOnImport: boolean;
   PerFileDeletionForAiringSeries: boolean;
-  EpisodeTypeScope: EpisodeTypeScopeType;
+  EpisodeTypeScope: 'KeepTogether' | 'BestPerType';
 };
 
 export type PluginRenamerSettingsType = {
@@ -412,8 +406,8 @@ export type WebUISettingsType = {
   settingsRevision: number;
   theme: string;
   toastPosition: 'top-right' | 'bottom-right';
-  updateChannel: ReleaseChannelType;
-  serverUpdateChannel: ReleaseChannelType;
+  updateChannel: ReleaseChannelValues;
+  serverUpdateChannel: ReleaseChannelValues;
   layout: {
     dashboard: Partial<Record<string, Layout>>;
   };

--- a/src/core/types/api/tmdb.ts
+++ b/src/core/types/api/tmdb.ts
@@ -1,4 +1,4 @@
-import type { MatchRatingType } from '@/core/types/api/episode';
+import type { MatchRatingValues } from '@/core/types/api/episode';
 
 export type TmdbEpisodeType = {
   ID: number;
@@ -31,7 +31,7 @@ export type TmdbEpisodeXrefType = {
   TmdbShowID: number;
   TmdbEpisodeID: number;
   Index: number;
-  Rating: MatchRatingType;
+  Rating: MatchRatingValues;
 } & TmdbXrefType;
 
 export type TmdbMovieXrefType = {

--- a/src/core/types/api/webui.ts
+++ b/src/core/types/api/webui.ts
@@ -1,6 +1,6 @@
 import type { ImageType, RatingType } from './common';
-import type { EpisodeTypeEnum } from './episode';
-import type { FileSourceEnum } from './file';
+import type { EpisodeTypeValues } from './episode';
+import type { ReleaseSourceValues } from './file';
 import type { SeriesTitleType } from './series';
 import type { TagType } from './tags';
 
@@ -61,7 +61,7 @@ export type WebuiSeriesFileSummaryGroupType = {
     FileID: number;
     Number: number;
     Size: number;
-    Type: EpisodeTypeEnum;
+    Type: EpisodeTypeValues;
   }[];
   Locations?: {
     ID: number;
@@ -111,12 +111,12 @@ export type WebuiSeriesFileSummaryOverview = {
 };
 
 export type WebuiSeriesFileSummarySourcesByType = {
-  Type: EpisodeTypeEnum;
+  Type: EpisodeTypeValues;
   Sources: WebuiSeriesFileSummarySourceCount[];
 };
 
 export type WebuiSeriesFileSummarySourceCount = {
-  Type: FileSourceEnum;
+  Type: ReleaseSourceValues;
   Count: number;
 };
 

--- a/src/core/utilities/auto-match-logic.ts
+++ b/src/core/utilities/auto-match-logic.ts
@@ -1,22 +1,21 @@
 import { every, reduce } from 'lodash';
 
-import { EpisodeTypeEnum } from '@/core/types/api/episode';
-
 import PathMatchRuleSet from './auto-match-regexes';
 
-import type { ReleaseSource } from '@/core/types/api/file';
+import type { EpisodeTypeValues } from '@/core/types/api/episode';
+import type { ReleaseSourceValues } from '@/core/types/api/file';
 
 export type PathDetails = {
   filePath: string;
   fileExtension: string | null;
   releaseGroup: string | null;
-  source: ReleaseSource | null;
+  source: ReleaseSourceValues | null;
   showName: string | null;
   season: number | null;
   episodeName: string | null;
   episodeStart: number;
   episodeEnd: number;
-  episodeType: EpisodeTypeEnum;
+  episodeType: EpisodeTypeValues;
   version: number | null;
   crc32: string | null;
   ruleName: string;
@@ -40,24 +39,24 @@ const DriveLetterRegex = /^[A-Z]:$/;
 
 const noopTransform = (show: PathDetails) => show;
 
-const detectEpisodeType = (matchGroups: Record<string, string | undefined>): EpisodeTypeEnum => {
+const detectEpisodeType = (matchGroups: Record<string, string | undefined>): EpisodeTypeValues => {
   if (matchGroups.isSpecial) {
-    return EpisodeTypeEnum.Special;
+    return 'Special';
   }
 
   if (matchGroups.isThemeSong) {
-    return EpisodeTypeEnum.Credits;
+    return 'Credits';
   }
 
   if (matchGroups.isOther) {
-    return EpisodeTypeEnum.Other;
+    return 'Other';
   }
 
   if (matchGroups.isTrailer) {
-    return EpisodeTypeEnum.Trailer;
+    return 'Trailer';
   }
 
-  return EpisodeTypeEnum.Episode;
+  return 'Episode';
 };
 
 export const detectShow = (filePath: string | undefined | null) => {
@@ -105,8 +104,8 @@ export const detectShow = (filePath: string | undefined | null) => {
       // The user is responsible if they link it without checking. We even show
       // a notification telling them to verify the matches before saving.
       let episodeType = detectEpisodeType(match.groups);
-      if (episodeType === EpisodeTypeEnum.Episode && episodeStart === episodeEnd && !Number.isInteger(episodeStart)) {
-        episodeType = EpisodeTypeEnum.Special;
+      if (episodeType === 'Episode' && episodeStart === episodeEnd && !Number.isInteger(episodeStart)) {
+        episodeType = 'Special';
         episodeStart = 0;
         episodeEnd = 0;
       }

--- a/src/core/utilities/auto-match-regexes.ts
+++ b/src/core/utilities/auto-match-regexes.ts
@@ -1,5 +1,3 @@
-import { EpisodeTypeEnum } from '@/core/types/api/episode';
-
 import type { PathDetails, PathMatchRule } from './auto-match-logic';
 
 const PathMatchRuleSet: PathMatchRule[] = [];
@@ -146,7 +144,7 @@ try {
         const { episode: episodeText = '0' } = trailerCheckResult.groups!;
         const episode = parseInt(episodeText, 10);
 
-        modifiedDetails.episodeType = EpisodeTypeEnum.Trailer;
+        modifiedDetails.episodeType = 'Trailer';
         if (episode > 0) {
           modifiedDetails.episodeStart = episode;
           modifiedDetails.episodeEnd = episode;
@@ -157,7 +155,7 @@ try {
         const { episode: episodeText = '0' } = extraCheckResult.groups!;
         const episode = parseInt(episodeText, 10);
 
-        modifiedDetails.episodeType = EpisodeTypeEnum.Special;
+        modifiedDetails.episodeType = 'Special';
         if (episode > 0) {
           modifiedDetails.episodeStart = episode;
           modifiedDetails.episodeEnd = episode;

--- a/src/core/utilities/getEpisodePrefix.ts
+++ b/src/core/utilities/getEpisodePrefix.ts
@@ -1,36 +1,36 @@
-import { EpisodeTypeEnum } from '@/core/types/api/episode';
+import type { EpisodeTypeValues } from '@/core/types/api/episode';
 
-export const getEpisodePrefix = (type?: EpisodeTypeEnum) => {
+export const getEpisodePrefix = (type?: EpisodeTypeValues) => {
   switch (type) {
-    case EpisodeTypeEnum.Special:
+    case 'Special':
       return 'S';
-    case EpisodeTypeEnum.Credits:
+    case 'Credits':
       return 'C';
-    case EpisodeTypeEnum.Trailer:
+    case 'Trailer':
       return 'T';
-    case EpisodeTypeEnum.Other:
+    case 'Other':
       return 'O';
-    case EpisodeTypeEnum.Parody:
+    case 'Parody':
       return 'P';
-    case EpisodeTypeEnum.Episode:
+    case 'Episode':
     default:
       return '';
   }
 };
 
-export const getEpisodePrefixAlt = (type?: EpisodeTypeEnum) => {
+export const getEpisodePrefixAlt = (type?: EpisodeTypeValues) => {
   switch (type) {
-    case EpisodeTypeEnum.Special:
+    case 'Special':
       return 'SP';
-    case EpisodeTypeEnum.Credits:
+    case 'Credits':
       return 'C';
-    case EpisodeTypeEnum.Trailer:
+    case 'Trailer':
       return 'T';
-    case EpisodeTypeEnum.Other:
+    case 'Other':
       return 'O';
-    case EpisodeTypeEnum.Parody:
+    case 'Parody':
       return 'P';
-    case EpisodeTypeEnum.Episode:
+    case 'Episode':
     default:
       return 'EP';
   }

--- a/src/core/utilities/releaseInfoHelpers.ts
+++ b/src/core/utilities/releaseInfoHelpers.ts
@@ -1,6 +1,5 @@
 import { produce } from 'immer';
 
-import { ReleaseSource } from '@/core/types/api/file';
 import { dayjs } from '@/core/util';
 
 import type { FileType, ReleaseInfoType } from '@/core/types/api/file';
@@ -24,7 +23,7 @@ const generateLinkId = () => {
 
 export const mergeReleaseInfo = (incoming: ReleaseInfoType, original: ReleaseInfoType): ReleaseInfoType =>
   produce(incoming, (draft) => {
-    if (draft.Source === ReleaseSource.Unknown && original.Source !== ReleaseSource.Unknown) {
+    if (draft.Source === 'Unknown' && original.Source !== 'Unknown') {
       draft.Source = original.Source;
     }
 
@@ -63,7 +62,7 @@ const createLinksFromFiles = (files: FileType[], providers: ManualLinkProviderTy
       OriginalFilename: file.Locations?.[0]?.RelativePath.split(/[/\\]/g).pop(),
       ProviderName: 'User',
       Version: 1,
-      Source: ReleaseSource.Unknown,
+      Source: 'Unknown',
       CrossReferences: [],
       FileSize: file.Size,
       Hashes: file.Hashes,

--- a/src/core/utilities/releaseManagementHelpers.ts
+++ b/src/core/utilities/releaseManagementHelpers.ts
@@ -1,7 +1,7 @@
 import { groupBy, mapValues } from 'lodash';
 
 import type { EpisodeCoverageType } from '@/core/types/api/release-management';
-import type { SignalType } from '@/core/types/api/settings';
+import type { ReleaseSignalTypeValues } from '@/core/types/api/settings';
 
 const episodePriority: string[] = ['Episode', 'Special', 'Trailer', 'Credits', 'Parody', 'Other', 'Unknown'];
 
@@ -9,7 +9,7 @@ export const typeOrder: Record<string, number> = Object.fromEntries(
   episodePriority.map((type, idx) => [type, idx]),
 );
 
-export const signalLabels: Record<SignalType, string> = {
+export const signalLabels: Record<ReleaseSignalTypeValues, string> = {
   AudioCodec: 'Audio Codec',
   AudioLanguage: 'Audio Language',
   AudioStreams: 'Audio Streams',

--- a/src/hooks/utilities/useReleaseInfoForm.ts
+++ b/src/hooks/utilities/useReleaseInfoForm.ts
@@ -1,7 +1,6 @@
 import { useEffect, useEffectEvent, useState } from 'react';
 import { useImmer } from 'use-immer';
 
-import { ReleaseSource } from '@/core/types/api/file';
 import { detectShow, findMostCommonShowName } from '@/core/utilities/auto-match-logic';
 import { AUTO_MATCH_EPISODE_ID } from '@/core/utilities/releaseInfoHelpers';
 
@@ -23,7 +22,7 @@ const useReleaseInfoForm = (selectedLinks: ManualLinkType[], show: boolean) => {
 
   const [formState, setFormState] = useImmer<FormState>({
     version: 1,
-    source: ReleaseSource.Unknown,
+    source: 'Unknown',
     comment: '',
   });
   const [touchedFields, setTouchedFields] = useImmer<Set<TouchableField>>(new Set());

--- a/src/hooks/utilities/useTableSearchSortCriteria.ts
+++ b/src/hooks/utilities/useTableSearchSortCriteria.ts
@@ -2,16 +2,16 @@ import type { ChangeEvent } from 'react';
 import { useEffect, useState } from 'react';
 import { useDebounceValue } from 'usehooks-ts';
 
-import type { FileSortCriteriaEnum } from '@/core/types/api/file';
+import type { FileSortOrderValue } from '@/core/types/api/file';
 
-const useTableSearchSortCriteria = (defaultSortCriteria: FileSortCriteriaEnum) => {
-  const [sortCriteria, setSortCriteria] = useState<number>(defaultSortCriteria);
-  const [searchSortCriteria, setSearchSortCriteria] = useState<number>();
+const useTableSearchSortCriteria = (defaultSortCriteria: FileSortOrderValue) => {
+  const [sortCriteria, setSortCriteria] = useState<FileSortOrderValue>(defaultSortCriteria);
+  const [searchSortCriteria, setSearchSortCriteria] = useState<FileSortOrderValue>();
 
   const [search, setSearch] = useState('');
   const [debouncedSearch] = useDebounceValue(search, 250);
 
-  const updateSortCriteria = (newCriteria: FileSortCriteriaEnum) => {
+  const updateSortCriteria = (newCriteria: FileSortOrderValue) => {
     if (debouncedSearch) setSearchSortCriteria(newCriteria);
     else setSortCriteria(newCriteria);
   };

--- a/src/pages/collection/series/SeriesEpisodes.tsx
+++ b/src/pages/collection/series/SeriesEpisodes.tsx
@@ -13,17 +13,17 @@ import EpisodeWatchModal from '@/components/Collection/Episode/EpisodeWatchModal
 import Button from '@/components/Input/Button';
 import { useWatchSeriesEpisodesMutation } from '@/core/react-query/series/mutations';
 import { useSeriesEpisodesInfiniteQuery } from '@/core/react-query/series/queries';
-import { EpisodeTypeEnum } from '@/core/types/api/episode';
 import { dayjs } from '@/core/util';
 import useFlattenListResult from '@/hooks/useFlattenListResult';
 
 import type { SeriesContextType } from '@/components/Collection/constants';
 import type { IncludeOnlyFilterType } from '@/core/react-query/types';
+import type { EpisodeTypeValues } from '@/core/types/api/episode';
 
 const pageSize = 26;
 
 type FilterOptionsType = {
-  type: EpisodeTypeEnum[];
+  type: EpisodeTypeValues[];
   includeMissing: IncludeOnlyFilterType;
   includeWatched: IncludeOnlyFilterType;
   includeHidden: IncludeOnlyFilterType;
@@ -43,7 +43,7 @@ const SeriesEpisodes = () => {
   const [debouncedSearch] = useDebounceValue(search, 200);
 
   const filterOptions = useMemo(() => ({
-    type: [searchParams.get('type') ?? EpisodeTypeEnum.Episode],
+    type: [searchParams.get('type') ?? 'Episode'],
     includeMissing: searchParams.get('includeMissing') ?? 'false',
     includeWatched: searchParams.get('includeWatched') ?? 'true',
     includeHidden: searchParams.get('includeHidden') ?? 'false',

--- a/src/pages/collection/series/SeriesImages.tsx
+++ b/src/pages/collection/series/SeriesImages.tsx
@@ -26,10 +26,10 @@ import useFlattenListResult from '@/hooks/useFlattenListResult';
 import useNavigateVoid from '@/hooks/useNavigateVoid';
 
 import type { SeriesContextType } from '@/components/Collection/constants';
-import type { ImageEntityType, ImageType } from '@/core/types/api/common';
+import type { ImageEntityValues, ImageType } from '@/core/types/api/common';
 import type { ImageTabType } from '@/core/types/api/image';
 
-const tabToImageTypeMap: Record<ImageTabType, ImageEntityType> = {
+const tabToImageTypeMap: Record<ImageTabType, ImageEntityValues> = {
   Posters: 'Primary',
   Backdrops: 'Backdrop',
   Logos: 'Logo',

--- a/src/pages/collection/series/TmdbLinking.tsx
+++ b/src/pages/collection/series/TmdbLinking.tsx
@@ -30,7 +30,6 @@ import {
   useTmdbShowOrMovieQuery,
 } from '@/core/react-query/tmdb/queries';
 import toast from '@/core/toast';
-import { EpisodeTypeEnum } from '@/core/types/api/episode';
 import { getAnidbAnimeLink } from '@/core/util';
 import useFlattenListResult from '@/hooks/useFlattenListResult';
 import useNavigateVoid from '@/hooks/useNavigateVoid';
@@ -69,7 +68,7 @@ const TmdbLinking = () => {
       includeDataFrom: ['AniDB'],
       includeMissing: 'true',
       includeUnaired: 'true',
-      type: [EpisodeTypeEnum.Episode, EpisodeTypeEnum.Special, EpisodeTypeEnum.Other],
+      type: ['Episode', 'Special', 'Other'],
       pageSize: 50,
     },
     !!seriesId,

--- a/src/pages/dashboard/components/EpisodeDetails.tsx
+++ b/src/pages/dashboard/components/EpisodeDetails.tsx
@@ -1,10 +1,10 @@
 import DashboardEpisode from '@/components/Dashboard/DashboardEpisode';
 import SeriesPoster from '@/components/SeriesPoster';
 import { useSettingsQuery } from '@/core/react-query/settings/queries';
-import { EpisodeTypeEnum } from '@/core/types/api/episode';
 import { convertTimeSpanToMs, dayjs } from '@/core/util';
 
 import type { DashboardEpisodeDetailsType } from '@/core/types/api/dashboard';
+import type { EpisodeTypeValues } from '@/core/types/api/episode';
 
 type Props = {
   episode: DashboardEpisodeDetailsType;
@@ -21,19 +21,19 @@ const CalendarConfig = {
   sameElse: 'dddd',
 };
 
-const anidbEpisodePrefixes = (type: EpisodeTypeEnum, epNumber: number): string => {
+const anidbEpisodePrefixes = (type: EpisodeTypeValues, epNumber: number): string => {
   const fullPrefixes = (prefix: string) => `${prefix}${epNumber}`;
   // Prefixes for episode types base on https://wiki.anidb.net/Content:Episodes#Type
   switch (type) {
-    case EpisodeTypeEnum.Credits:
+    case 'Credits':
       return fullPrefixes('C');
-    case EpisodeTypeEnum.Special:
+    case 'Special':
       return fullPrefixes('S');
-    case EpisodeTypeEnum.Trailer:
+    case 'Trailer':
       return fullPrefixes('T');
-    case EpisodeTypeEnum.Other:
+    case 'Other':
       return fullPrefixes('O');
-    case EpisodeTypeEnum.Parody:
+    case 'Parody':
       return fullPrefixes('P');
     default:
       return fullPrefixes('');

--- a/src/pages/dashboard/panels/UnrecognizedFiles.tsx
+++ b/src/pages/dashboard/panels/UnrecognizedFiles.tsx
@@ -10,9 +10,10 @@ import { useRescanFileMutation } from '@/core/react-query/file/mutations';
 import { useFilesInfiniteQuery } from '@/core/react-query/file/queries';
 import { useSelector } from '@/core/store';
 import toast from '@/core/toast';
-import { FileSortCriteriaEnum, type FileType } from '@/core/types/api/file';
 import { dayjs } from '@/core/util';
 import useNavigateVoid from '@/hooks/useNavigateVoid';
+
+import type { FileType } from '@/core/types/api/file';
 
 const FileItem = ({ file }: { file: FileType }) => {
   const createdTime = dayjs(file.Created);
@@ -76,7 +77,7 @@ const UnrecognizedFiles = () => {
   const filesQuery = useFilesInfiniteQuery({
     pageSize: 20,
     include_only: ['Unrecognized'],
-    sortOrder: [FileSortCriteriaEnum.FileID * -1],
+    sortOrder: ['-FileID'],
   });
   const [files, fileCount] = useMemo(
     () => {

--- a/src/pages/utilities/DuplicateFilesTabs/DuplicateFilesUnrecognizedTab.tsx
+++ b/src/pages/utilities/DuplicateFilesTabs/DuplicateFilesUnrecognizedTab.tsx
@@ -15,29 +15,28 @@ import UtilitiesTable from '@/components/Utilities/UtilitiesTable';
 import { useFilesInfiniteQuery } from '@/core/react-query/file/queries';
 import { useManagedFoldersQuery } from '@/core/react-query/managed-folder/queries';
 import { resetQueries } from '@/core/react-query/queryClient';
-import { FileSortCriteriaEnum } from '@/core/types/api/file';
 import useFlattenListResult from '@/hooks/useFlattenListResult';
 import useTableSearchSortCriteria from '@/hooks/utilities/useTableSearchSortCriteria';
 
 import type { UtilityHeaderType } from '@/components/Utilities/constants';
-import type { FileType } from '@/core/types/api/file';
+import type { FileSortOrderValue, FileType } from '@/core/types/api/file';
 
 const DuplicateFilesUnrecognizedTab = () => {
   const [selectedFile, setSelectedFile] = useState(-1);
   const [showModal, toggleModal, setShowModal] = useToggle(false);
 
   const { debouncedSearch, search, setSearch, setSortCriteria, sortCriteria } = useTableSearchSortCriteria(
-    FileSortCriteriaEnum.DuplicateCount,
+    'DuplicateCount',
   );
 
   const managedFolderQuery = useManagedFoldersQuery();
   const managedFolders = managedFolderQuery?.data ?? [];
 
-  let sortOrder: FileSortCriteriaEnum[] | undefined;
+  let sortOrder: FileSortOrderValue[] | undefined;
   if (debouncedSearch && sortCriteria) {
     sortOrder = [sortCriteria];
   } else if (sortCriteria) {
-    sortOrder = [sortCriteria, FileSortCriteriaEnum.FileName, FileSortCriteriaEnum.RelativePath];
+    sortOrder = [sortCriteria, 'FileName', 'RelativePath'];
   }
 
   const filesQuery = useFilesInfiniteQuery(

--- a/src/pages/utilities/FileSearch.tsx
+++ b/src/pages/utilities/FileSearch.tsx
@@ -43,7 +43,6 @@ import { useSeriesQuery } from '@/core/react-query/series/queries';
 import { addFiles } from '@/core/slices/utilities/renamer';
 import { useDispatch } from '@/core/store';
 import toast from '@/core/toast';
-import { FileSortCriteriaEnum } from '@/core/types/api/file';
 import { copyToClipboard, isAnidbFileUri } from '@/core/util';
 import getEd2kLink from '@/core/utilities/getEd2kLink';
 import useFlattenListResult from '@/hooks/useFlattenListResult';
@@ -348,7 +347,7 @@ const FileSearch = () => {
     setSearch,
     setSortCriteria,
     sortCriteria,
-  } = useTableSearchSortCriteria(-FileSortCriteriaEnum.CreatedAt);
+  } = useTableSearchSortCriteria('-CreatedAt');
 
   const filesQuery = useFilesInfiniteQuery({
     include: ['XRefs', 'ImportLimbo'],

--- a/src/pages/utilities/LinkFilesWithProviders.tsx
+++ b/src/pages/utilities/LinkFilesWithProviders.tsx
@@ -20,7 +20,6 @@ import Menu from '@/components/Utilities/LinkFilesWithProvider/Menu';
 import TitleOptions from '@/components/Utilities/LinkFilesWithProvider/TitleOptions';
 import { useSettingsQuery } from '@/core/react-query/settings/queries';
 import toast from '@/core/toast';
-import { EpisodeTypeEnum } from '@/core/types/api/episode';
 import { handleShiftSelect } from '@/core/util';
 import { detectShow } from '@/core/utilities/auto-match-logic';
 import createLinksFromFiles, { AUTO_MATCH_EPISODE_ID, EDITABLE_STATES } from '@/core/utilities/releaseInfoHelpers';
@@ -217,7 +216,7 @@ const LinkFilesWithProviders = () => {
           if (episodeId === AUTO_MATCH_EPISODE_ID) {
             const details = detectShow(link.file?.Locations?.[0]?.RelativePath);
             if (details) {
-              const episodeNumber = details.episodeType === EpisodeTypeEnum.Special && details.episodeStart === 0
+              const episodeNumber = details.episodeType === 'Special' && details.episodeStart === 0
                 ? specials += 1
                 : details.episodeStart;
               episodeId = find(

--- a/src/pages/utilities/UnrecognizedUtilityTabs/IgnoredFilesTab.tsx
+++ b/src/pages/utilities/UnrecognizedUtilityTabs/IgnoredFilesTab.tsx
@@ -15,12 +15,12 @@ import { useFilesInfiniteQuery } from '@/core/react-query/file/queries';
 import { useManagedFoldersQuery } from '@/core/react-query/managed-folder/queries';
 import { invalidateQueries } from '@/core/react-query/queryClient';
 import toast from '@/core/toast';
-import { FileSortCriteriaEnum, type FileType } from '@/core/types/api/file';
 import useFlattenListResult from '@/hooks/useFlattenListResult';
 import useRowSelection from '@/hooks/useRowSelection';
 import useTableSearchSortCriteria from '@/hooks/utilities/useTableSearchSortCriteria';
 
 import type { UtilityHeaderType } from '@/components/Utilities/constants';
+import type { FileSortOrderValue, FileType } from '@/core/types/api/file';
 import type { Updater } from 'use-immer';
 
 const Menu = (
@@ -89,16 +89,16 @@ const IgnoredFilesTab = () => {
     setSearch,
     setSortCriteria,
     sortCriteria,
-  } = useTableSearchSortCriteria(FileSortCriteriaEnum.ManagedFolderName);
+  } = useTableSearchSortCriteria('ManagedFolderName');
 
   const managedFolderQuery = useManagedFoldersQuery();
   const managedFolders = managedFolderQuery?.data ?? [];
 
-  let sortOrder: FileSortCriteriaEnum[] | undefined;
+  let sortOrder: FileSortOrderValue[] | undefined;
   if (debouncedSearch && sortCriteria) {
     sortOrder = [sortCriteria];
   } else if (sortCriteria) {
-    sortOrder = [sortCriteria, FileSortCriteriaEnum.FileName, FileSortCriteriaEnum.RelativePath];
+    sortOrder = [sortCriteria, 'FileName', 'RelativePath'];
   }
 
   const filesQuery = useFilesInfiniteQuery(

--- a/src/pages/utilities/UnrecognizedUtilityTabs/LinkFilesTab.tsx
+++ b/src/pages/utilities/UnrecognizedUtilityTabs/LinkFilesTab.tsx
@@ -36,8 +36,6 @@ import {
 } from '@/core/react-query/series/mutations';
 import { useSeriesAniDBEpisodesQuery, useSeriesEpisodesInfiniteQuery } from '@/core/react-query/series/queries';
 import toast from '@/core/toast';
-import { EpisodeTypeEnum } from '@/core/types/api/episode';
-import { SeriesTypeEnum } from '@/core/types/api/series';
 import { getAnidbAnimeLink } from '@/core/util';
 import { detectShow, findMostCommonShowName } from '@/core/utilities/auto-match-logic';
 import useNavigateVoid from '@/hooks/useNavigateVoid';
@@ -117,7 +115,7 @@ const LinkFilesTab = () => {
     createdNewSeries: true,
   });
   const [selectedLink, setSelectedLink] = useState<number>(-1);
-  const [selectedSeries, setSelectedSeries] = useState({ Type: SeriesTypeEnum.Unknown } as SeriesAniDBSearchResult);
+  const [selectedSeries, setSelectedSeries] = useState({ Type: 'Unknown' } as SeriesAniDBSearchResult);
   const [seriesUpdating, setSeriesUpdating] = useState(false);
   const [showRangeFillModal, setShowRangeFillModal] = useState(false);
   const [links, setLinks] = useImmer<ManualLink[]>(
@@ -147,7 +145,7 @@ const LinkFilesTab = () => {
       includeMissing: 'true',
       includeUnaired: 'true',
     },
-    !!selectedSeries.ID && selectedSeries.Type !== SeriesTypeEnum.Unknown,
+    !!selectedSeries.ID && selectedSeries.Type !== 'Unknown',
   );
 
   const selectedSeriesLoaded = useMemo(() => !!selectedSeries?.ID && !anidbEpisodesQuery.isFetching, [
@@ -184,7 +182,7 @@ const LinkFilesTab = () => {
         value: item.ID,
         AirDate: item?.AirDate ?? '',
         label: item?.Title ?? '',
-        type: item?.Type ?? EpisodeTypeEnum.Unknown,
+        type: item?.Type ?? 'Unknown',
         number: item?.EpisodeNumber ?? 0,
       }
     ))
@@ -228,7 +226,7 @@ const LinkFilesTab = () => {
       });
     });
 
-    if (series.Type !== SeriesTypeEnum.Unknown) {
+    if (series.Type !== 'Unknown') {
       setSelectedSeries(series);
       return;
     }
@@ -260,7 +258,7 @@ const LinkFilesTab = () => {
   };
 
   const editSelectedSeries = () => {
-    setSelectedSeries({ Type: SeriesTypeEnum.Unknown } as SeriesAniDBSearchResult);
+    setSelectedSeries({ Type: 'Unknown' } as SeriesAniDBSearchResult);
   };
 
   const openRangeFill = () => {
@@ -272,7 +270,7 @@ const LinkFilesTab = () => {
   };
 
   const cancelChanges = () => {
-    setSelectedSeries({ Type: SeriesTypeEnum.Unknown } as SeriesAniDBSearchResult);
+    setSelectedSeries({ Type: 'Unknown' } as SeriesAniDBSearchResult);
     navigate('../');
   };
 
@@ -334,7 +332,7 @@ const LinkFilesTab = () => {
       // single episode link
       if ((episodeEnd - episodeStart) === 0) {
         // Special handling of specials if we were unable to determine the episode number during the detection phase.
-        const episodeNumber = episodeType === EpisodeTypeEnum.Special && episodeStart === 0
+        const episodeNumber = episodeType === 'Special' && episodeStart === 0
           ? specials += 1
           : episodeStart;
         const episode = find(
@@ -598,7 +596,7 @@ const LinkFilesTab = () => {
                   onClick={openRangeFill}
                   buttonType="secondary"
                   className="px-4 py-3"
-                  disabled={isLinking || selectedSeries.Type === SeriesTypeEnum.Unknown}
+                  disabled={isLinking || selectedSeries.Type === 'Unknown'}
                 >
                   Range Fill
                 </Button>
@@ -611,7 +609,7 @@ const LinkFilesTab = () => {
                   }}
                   buttonType="primary"
                   className="px-4 py-3"
-                  disabled={isLinking || selectedSeries.Type === SeriesTypeEnum.Unknown}
+                  disabled={isLinking || selectedSeries.Type === 'Unknown'}
                   loading={isLinking}
                 >
                   Save

--- a/src/pages/utilities/UnrecognizedUtilityTabs/UnrecognizedTab.tsx
+++ b/src/pages/utilities/UnrecognizedUtilityTabs/UnrecognizedTab.tsx
@@ -44,7 +44,6 @@ import { invalidateQueries } from '@/core/react-query/queryClient';
 import { addFiles } from '@/core/slices/utilities/renamer';
 import { useDispatch, useSelector } from '@/core/store';
 import toast from '@/core/toast';
-import { FileSortCriteriaEnum } from '@/core/types/api/file';
 import { processError } from '@/core/util';
 import getEd2kLink from '@/core/utilities/getEd2kLink';
 import useFlattenListResult from '@/hooks/useFlattenListResult';
@@ -53,7 +52,7 @@ import useRowSelection from '@/hooks/useRowSelection';
 import useTableSearchSortCriteria from '@/hooks/utilities/useTableSearchSortCriteria';
 
 import type { UtilityHeaderType } from '@/components/Utilities/constants';
-import type { FileType } from '@/core/types/api/file';
+import type { FileSortOrderValue, FileType } from '@/core/types/api/file';
 import type { AxiosError } from 'axios';
 import type { Updater } from 'use-immer';
 
@@ -242,7 +241,7 @@ const UnrecognizedTab = () => {
     setSearch,
     setSortCriteria,
     sortCriteria,
-  } = useTableSearchSortCriteria(FileSortCriteriaEnum.ManagedFolderName);
+  } = useTableSearchSortCriteria('ManagedFolderName');
   const [seriesSelectModal, setSeriesSelectModal] = useState(false);
 
   const { mutateAsync: avdumpFiles } = useAvdumpFilesMutation();
@@ -250,11 +249,11 @@ const UnrecognizedTab = () => {
   const managedFolderQuery = useManagedFoldersQuery();
   const managedFolders = managedFolderQuery?.data ?? [];
 
-  let sortOrder: FileSortCriteriaEnum[] | undefined;
+  let sortOrder: FileSortOrderValue[] | undefined;
   if (debouncedSearch && sortCriteria) {
     sortOrder = [sortCriteria];
   } else if (sortCriteria) {
-    sortOrder = [sortCriteria, FileSortCriteriaEnum.FileName, FileSortCriteriaEnum.RelativePath];
+    sortOrder = [sortCriteria, 'FileName', 'RelativePath'];
   }
 
   const filesQuery = useFilesInfiniteQuery(

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -77,7 +77,7 @@ export default defineConfig(async () => {
 async function setupEnv(isDebug) {
   const gitHash = childProcess.execSync("git log --pretty=format:'%h' -n 1").toString().replace(/["']/g, '');
   const appVersion = pkg.version;
-  const minimumServerVersion = '6.0.0-dev.409';
+  const minimumServerVersion = '6.0.0-dev.422';
 
   process.env.VITE_GITHASH = gitHash;
   process.env.VITE_APPVERSION = appVersion;


### PR DESCRIPTION
## Why string unions instead of enums

TypeScript `enum`s have well-known problems that make string unions the preferred choice in modern codebases:

1. **Enums are a non-standard runtime construct.** An `enum` compiles to real JavaScript — a runtime object (numeric enums even emit a reverse mapping, `Enum[0] → 'Name'`). A string union is a *pure type*: erased at compile time, zero runtime code, so it can't drift out of sync with what the server actually sends.

2. **`const enum` doesn't survive isolated transpilation.** `const enum` relies on the TypeScript compiler inlining every reference, which only works when `tsc` sees the whole program at once. Under `isolatedModules` — and under per-file transpilers like esbuild, Vite/Rolldown, Babel, and SWC — cross-module `const enum` references can't be inlined and break. This project transpiles with Rolldown + Babel, so the existing `const enum`s were depending on a fragile assumption.

3. **Numeric enums are unsound and opaque.** Their numeric values are an implementation detail, and they type-check loosely (`number` slips through in places — this project has `strict: false`). We saw it directly: `FileSortCriteriaEnum.FileSize` sent `5`, which only worked because the server's `Enum.TryParse` accepts numeric strings. That coupling is an accident, not a contract.

4. **A union matches the data; an enum matches an abstraction.** The wire format is a string like `"FileSize"` or `"KeepTogether"`. A `'FileSize' | 'FileName' | ...` union *is* that string; an enum is an indirection you have to translate. Since the server serializes enums as strings (`StringEnumConverter`), the union is the honest representation of the API.

## The `Values` suffix

All converted unions use a `Values` suffix, and where the WebUI name diverged from the server enum, it's renamed to match the server enum name so the 1:1 mapping is obvious:

- `SeriesTypeValues` → `AnimeTypeValues` (server `AnimeType`)
- `SeriesRelationTypeValues` → `RelationTypeValues` (server `RelationType`)
- `SignalValues` → `ReleaseSignalTypeValues` (server `ReleaseSignalType`)
- `FileIncludeValues` stays, since `FileNonDefaultIncludeTypeValues` was awkward

UI-only unions (e.g. `ButtonType`, `LinkStateType`, `SortingType`) are left as `Type` — they aren't server enums.

## Server/WebUI sync fixes (not the conversion itself)

- **`EpisodeTypeScope`** — WebUI had `'AllTogether' | 'PerEpisodeType'`, but the server enum is `KeepTogether | BestPerType`. Fixed the values and inlined the type (it had a single usage).
- **`DataSource`** — the server has two enums: `DataSource` (19 members) and `DataSourceType` (2 members, used for `includeDataFrom`). The WebUI now mirrors both as `DataSourceValues` and `DataSourceTypeValues`. The old `ImageSourceValues` (4) and `LanguageSourceValues` (2) were artificial narrowings that under-represented what the server returns/accepts; both dropped in favor of `DataSourceValues`.
- **`FileSourceValues`** — was `ReleaseSourceValues` minus `Film`; the server uses a single `ReleaseSource` enum (which includes `Film`). Collapsed into `ReleaseSourceValues`.
- **`FileSortCriteriaEnum`** — the server takes sort criteria as `List<string>` (enum names with an optional `-` prefix). Converted the numeric enum to a string union, added the 5 missing members (`ReleaseProviderName` … `ReleaseGroupID`), and reworked the sort-direction handling from numeric negation to a `-` string prefix.
- **`AniDBBanTypeEnum`** — the server now string-serializes this (`UpdateType` enum). Converted to `BanUpdateTypeValues` and added the new `LoginFailed` member.

## Verification

- `pnpm lint` (dprint → oxlint → stylelint) passes
- `tsc --noEmit` passes
