### PR TITLE
Add release group field to Edit Release Info modal

### DIFF
--- a/docs/LinkFilesWithProviders.md
+++ b/docs/LinkFilesWithProviders.md
@@ -25,7 +25,7 @@ src/hooks/utilities/
   useReleaseInfoForm.ts          Form state + touched-field tracking for the Edit Release Info modal
 
 src/core/utilities/
-  releaseInfoHelpers.ts          Pure helpers: createLinksFromFiles, mergeReleaseInfo; shared constants EDITABLE_STATES, AUTO_MATCH_EPISODE_ID
+  releaseInfoHelpers.ts          Pure helpers: createLinksFromFiles, mergeReleaseInfo, isUserEdited; shared constants EDITABLE_STATES, AUTO_MATCH_EPISODE_ID
   auto-match-logic.ts            detectShow, findMostCommonShowName
 
 src/core/types/utilities/
@@ -40,6 +40,7 @@ src/components/Utilities/Unrecognized/
     Menu.tsx                     Action bar (Search, Edit, Submit, etc.)
     TitleOptions.tsx             Header counts (submitted/pending/total/selected)
     AutoSearchReleaseModal.tsx   Provider picker modal
+    SelectReleaseGroup.tsx       Searchable release-group combobox
     EditReleaseInfoModal.tsx     Edit release metadata for selected links
 ```
 
@@ -70,7 +71,7 @@ type CrossReferenceType = {
   episodes: AniDBEpisodeType[];
 };
 
-type TouchableField = 'Comment' | 'CrossReferences' | 'IsChaptered' | 'IsCreditless' | 'Source' | 'Version';
+type TouchableField = 'Comment' | 'CrossReferences' | 'Group' | 'IsChaptered' | 'IsCreditless' | 'Source' | 'Version';
 ```
 
 ## State Groups
@@ -167,7 +168,11 @@ Converts `FileType[]` into `Record<number, ManualLinkType>`:
 
 ### `mergeReleaseInfo(incoming, original)`
 
-Merges AutoPreview result into the user's seed release. Preserves user-set fields via nullish coalescing (`FileSize`, `OriginalFilename`, `IsChaptered`, `IsCensored`, `IsCreditless`, `Group`), restores `Source` from the original only when the incoming `Source` is `Unknown`, enforces `Version >= 1`, and appends `+User` to `ProviderName` unless it is already `'User'` or already contains `+User`.
+Merges AutoPreview result into the user's seed release. Preserves user-set fields via nullish coalescing (`FileSize`, `OriginalFilename`, `IsChaptered`, `IsCensored`, `IsCreditless`, `Group`), restores `Source` from the original only when the incoming `Source` is `Unknown`, enforces `Version >= 1`, and appends `+User` to `ProviderName` unless `isUserEdited` reports it as already user-edited.
+
+### `isUserEdited(providerName)`
+
+Returns whether `User` is one of the providers in the `+`-joined `ProviderName` chain (e.g. `AniDB+User`, `User+AniDB`, `AniDB+User+TestProvider`). Shared by `mergeReleaseInfo`, `handleSaveReleaseInfo`, and `ProviderName` to detect user edits consistently.
 
 ## API Endpoints
 
@@ -185,13 +190,13 @@ Opened from the Menu's "Edit Release Info" action (`E`) for the selected links. 
 1. **Series search** — a shared `AnimeSelectPanel` (debounced AniDB search) when no series is selected.
 2. **Review form** — once a series is chosen (or when bulk-selecting mixed series), shows series + episode selection and the release fields.
 
-Editable fields: `Version`, `Source`, `IsChaptered`, `IsCreditless`, and `Comment`. Episode selection includes an "Auto-match (from filename)" option (`AUTO_MATCH_EPISODE_ID = -1`). When selected files have differing episode links, the selector shows a disabled "Multiple episodes selected" entry and those per-file links are preserved unless an episode (or auto-match) is explicitly chosen. Save stays disabled until a field is touched.
+Editable fields: `Version`, `Source`, `IsChaptered`, `IsCreditless`, `Comment`, and `Release Group`. The release group is a searchable `SelectReleaseGroup` combobox that filters known groups by name/shortname and only shows options while typing; typing an unknown name offers a `Create "…"` option that sets the group's `Name`, `ShortName`, and `ID` to the typed value with `Source: User`. Episode selection includes an "Auto-match (from filename)" option (`AUTO_MATCH_EPISODE_ID = -1`). When selected files have differing episode links, the selector shows a disabled "Multiple episodes selected" entry and those per-file links are preserved unless an episode (or auto-match) is explicitly chosen; the release group field shows "Multiple groups selected" for mixed groups. Save stays disabled until a field is touched.
 
-State is managed by the `useReleaseInfoForm` hook (form state, touched-field tracking, mixed-selection flags). On save, `handleSaveReleaseInfo` in the page merges the patch into each selected link's `release`, resolves the episode cross-reference (auto-match resolves via `detectShow` → matching episode, writing `CrossReferences` at 0–100%), appends the `+User` marker to `ProviderName`, and sets the link state to `ready`. Links whose auto-match fails keep their previous state (no `ready` transition) and are reported in an error toast with the file count.
+State is managed by the `useReleaseInfoForm` hook (form state, touched-field tracking, mixed-selection flags). Clearing the release group or comment and leaving the field removes the stored value on save — `setIfTouched` uses a `writeUndefined` option so an empty value is omitted from the payload and cleared server-side. On save, `handleSaveReleaseInfo` in the page merges the patch into each selected link's `release`, resolves the episode cross-reference (auto-match resolves via `detectShow` → matching episode, writing `CrossReferences` at 0–100%), appends the `+User` marker to `ProviderName` (unless `isUserEdited`), and sets the link state to `ready`. Links whose auto-match fails keep their previous state (no `ready` transition) and are reported in an error toast with the file count.
 
 ## Supporting Components
 
 - **`LinkCard`** — Per-link card. Border color reflects state (`submitted` → important, `searching`/`submitting` → primary, `ready` → warning). Click-to-select disabled for busy states (`searching`/`submitting`/`fetching`).
-- **`ProviderName`** — Status text per state (`"Retrieving existing release info..."` for `fetching`, etc.). Appends "(Edited by User)" when `ProviderName` starts with `User+` or ends with `+User`.
+- **`ProviderName`** — Status text per state (`"Retrieving existing release info..."` for `fetching`, etc.). Appends "(Edited by User)" when `User` is part of the `+`-joined `ProviderName` chain (via `isUserEdited`).
 - **`Menu`** — Action bar. "Search for Release Info" and "Edit Release Info" enable when all selected links are in `EDITABLE_STATES` (`ready`/`init`); "Remove Selected" and "Submit Selected" render conditionally. The "Edit Release Info" button (`E`) opens the Edit Release Info modal. Hotkeys are registered on the page: `S` search, `A` select-all, `D` remove, `E` edit, `Q` submit, `Esc` cancel, `Enter` submit.
 - **`TitleOptions`** — Header showing `{submitted} / {submitted + pending} Submitted | {total} Files | {selected} Selected`. Only `ready` and `submitting` count as pending; `init`, `searching`, and `fetching` do not.

--- a/src/components/Input/SelectEpisodeList.tsx
+++ b/src/components/Input/SelectEpisodeList.tsx
@@ -34,7 +34,7 @@ const SelectOption = ({ option }: { option: Option }) => (
   <ListboxOption
     value={option}
     disabled={option.disabled}
-    className="group relative cursor-pointer px-2 py-0.5 text-panel-text transition-colors select-none data-disabled:cursor-not-allowed data-disabled:opacity-60 data-focus:text-panel-text-primary"
+    className="group relative cursor-pointer px-2 py-0.5 text-panel-text transition-colors select-none data-disabled:cursor-auto data-disabled:opacity-60 data-focus:text-panel-text-primary"
   >
     <div className="flex items-center justify-between">
       <div className="flex grow truncate">

--- a/src/components/Input/SelectReleaseGroup.tsx
+++ b/src/components/Input/SelectReleaseGroup.tsx
@@ -1,0 +1,104 @@
+import { useState } from 'react';
+import type { ChangeEvent } from 'react';
+import { Combobox, ComboboxInput, ComboboxOption, ComboboxOptions } from '@headlessui/react';
+import cx from 'classnames';
+
+import type { ReleaseGroupType } from '@/core/types/api/file';
+
+const MULTIPLE_GROUPS: ReleaseGroupType = { ID: '', Name: 'Multiple groups selected', ShortName: '', Source: '' };
+
+type Props = {
+  options: ReleaseGroupType[];
+  value?: ReleaseGroupType;
+  onChange: (group: ReleaseGroupType | undefined) => void;
+  disabled?: boolean;
+  hasDifferent?: boolean;
+};
+
+const SelectReleaseGroup = ({
+  disabled = false,
+  hasDifferent = false,
+  onChange,
+  options,
+  value,
+}: Props) => {
+  const [query, setQuery] = useState('');
+  const [focused, setFocused] = useState(false);
+
+  const normalizedQuery = query.trim().toLowerCase();
+  const listOptions = hasDifferent ? [MULTIPLE_GROUPS, ...options] : options;
+  const filteredOptions = normalizedQuery === ''
+    ? listOptions
+    : listOptions.filter(option =>
+      option.Name.toLowerCase().includes(normalizedQuery)
+      || option.ShortName.toLowerCase().includes(normalizedQuery)
+    );
+
+  const hasExactMatch = normalizedQuery !== '' && options.some(option => option.Name.toLowerCase() === normalizedQuery);
+
+  const handleChange = (group: ReleaseGroupType | null) => {
+    setQuery('');
+    if (group) onChange(group);
+  };
+
+  return (
+    <Combobox
+      as="div"
+      value={value ?? null}
+      onChange={handleChange}
+      by={(left, right) => left?.ID === right?.ID && left?.Source === right?.Source}
+      disabled={disabled}
+      immediate
+    >
+      <ComboboxInput
+        displayValue={(group: ReleaseGroupType | null) => {
+          if (group) return group.Name;
+          return hasDifferent && !focused ? MULTIPLE_GROUPS.Name : '';
+        }}
+        onChange={(event: ChangeEvent<HTMLInputElement>) => setQuery(event.target.value)}
+        onFocus={() => setFocused(true)}
+        onBlur={() => setFocused(false)}
+        placeholder="Select release group"
+        className={cx(
+          'w-full rounded-lg border border-panel-border bg-panel-input px-4 py-2 text-left text-panel-text transition-colors focus:border-panel-text-primary focus:outline-hidden data-open:border-panel-text-primary',
+          disabled && 'opacity-65',
+        )}
+      />
+      <ComboboxOptions
+        anchor={{ to: 'bottom', padding: '1rem', gap: '0.25rem' }}
+        transition
+        className="z-110 w-(--input-width) origin-top rounded-lg bg-panel-background transition [--anchor-max-height:16rem] focus:outline-hidden data-closed:opacity-0"
+      >
+        <div className="max-h-(--anchor-max-height) overflow-y-auto rounded-lg border border-panel-border bg-panel-input p-4">
+          {normalizedQuery !== '' && !hasExactMatch && (
+            <ComboboxOption
+              value={{ ID: query.trim(), Name: query.trim(), ShortName: query.trim(), Source: 'User' }}
+              className="cursor-pointer px-2 py-0.5 text-panel-text transition-colors select-none data-focus:text-panel-text-primary"
+            >
+              <div className="grow truncate">
+                Create &quot;{query.trim()}&quot;
+              </div>
+            </ComboboxOption>
+          )}
+          {filteredOptions.map(option => (
+            <ComboboxOption
+              key={`${option.Source}-${option.ID}`}
+              value={option}
+              disabled={option === MULTIPLE_GROUPS}
+              className="cursor-pointer px-2 py-0.5 text-panel-text transition-colors select-none data-disabled:cursor-auto data-disabled:opacity-60 data-focus:text-panel-text-primary data-selected:text-panel-text-primary"
+            >
+              <div className="flex items-center justify-between">
+                <div className="grow truncate">{option.Name}</div>
+                {option.ShortName && option.ShortName !== option.Name && (
+                  <div className="ml-2 text-panel-text-important">{option.ShortName}</div>
+                )}
+              </div>
+            </ComboboxOption>
+          ))}
+        </div>
+      </ComboboxOptions>
+    </Combobox>
+  );
+};
+
+export default SelectReleaseGroup;

--- a/src/components/Input/SelectReleaseGroup.tsx
+++ b/src/components/Input/SelectReleaseGroup.tsx
@@ -1,11 +1,9 @@
 import { useState } from 'react';
-import type { ChangeEvent } from 'react';
+import type { ChangeEvent, FocusEvent } from 'react';
 import { Combobox, ComboboxInput, ComboboxOption, ComboboxOptions } from '@headlessui/react';
 import cx from 'classnames';
 
 import type { ReleaseGroupType } from '@/core/types/api/file';
-
-const MULTIPLE_GROUPS: ReleaseGroupType = { ID: '', Name: 'Multiple groups selected', ShortName: '', Source: '' };
 
 type Props = {
   options: ReleaseGroupType[];
@@ -23,13 +21,11 @@ const SelectReleaseGroup = ({
   value,
 }: Props) => {
   const [query, setQuery] = useState('');
-  const [focused, setFocused] = useState(false);
 
   const normalizedQuery = query.trim().toLowerCase();
-  const listOptions = hasDifferent ? [MULTIPLE_GROUPS, ...options] : options;
   const filteredOptions = normalizedQuery === ''
-    ? listOptions
-    : listOptions.filter(option =>
+    ? []
+    : options.filter(option =>
       option.Name.toLowerCase().includes(normalizedQuery)
       || option.ShortName.toLowerCase().includes(normalizedQuery)
     );
@@ -53,50 +49,56 @@ const SelectReleaseGroup = ({
       <ComboboxInput
         displayValue={(group: ReleaseGroupType | null) => {
           if (group) return group.Name;
-          return hasDifferent && !focused ? MULTIPLE_GROUPS.Name : '';
+          return hasDifferent ? 'Multiple groups selected' : '';
         }}
         onChange={(event: ChangeEvent<HTMLInputElement>) => setQuery(event.target.value)}
-        onFocus={() => setFocused(true)}
-        onBlur={() => setFocused(false)}
+        onFocus={(event: FocusEvent<HTMLInputElement>) => event.target.select()}
+        onBlur={(event: FocusEvent<HTMLInputElement>) => {
+          if (event.target.value.trim() === '' && (value || hasDifferent)) {
+            onChange(undefined);
+          }
+          setQuery('');
+        }}
         placeholder="Select release group"
         className={cx(
           'w-full rounded-lg border border-panel-border bg-panel-input px-4 py-2 text-left text-panel-text transition-colors focus:border-panel-text-primary focus:outline-hidden data-open:border-panel-text-primary',
           disabled && 'opacity-65',
         )}
       />
-      <ComboboxOptions
-        anchor={{ to: 'bottom', padding: '1rem', gap: '0.25rem' }}
-        transition
-        className="z-110 w-(--input-width) origin-top rounded-lg bg-panel-background transition [--anchor-max-height:16rem] focus:outline-hidden data-closed:opacity-0"
-      >
-        <div className="max-h-(--anchor-max-height) overflow-y-auto rounded-lg border border-panel-border bg-panel-input p-4">
-          {normalizedQuery !== '' && !hasExactMatch && (
-            <ComboboxOption
-              value={{ ID: query.trim(), Name: query.trim(), ShortName: query.trim(), Source: 'User' }}
-              className="cursor-pointer px-2 py-0.5 text-panel-text transition-colors select-none data-focus:text-panel-text-primary"
-            >
-              <div className="grow truncate">
-                Create &quot;{query.trim()}&quot;
-              </div>
-            </ComboboxOption>
-          )}
-          {filteredOptions.map(option => (
-            <ComboboxOption
-              key={`${option.Source}-${option.ID}`}
-              value={option}
-              disabled={option === MULTIPLE_GROUPS}
-              className="cursor-pointer px-2 py-0.5 text-panel-text transition-colors select-none data-disabled:cursor-auto data-disabled:opacity-60 data-focus:text-panel-text-primary data-selected:text-panel-text-primary"
-            >
-              <div className="flex items-center justify-between">
-                <div className="grow truncate">{option.Name}</div>
-                {option.ShortName && option.ShortName !== option.Name && (
-                  <div className="ml-2 text-panel-text-important">{option.ShortName}</div>
-                )}
-              </div>
-            </ComboboxOption>
-          ))}
-        </div>
-      </ComboboxOptions>
+      {normalizedQuery !== '' && (
+        <ComboboxOptions
+          anchor={{ to: 'bottom', padding: '1rem', gap: '0.25rem' }}
+          transition
+          className="z-110 w-(--input-width) origin-top rounded-lg bg-panel-background transition [--anchor-max-height:16rem] focus:outline-hidden data-closed:opacity-0"
+        >
+          <div className="max-h-(--anchor-max-height) overflow-y-auto rounded-lg border border-panel-border bg-panel-input p-4">
+            {!hasExactMatch && (
+              <ComboboxOption
+                value={{ ID: query.trim(), Name: query.trim(), ShortName: query.trim(), Source: 'User' }}
+                className="cursor-pointer px-2 py-0.5 text-panel-text transition-colors select-none data-focus:text-panel-text-primary"
+              >
+                <div className="grow truncate">
+                  Create &quot;{query.trim()}&quot;
+                </div>
+              </ComboboxOption>
+            )}
+            {filteredOptions.map(option => (
+              <ComboboxOption
+                key={`${option.Source}-${option.ID}`}
+                value={option}
+                className="cursor-pointer px-2 py-0.5 text-panel-text transition-colors select-none data-focus:text-panel-text-primary data-selected:text-panel-text-primary"
+              >
+                <div className="flex items-center justify-between">
+                  <div className="grow truncate">{option.Name}</div>
+                  {option.ShortName && option.ShortName !== option.Name && (
+                    <div className="ml-2 text-panel-text-important">{option.ShortName}</div>
+                  )}
+                </div>
+              </ComboboxOption>
+            ))}
+          </div>
+        </ComboboxOptions>
+      )}
     </Combobox>
   );
 };

--- a/src/components/Utilities/LinkFilesWithProvider/EditReleaseInfoModal.tsx
+++ b/src/components/Utilities/LinkFilesWithProvider/EditReleaseInfoModal.tsx
@@ -11,9 +11,11 @@ import Checkbox from '@/components/Input/Checkbox';
 import Input from '@/components/Input/Input';
 import InputSmall from '@/components/Input/InputSmall';
 import SelectEpisodeList from '@/components/Input/SelectEpisodeList';
+import SelectReleaseGroup from '@/components/Input/SelectReleaseGroup';
 import SelectSmall from '@/components/Input/SelectSmall';
 import ModalPanel from '@/components/Panels/ModalPanel';
 import AnimeSelectPanel from '@/components/Utilities/Unrecognized/AnimeSelectPanel';
+import { useReleaseInfoReleaseGroupsQuery } from '@/core/react-query/release-info/queries';
 import { useGetSeriesAniDBMutation, useRefreshAniDBSeriesMutation } from '@/core/react-query/series/mutations';
 import { useSeriesAniDBEpisodesQuery, useSeriesAniDBQuery } from '@/core/react-query/series/queries';
 import toast from '@/core/toast';
@@ -21,7 +23,7 @@ import { AUTO_MATCH_EPISODE_ID } from '@/core/utilities/releaseInfoHelpers';
 import useToggleModalKeybinds from '@/hooks/useToggleModalKeybinds';
 import useReleaseInfoForm from '@/hooks/utilities/useReleaseInfoForm';
 
-import type { ReleaseInfoType, ReleaseSourceValues } from '@/core/types/api/file';
+import type { ReleaseGroupType, ReleaseInfoType, ReleaseSourceValues } from '@/core/types/api/file';
 import type { SeriesAniDBSearchResult } from '@/core/types/api/series';
 import type {
   CrossReferenceType,
@@ -99,6 +101,8 @@ const EditReleaseInfoModal = (props: Props) => {
     !!formState.selectedSeriesId && show,
   );
 
+  const releaseGroupOptions = useReleaseInfoReleaseGroupsQuery(show).data ?? [];
+
   const episodeOptions = [
     ...(hasDifferent.episodes
       ? [
@@ -167,6 +171,16 @@ const EditReleaseInfoModal = (props: Props) => {
     });
     setFormState((draft) => {
       draft.selectedEpisodeId = optionValue;
+    });
+  };
+
+  const handleReleaseGroupChange = (group?: ReleaseGroupType) => {
+    markTouched('Group');
+    setHasDifferent((draft) => {
+      draft.group = false;
+    });
+    setFormState((draft) => {
+      draft.group = group;
     });
   };
 
@@ -254,6 +268,7 @@ const EditReleaseInfoModal = (props: Props) => {
     setIfTouched('IsCreditless', formState.isCreditless);
     setIfTouched('Source', formState.source === '' ? undefined : formState.source);
     setIfTouched('Comment', formState.comment);
+    setIfTouched('Group', formState.group);
 
     if (touchedFields.has('CrossReferences') && formState.selectedSeriesId) {
       crossReference = {
@@ -295,7 +310,7 @@ const EditReleaseInfoModal = (props: Props) => {
         </div>
       }
       noPadding
-      className="h-156"
+      className="h-172"
     >
       <div className="flex grow flex-col gap-y-4 p-6">
         {!formState.selectedSeriesId && !hasDifferent.series && (
@@ -310,7 +325,7 @@ const EditReleaseInfoModal = (props: Props) => {
         {hasSeriesSelection && (
           <>
             <div className="flex flex-col gap-y-2">
-              <span className="text-base font-semibold">Series</span>
+              <span className="font-semibold">Series</span>
               <div className="flex items-center justify-between rounded-lg border border-panel-border bg-panel-input px-4 py-3">
                 <span className="truncate">{seriesName}</span>
                 <Button onClick={handleEditSeries}>
@@ -326,7 +341,7 @@ const EditReleaseInfoModal = (props: Props) => {
                 : ''}
             >
               <div className="flex items-center gap-x-2">
-                <span className="text-base font-semibold">Episode</span>
+                <span className="font-semibold">Episode</span>
                 <Button
                   onClick={handleRefreshSeries}
                   tooltip={isRefreshingSeries || hasDifferent.series ? '' : 'Force Refresh'}
@@ -342,6 +357,15 @@ const EditReleaseInfoModal = (props: Props) => {
                 rowIdx={0}
                 standalone
                 disabled={hasDifferent.series}
+              />
+            </div>
+            <div className="flex flex-col gap-y-2">
+              <span className="font-semibold">Release Group</span>
+              <SelectReleaseGroup
+                options={releaseGroupOptions}
+                value={formState.group}
+                onChange={handleReleaseGroupChange}
+                hasDifferent={hasDifferent.group}
               />
             </div>
             <div className="grid grid-cols-2 gap-x-8 gap-y-4">

--- a/src/components/Utilities/LinkFilesWithProvider/EditReleaseInfoModal.tsx
+++ b/src/components/Utilities/LinkFilesWithProvider/EditReleaseInfoModal.tsx
@@ -11,7 +11,6 @@ import Checkbox from '@/components/Input/Checkbox';
 import Input from '@/components/Input/Input';
 import InputSmall from '@/components/Input/InputSmall';
 import SelectEpisodeList from '@/components/Input/SelectEpisodeList';
-import SelectReleaseGroup from '@/components/Input/SelectReleaseGroup';
 import SelectSmall from '@/components/Input/SelectSmall';
 import ModalPanel from '@/components/Panels/ModalPanel';
 import AnimeSelectPanel from '@/components/Utilities/Unrecognized/AnimeSelectPanel';
@@ -22,6 +21,8 @@ import toast from '@/core/toast';
 import { AUTO_MATCH_EPISODE_ID } from '@/core/utilities/releaseInfoHelpers';
 import useToggleModalKeybinds from '@/hooks/useToggleModalKeybinds';
 import useReleaseInfoForm from '@/hooks/utilities/useReleaseInfoForm';
+
+import SelectReleaseGroup from './SelectReleaseGroup';
 
 import type { ReleaseGroupType, ReleaseInfoType, ReleaseSourceValues } from '@/core/types/api/file';
 import type { SeriesAniDBSearchResult } from '@/core/types/api/series';

--- a/src/components/Utilities/LinkFilesWithProvider/EditReleaseInfoModal.tsx
+++ b/src/components/Utilities/LinkFilesWithProvider/EditReleaseInfoModal.tsx
@@ -268,7 +268,11 @@ const EditReleaseInfoModal = (props: Props) => {
     setIfTouched('IsCreditless', formState.isCreditless);
     setIfTouched('Source', formState.source === '' ? undefined : formState.source);
     setIfTouched('Comment', formState.comment);
-    setIfTouched('Group', formState.group);
+    // Unlike the other fields, an undefined Group must be written through so it
+    // is omitted from the payload and the server clears the stored group.
+    if (touchedFields.has('Group')) {
+      releaseInfo.Group = formState.group;
+    }
 
     if (touchedFields.has('CrossReferences') && formState.selectedSeriesId) {
       crossReference = {

--- a/src/components/Utilities/LinkFilesWithProvider/EditReleaseInfoModal.tsx
+++ b/src/components/Utilities/LinkFilesWithProvider/EditReleaseInfoModal.tsx
@@ -257,9 +257,10 @@ const EditReleaseInfoModal = (props: Props) => {
     const setIfTouched = <FieldName extends TouchableField>(
       field: FieldName,
       value?: ReleaseInfoType[FieldName],
+      writeUndefined = false,
     ) => {
       if (!touchedFields.has(field)) return;
-      if (value === undefined) return;
+      if (value === undefined && !writeUndefined) return;
       releaseInfo[field] = value;
     };
 
@@ -267,12 +268,10 @@ const EditReleaseInfoModal = (props: Props) => {
     setIfTouched('IsChaptered', formState.isChaptered);
     setIfTouched('IsCreditless', formState.isCreditless);
     setIfTouched('Source', formState.source === '' ? undefined : formState.source);
-    setIfTouched('Comment', formState.comment);
-    // Unlike the other fields, an undefined Group must be written through so it
-    // is omitted from the payload and the server clears the stored group.
-    if (touchedFields.has('Group')) {
-      releaseInfo.Group = formState.group;
-    }
+    // Comment and Group can be cleared: write undefined through so it is
+    // omitted from the payload and the server clears the stored value.
+    setIfTouched('Comment', formState.comment === '' ? undefined : formState.comment, true);
+    setIfTouched('Group', formState.group, true);
 
     if (touchedFields.has('CrossReferences') && formState.selectedSeriesId) {
       crossReference = {

--- a/src/components/Utilities/LinkFilesWithProvider/ProviderName.tsx
+++ b/src/components/Utilities/LinkFilesWithProvider/ProviderName.tsx
@@ -1,3 +1,5 @@
+import { isUserEdited } from '@/core/utilities/releaseInfoHelpers';
+
 import type { ManualLinkType } from '@/core/types/utilities/link-files-with-providers';
 
 type Props = {
@@ -33,7 +35,7 @@ const linkStateAttributes = {
 
 const ProviderName = ({ link }: Props) => {
   const name = link.release.ProviderName;
-  const editedByUser = name.startsWith('User+') || name.endsWith('+User');
+  const editedByUser = isUserEdited(name);
   const providerName = name !== 'User' && link.state !== 'searching'
     ? name
       .replace(/^User\+/, '')

--- a/src/components/Utilities/LinkFilesWithProvider/SelectReleaseGroup.tsx
+++ b/src/components/Utilities/LinkFilesWithProvider/SelectReleaseGroup.tsx
@@ -8,7 +8,7 @@ import type { ReleaseGroupType } from '@/core/types/api/file';
 type Props = {
   options: ReleaseGroupType[];
   value?: ReleaseGroupType;
-  onChange: (group: ReleaseGroupType | undefined) => void;
+  onChange: (group?: ReleaseGroupType) => void;
   disabled?: boolean;
   hasDifferent?: boolean;
 };

--- a/src/core/react-query/release-info/queries.ts
+++ b/src/core/react-query/release-info/queries.ts
@@ -1,13 +1,24 @@
 import { useQuery } from '@tanstack/react-query';
 
 import { axios } from '@/core/axios';
+import { transformListResultSimplified } from '@/core/react-query/helpers';
 
 import type { ReleaseProviderInfoType } from '@/core/react-query/release-info/types';
+import type { ListResultType } from '@/core/types/api';
+import type { ReleaseGroupType } from '@/core/types/api/file';
 
 export const useReleaseInfoProvidersQuery = (noStale = false, enabled = true) =>
   useQuery<ReleaseProviderInfoType[]>({
     queryKey: ['release-info', 'providers', noStale],
     queryFn: () => axios.get('ReleaseInfo/Provider'),
     staleTime: noStale ? Infinity : 1000,
+    enabled,
+  });
+
+export const useReleaseInfoReleaseGroupsQuery = (enabled = true) =>
+  useQuery<ListResultType<ReleaseGroupType>, unknown, ReleaseGroupType[]>({
+    queryKey: ['release-info', 'release-groups'],
+    queryFn: () => axios.get('ReleaseInfo/ReleaseGroup', { params: { pageSize: 0, includeMissing: true } }),
+    select: transformListResultSimplified,
     enabled,
   });

--- a/src/core/types/utilities/link-files-with-providers.ts
+++ b/src/core/types/utilities/link-files-with-providers.ts
@@ -23,4 +23,11 @@ export type CrossReferenceType = {
   episodes: AniDBEpisodeType[];
 };
 
-export type TouchableField = 'Comment' | 'CrossReferences' | 'IsChaptered' | 'IsCreditless' | 'Source' | 'Version';
+export type TouchableField =
+  | 'Comment'
+  | 'CrossReferences'
+  | 'Group'
+  | 'IsChaptered'
+  | 'IsCreditless'
+  | 'Source'
+  | 'Version';

--- a/src/core/utilities/releaseInfoHelpers.ts
+++ b/src/core/utilities/releaseInfoHelpers.ts
@@ -12,6 +12,8 @@ import type {
 export const EDITABLE_STATES = new Set<LinkStateType>(['ready', 'init']);
 export const AUTO_MATCH_EPISODE_ID = -1;
 
+export const isUserEdited = (providerName: string) => providerName.split('+').includes('User');
+
 let lastLinkId = 0;
 const generateLinkId = () => {
   if (lastLinkId === Number.MAX_SAFE_INTEGER) {
@@ -36,7 +38,7 @@ export const mergeReleaseInfo = (incoming: ReleaseInfoType, original: ReleaseInf
     draft.IsCreditless ??= original.IsCreditless;
     draft.Group ??= original.Group;
 
-    if (draft.ProviderName !== 'User' && !/\+User\b/.test(draft.ProviderName)) {
+    if (!isUserEdited(draft.ProviderName)) {
       draft.ProviderName += '+User';
     }
   });

--- a/src/hooks/utilities/useReleaseInfoForm.ts
+++ b/src/hooks/utilities/useReleaseInfoForm.ts
@@ -4,7 +4,7 @@ import { useImmer } from 'use-immer';
 import { detectShow, findMostCommonShowName } from '@/core/utilities/auto-match-logic';
 import { AUTO_MATCH_EPISODE_ID } from '@/core/utilities/releaseInfoHelpers';
 
-import type { ReleaseInfoType } from '@/core/types/api/file';
+import type { ReleaseGroupType, ReleaseInfoType } from '@/core/types/api/file';
 import type { ManualLinkType, TouchableField } from '@/core/types/utilities/link-files-with-providers';
 
 type FormState = {
@@ -15,6 +15,7 @@ type FormState = {
   isCreditless?: ReleaseInfoType['IsCreditless'];
   source: ReleaseInfoType['Source'] | '';
   comment: ReleaseInfoType['Comment'];
+  group?: ReleaseGroupType;
 };
 
 const useReleaseInfoForm = (selectedLinks: ManualLinkType[], show: boolean) => {
@@ -30,6 +31,7 @@ const useReleaseInfoForm = (selectedLinks: ManualLinkType[], show: boolean) => {
     chaptered: false,
     creditless: false,
     episodes: false,
+    group: false,
     series: false,
   });
   const [initialSeriesName, setInitialSeriesName] = useState('');
@@ -60,11 +62,13 @@ const useReleaseInfoForm = (selectedLinks: ManualLinkType[], show: boolean) => {
     const hasDifferentSource = isBulk && !allSame(link => link.Source);
     const hasDifferentVersion = isBulk && !allSame(link => link.Version);
     const hasDifferentComment = isBulk && !allSame(link => link.Comment);
+    const hasDifferentGroup = isBulk && !allSame(link => [link.Group?.Source, link.Group?.ID].join(':'));
 
     setHasDifferent({
       chaptered: isBulk && !allSame(link => link.IsChaptered),
       creditless: isBulk && !allSame(link => link.IsCreditless),
       episodes: hasDifferentEpisodes,
+      group: hasDifferentGroup,
       series: hasMultipleSeries,
     });
 
@@ -76,6 +80,7 @@ const useReleaseInfoForm = (selectedLinks: ManualLinkType[], show: boolean) => {
       isCreditless: first.IsCreditless,
       source: hasDifferentSource ? '' : first.Source,
       comment: hasDifferentComment ? '' : (first.Comment ?? ''),
+      group: hasDifferentGroup ? undefined : first.Group,
     });
   });
 

--- a/src/pages/utilities/LinkFilesWithProviders.tsx
+++ b/src/pages/utilities/LinkFilesWithProviders.tsx
@@ -22,7 +22,11 @@ import { useSettingsQuery } from '@/core/react-query/settings/queries';
 import toast from '@/core/toast';
 import { handleShiftSelect } from '@/core/util';
 import { detectShow } from '@/core/utilities/auto-match-logic';
-import createLinksFromFiles, { AUTO_MATCH_EPISODE_ID, EDITABLE_STATES } from '@/core/utilities/releaseInfoHelpers';
+import createLinksFromFiles, {
+  AUTO_MATCH_EPISODE_ID,
+  EDITABLE_STATES,
+  isUserEdited,
+} from '@/core/utilities/releaseInfoHelpers';
 import useNavigateVoid from '@/hooks/useNavigateVoid';
 import useRowSelection from '@/hooks/useRowSelection';
 import useLinkWorkflow from '@/hooks/utilities/useLinkWorkflow';
@@ -238,7 +242,7 @@ const LinkFilesWithProviders = () => {
           }
         }
 
-        if (!draft[link.id].release.ProviderName.includes('+User')) {
+        if (!isUserEdited(draft[link.id].release.ProviderName)) {
           draft[link.id].release.ProviderName += '+User';
         }
         if (!matchFailed) {


### PR DESCRIPTION
## Summary

Adds a **Release Group** field to the Edit Release Info modal in the Link Files With Providers workflow, so the release group can be set alongside series, episode, source, version, and comment. Emptying the release group or comment now actually removes the stored value on save instead of leaving it unchanged.

## Changes

- **New `SelectReleaseGroup` component** — a searchable combobox (Headless UI v2 `Combobox`). Options are filtered by name/shortname and shown only while typing; the field keeps its current value visible when idle.
- **Release group lookup** — `useReleaseInfoReleaseGroupsQuery` fetches all known groups from `GET /api/v3/ReleaseInfo/ReleaseGroup` (`pageSize=0`, `includeMissing=true`).
- **Arbitrary values** — typing a name not in the list shows a `Create "…"` option; selecting it sets the group's `Name`, `ShortName`, and `ID` to the typed value with `Source: User`.
- **Bulk edit** — when multiple files with differing groups are selected, the field shows "Multiple groups selected" (mirroring the episode field) and stays editable.
- **Clearing** — emptying the release group or comment and leaving the field removes the stored value on save. `setIfTouched` gained a `writeUndefined` option so an empty value is omitted from the payload and cleared server-side.
- **Form state** — `useReleaseInfoForm` now tracks `group` and `hasDifferent.group`, and `'Group'` was added to `TouchableField` so it flows through the save path.
- **User-edit detection** — a shared `isUserEdited` helper detects whether `User` is part of the `+`-joined provider chain (e.g. `AniDB+User`, `User+AniDB`, `AniDB+User+TestProvider`), replacing three inconsistent inline checks.

## Verification

- `pnpm lint` (dprint → oxlint → stylelint) passes
- `tsc --noEmit` passes
