### PR TITLE
feat(avdump): Display CRC32 filename matching status

### DIFF
--- a/src/components/Utilities/Unrecognized/AvDumpFileIcon.tsx
+++ b/src/components/Utilities/Unrecognized/AvDumpFileIcon.tsx
@@ -3,8 +3,9 @@ import type { MouseEvent } from 'react';
 import {
   mdiDumpTruck,
   mdiFileDocumentAlertOutline,
+  mdiFileDocumentArrowRightOutline,
   mdiFileDocumentCheckOutline,
-  mdiFileDocumentPlusOutline,
+  mdiFileDocumentOutline,
   mdiFileDocumentRefreshOutline,
   mdiLoading,
 } from '@mdi/js';
@@ -50,7 +51,7 @@ const AVDumpFileIcon = ({ file, truck = false }: { file: FileType, truck?: boole
 
     if (dumpSession?.status === 'Success') {
       return {
-        path: mdiFileDocumentCheckOutline,
+        path: mdiFileDocumentArrowRightOutline,
         color: 'text-panel-icon-important',
         title: 'Dumped Successfully!',
         state: 'success',
@@ -68,7 +69,7 @@ const AVDumpFileIcon = ({ file, truck = false }: { file: FileType, truck?: boole
 
     if (file.AVDump.LastDumpedAt) {
       return {
-        path: mdiFileDocumentCheckOutline,
+        path: mdiFileDocumentArrowRightOutline,
         color: 'text-panel-icon-important',
         title: 'Previously Dumped!',
         state: 'success',
@@ -84,19 +85,26 @@ const AVDumpFileIcon = ({ file, truck = false }: { file: FileType, truck?: boole
       } as const;
     }
 
-    if (!file.Locations[0].RelativePath?.includes(file.Hashes.find(hash => hash.Type === 'CRC32')?.Value ?? '')) {
-      return {
-        path: mdiFileDocumentAlertOutline,
-        color: 'text-panel-text-warning',
-        title: 'The computed CRC32 does not match or is not present in filename!',
-        state: 'info',
-      } as const;
+    const crc32 = (/\b[0-9A-F]{8}\b/i.exec(file.Locations[0].RelativePath))?.[0].toUpperCase();
+    if (crc32) {
+      return crc32 === file.Hashes.find(hash => hash.Type === 'CRC32')?.Value
+        ? {
+          path: mdiFileDocumentCheckOutline,
+          color: 'text-panel-text-primary',
+          title: 'Computed CRC32 matches filename!',
+          state: 'info',
+        } as const
+        : {
+          path: mdiFileDocumentAlertOutline,
+          color: 'text-panel-text-warning',
+          title: 'Computed CRC32 does not match filename!',
+          state: 'info',
+        } as const;
     }
 
     return {
-      path: mdiFileDocumentPlusOutline,
-      color: 'text-panel-text-primary',
-      title: 'File CRC32 is present in filename and matches',
+      path: mdiFileDocumentOutline,
+      color: 'text-panel-text',
       state: 'info',
     } as const;
   }, [file, dumpSession, truck]);

--- a/src/components/Utilities/Unrecognized/AvDumpFileIcon.tsx
+++ b/src/components/Utilities/Unrecognized/AvDumpFileIcon.tsx
@@ -17,6 +17,7 @@ import { useAvdumpFilesMutation } from '@/core/react-query/avdump/mutations';
 import { useSelector } from '@/core/store';
 import toast from '@/core/toast';
 import { copyToClipboard, processError } from '@/core/util';
+import { Crc32Regex } from '@/core/utilities/auto-match-regexes';
 import getEd2kLink from '@/core/utilities/getEd2kLink';
 
 import type { FileType } from '@/core/types/api/file';
@@ -85,10 +86,11 @@ const AVDumpFileIcon = ({ file, truck = false }: { file: FileType, truck?: boole
       } as const;
     }
 
-    const crc32 = file.Locations[0].RelativePath
-      && /\b[0-9A-F]{8}\b/i.exec(file.Locations[0].RelativePath)?.[0].toUpperCase();
-    if (crc32) {
-      return crc32 === file.Hashes.find(hash => hash.Type === 'CRC32')?.Value
+    const relativePath = file.Locations?.[0]?.RelativePath;
+    const crc32Result = relativePath && Crc32Regex.exec(relativePath)?.[0]?.toUpperCase();
+
+    if (crc32Result) {
+      return crc32Result === file.Hashes.find(hash => hash.Type === 'CRC32')?.Value
         ? {
           path: mdiFileDocumentCheckOutline,
           color: 'text-panel-text-primary',

--- a/src/components/Utilities/Unrecognized/AvDumpFileIcon.tsx
+++ b/src/components/Utilities/Unrecognized/AvDumpFileIcon.tsx
@@ -4,8 +4,8 @@ import {
   mdiDumpTruck,
   mdiFileDocumentAlertOutline,
   mdiFileDocumentCheckOutline,
+  mdiFileDocumentPlusOutline,
   mdiFileDocumentRefreshOutline,
-  mdiInformationOutline,
   mdiLoading,
 } from '@mdi/js';
 import Icon from '@mdi/react';
@@ -27,7 +27,7 @@ const AVDumpFileIcon = ({ file, truck = false }: { file: FileType, truck?: boole
   const fileId = file.ID;
   const dumpSession = avdumpList.sessions[avdumpList.sessionMap[fileId]];
 
-  const hash = useMemo(() => getEd2kLink(file), [file]);
+  const ed2kHashLink = useMemo(() => getEd2kLink(file), [file]);
 
   const { color, path, state, title } = useMemo(() => {
     if (dumpSession?.status === 'Running') {
@@ -84,11 +84,20 @@ const AVDumpFileIcon = ({ file, truck = false }: { file: FileType, truck?: boole
       } as const;
     }
 
+    if (!file.Locations[0].RelativePath?.includes(file.Hashes.find(hash => hash.Type === 'CRC32')?.Value ?? '')) {
+      return {
+        path: mdiFileDocumentAlertOutline,
+        color: 'text-panel-text-warning',
+        title: 'The computed CRC32 does not match or is not present in filename!',
+        state: 'info',
+      } as const;
+    }
+
     return {
-      path: mdiInformationOutline,
-      color: 'text-panel-text',
-      title: 'Click to Dump!',
-      state: 'idle',
+      path: mdiFileDocumentPlusOutline,
+      color: 'text-panel-text-primary',
+      title: 'File CRC32 is present in filename and matches',
+      state: 'info',
     } as const;
   }, [file, dumpSession, truck]);
 
@@ -102,7 +111,7 @@ const AVDumpFileIcon = ({ file, truck = false }: { file: FileType, truck?: boole
 
   const handleCopy = (event: MouseEvent<HTMLButtonElement>) => {
     event.stopPropagation();
-    copyToClipboard(hash, 'ED2K hash').catch(console.error);
+    copyToClipboard(ed2kHashLink, 'ED2K hash').catch(console.error);
   };
 
   return (
@@ -112,17 +121,20 @@ const AVDumpFileIcon = ({ file, truck = false }: { file: FileType, truck?: boole
           <Button
             onClick={handleCopy}
             className={color}
+            tooltip={title}
           >
-            <Icon path={path} spin={path === mdiLoading} size={1} title={title} />
+            <Icon path={path} spin={path === mdiLoading} size={1} />
           </Button>
         )
         : (
           <Button
             onClick={handleDump}
-            className={cx((state !== 'idle' && state !== 'failed') && 'pointer-events-none cursor-default')}
-            tooltip="Dump File"
+            className={cx(
+              (state !== 'idle' && state !== 'failed' && state !== 'info') && 'pointer-events-none cursor-default',
+            )}
+            tooltip={title}
           >
-            <Icon path={path} spin={path === mdiLoading} size={1} className={color} title={title} />
+            <Icon path={path} spin={path === mdiLoading} size={1} className={color} />
           </Button>
         )}
     </div>

--- a/src/components/Utilities/Unrecognized/AvDumpFileIcon.tsx
+++ b/src/components/Utilities/Unrecognized/AvDumpFileIcon.tsx
@@ -29,7 +29,7 @@ const AVDumpFileIcon = ({ file, truck = false }: { file: FileType, truck?: boole
   const fileId = file.ID;
   const dumpSession = avdumpList.sessions[avdumpList.sessionMap[fileId]];
 
-  const ed2kHashLink = useMemo(() => getEd2kLink(file), [file]);
+  const ed2kHashLink = getEd2kLink(file);
 
   const { color, path, state, title } = useMemo(() => {
     if (dumpSession?.status === 'Running') {

--- a/src/components/Utilities/Unrecognized/AvDumpFileIcon.tsx
+++ b/src/components/Utilities/Unrecognized/AvDumpFileIcon.tsx
@@ -87,7 +87,7 @@ const AVDumpFileIcon = ({ file, truck = false }: { file: FileType, truck?: boole
     }
 
     const relativePath = file.Locations?.[0]?.RelativePath;
-    const crc32Result = relativePath && Crc32Regex.exec(relativePath)?.[0]?.toUpperCase();
+    const crc32Result = relativePath && Crc32Regex.exec(relativePath)?.[1]?.toUpperCase();
 
     if (crc32Result) {
       return crc32Result === file.Hashes.find(hash => hash.Type === 'CRC32')?.Value

--- a/src/components/Utilities/Unrecognized/AvDumpFileIcon.tsx
+++ b/src/components/Utilities/Unrecognized/AvDumpFileIcon.tsx
@@ -85,7 +85,8 @@ const AVDumpFileIcon = ({ file, truck = false }: { file: FileType, truck?: boole
       } as const;
     }
 
-    const crc32 = (/\b[0-9A-F]{8}\b/i.exec(file.Locations[0].RelativePath))?.[0].toUpperCase();
+    const crc32 = file.Locations[0].RelativePath
+      && /\b[0-9A-F]{8}\b/i.exec(file.Locations[0].RelativePath)?.[0].toUpperCase();
     if (crc32) {
       return crc32 === file.Hashes.find(hash => hash.Type === 'CRC32')?.Value
         ? {

--- a/src/core/utilities/auto-match-regexes.ts
+++ b/src/core/utilities/auto-match-regexes.ts
@@ -2,13 +2,13 @@ import type { PathDetails, PathMatchRule } from './auto-match-logic';
 
 const PathMatchRuleSet: PathMatchRule[] = [];
 
+export const Crc32Regex = /\b[0-9A-F]{8}\b/i;
+
 try {
   const TrimShowNameRegex =
     /(?![\s_.]*\(part[\s_.]*[ivx]+\))(?![\s_.]*\((?:19|20)\d{2}\))(?:[\s_.]*(?:[([{][^)\]}\n]*[)\]}]|(?:(?<![a-z])(?:jpn?|jap(?:anese)?|en|eng(?:lish)?|es|(?:spa(?:nish)?|de|ger(?:man)?)|\d{3,4}[pi](?:-+hi\w*)?|(?:[uf]?hd|sd)|\d{3,4}x\d{3,4}|dual[\s_.-]*audio|(?:www|web|bd|dvd|ld|blu[\s_.-]*ray)(?:[\s_.-]*(?:rip|dl))?|dl|rip|(?:av1|hevc|[hx]26[45])(?:-[a-z0-9]{1,6})?|(?:dolby(?:[\s_.-]*atmos)?|dts|opus|ac3|aac|flac)(?:[\s._]*[257]\.[0124](?:[_.-]+\w{1,3})?)?|(?:\w{2,3}[\s_.-]*)?(?:sub(?:title)?s?|dub)|(?:un)?cen(?:\.|sored)?)[\s_.]*){1,20})){0,20}[\s_.]*$/i;
 
   const ReStitchRegex = /^[\s_.]*-+[\s_.]*$/i;
-
-  const Crc32Regex = /\(([0-9a-fA-F]{8})\)|\[([0-9a-fA-F]{8})\]/;
 
   const ThemeSongCheckRegex =
     /(?<isThemeSong>(?<![a-z0-9])(?:(?:nc|creditless)[\s_.]*)?(?:ed|op)(?![a-z]))(?:[\s_.]*(?<episode>\d+(?!\d*p)))?/i;
@@ -49,10 +49,7 @@ try {
     const modifiedDetails = { ...originalDetails };
 
     // Add crc32 if found
-    const crc32Result = Crc32Regex.exec(match[0]);
-    if (crc32Result) {
-      modifiedDetails.crc32 = crc32Result[1] || crc32Result[2];
-    }
+    modifiedDetails.crc32 = Crc32Regex.exec(match[0])?.[0] ?? null;
 
     // Fix up show name by removing unwanted details and fixing spaces.
     if (modifiedDetails.showName) {

--- a/src/core/utilities/auto-match-regexes.ts
+++ b/src/core/utilities/auto-match-regexes.ts
@@ -2,7 +2,7 @@ import type { PathDetails, PathMatchRule } from './auto-match-logic';
 
 const PathMatchRuleSet: PathMatchRule[] = [];
 
-export const Crc32Regex = /\b[0-9A-F]{8}\b/i;
+export const Crc32Regex = /[^0-9A-Z]([0-9A-F]{8})[^0-9A-Z]/i;
 
 try {
   const TrimShowNameRegex =
@@ -49,7 +49,7 @@ try {
     const modifiedDetails = { ...originalDetails };
 
     // Add crc32 if found
-    modifiedDetails.crc32 = Crc32Regex.exec(match[0])?.[0] ?? null;
+    modifiedDetails.crc32 = Crc32Regex.exec(match[0])?.[1] ?? null;
 
     // Fix up show name by removing unwanted details and fixing spaces.
     if (modifiedDetails.showName) {


### PR DESCRIPTION
Introduces a visual warning for files where the computed CRC32 hash does not match or is absent from the filename. The default 'ready to dump' state now explicitly uses a distinct icon and tooltip to confirm a successful CRC32 match.