### PR TITLE
Add selected files modal to Edit Release Info; fix cross-reference matching and hotkeys

### DIFF
--- a/src/components/Utilities/LinkFilesWithProvider/EditReleaseInfoModal.tsx
+++ b/src/components/Utilities/LinkFilesWithProvider/EditReleaseInfoModal.tsx
@@ -1,10 +1,11 @@
 import { useState } from 'react';
 import type { ChangeEvent } from 'react';
 import { useHotkeys } from 'react-hotkeys-hook';
-import { mdiPencilCircleOutline, mdiRefresh } from '@mdi/js';
+import { mdiInformationOutline, mdiPencilCircleOutline, mdiRefresh } from '@mdi/js';
 import { Icon } from '@mdi/react';
 import cx from 'classnames';
 import { map } from 'lodash';
+import { useToggle } from 'usehooks-ts';
 
 import Button from '@/components/Input/Button';
 import Checkbox from '@/components/Input/Checkbox';
@@ -22,6 +23,7 @@ import { AUTO_MATCH_EPISODE_ID } from '@/core/utilities/releaseInfoHelpers';
 import useToggleModalKeybinds from '@/hooks/useToggleModalKeybinds';
 import useReleaseInfoForm from '@/hooks/utilities/useReleaseInfoForm';
 
+import SelectedFilesModal from './SelectedFilesModal';
 import SelectReleaseGroup from './SelectReleaseGroup';
 
 import type { ReleaseGroupType, ReleaseInfoType, ReleaseSourceValues } from '@/core/types/api/file';
@@ -63,16 +65,47 @@ const sourceOptions = [
   )),
 ];
 
-const Title = ({ count }: { count: number }) => (
-  <div className="flex items-center justify-between gap-x-1 font-semibold">
-    Edit Release Info
-    <div className="flex">
-      <div className="text-panel-text-important">{count}</div>
-      &nbsp;
-      {count === 1 ? 'File' : 'Files'}
-    </div>
-  </div>
-);
+const Title = ({ selectedLinks }: { selectedLinks: ManualLinkType[] }) => {
+  const [showFilesModal, toggleShowFilesModal, setShowFilesModal] = useToggle(false);
+  const count = selectedLinks.length;
+
+  useToggleModalKeybinds(!showFilesModal, 'modal');
+
+  const singleFileName = count === 1
+    ? selectedLinks[0].file.Locations[0]?.RelativePath.split(/[/\\]/g).pop() ?? ''
+    : '';
+
+  const handleShowFiles = () => {
+    if (count > 1) toggleShowFilesModal();
+  };
+
+  return (
+    <>
+      <div className="flex items-center justify-between gap-x-1 font-semibold">
+        Edit Release Info
+        <div className="flex items-center gap-x-1">
+          <div>
+            <span className="text-panel-text-important">{count}</span>
+            &nbsp;
+            {count === 1 ? 'File' : 'Files'}
+          </div>
+          <Button
+            onClick={handleShowFiles}
+            tooltip={count === 1 ? singleFileName : 'Show files'}
+            className="text-panel-icon-action"
+          >
+            <Icon path={mdiInformationOutline} size={1} />
+          </Button>
+        </div>
+      </div>
+      <SelectedFilesModal
+        show={showFilesModal}
+        onClose={() => setShowFilesModal(false)}
+        files={selectedLinks.map(link => link.file)}
+      />
+    </>
+  );
+};
 
 const EditReleaseInfoModal = (props: Props) => {
   const { onClose, onSave, selectedLinks, show } = props;
@@ -295,7 +328,7 @@ const EditReleaseInfoModal = (props: Props) => {
       show={show}
       size="md"
       onRequestClose={onClose}
-      header={<Title count={selectedLinks.length} />}
+      header={<Title selectedLinks={selectedLinks} />}
       footer={
         <div className="flex justify-end gap-x-3">
           <Button onClick={onClose} buttonType="secondary" buttonSize="normal">

--- a/src/components/Utilities/LinkFilesWithProvider/SelectedFilesModal.tsx
+++ b/src/components/Utilities/LinkFilesWithProvider/SelectedFilesModal.tsx
@@ -1,0 +1,63 @@
+import { useHotkeys } from 'react-hotkeys-hook';
+
+import ModalPanel from '@/components/Panels/ModalPanel';
+import { useManagedFoldersQuery } from '@/core/react-query/managed-folder/queries';
+import useToggleModalKeybinds from '@/hooks/useToggleModalKeybinds';
+
+import type { FileType } from '@/core/types/api/file';
+
+type Props = {
+  files: FileType[];
+  show: boolean;
+  onClose: () => void;
+};
+
+const SelectedFilesModal = ({ files, onClose, show }: Props) => {
+  useToggleModalKeybinds(show, 'nested-modal');
+  useHotkeys('escape', onClose, { scopes: 'nested-modal' });
+
+  const managedFoldersQuery = useManagedFoldersQuery();
+
+  return (
+    <ModalPanel
+      show={show}
+      onRequestClose={onClose}
+      header="Selected Files"
+      size="md"
+      overlayClassName="!z-[90]"
+      className="h-120"
+    >
+      <div className="flex flex-col gap-y-2 overflow-y-auto">
+        {files.map((file) => {
+          const location = file.Locations[0];
+          const path = location?.RelativePath ?? '';
+          const match = /[/\\](?=[^/\\]*$)/g.exec(path);
+          const relativePath = match ? path.substring(0, match.index) : 'Root Level';
+          const fileName = path.split(/[/\\]/g).pop() ?? `<missing file path for ${file.ID}>`;
+          const folderName = managedFoldersQuery.data?.find(
+            folder => folder.ID === location?.ManagedFolderID,
+          )?.Name ?? '';
+
+          return (
+            <div
+              key={`selected-file-${file.ID}`}
+              className="mr-2 flex flex-col gap-1 rounded-lg border border-panel-border bg-panel-background-alt p-3"
+              data-tooltip-id="tooltip"
+              data-tooltip-content={path}
+              data-tooltip-delay-show={200}
+            >
+              <span className="line-clamp-1 truncate text-xs font-semibold opacity-65">
+                {folderName}
+                &nbsp;-&nbsp;
+                {relativePath}
+              </span>
+              <span className="line-clamp-1 truncate text-sm">{fileName}</span>
+            </div>
+          );
+        })}
+      </div>
+    </ModalPanel>
+  );
+};
+
+export default SelectedFilesModal;

--- a/src/pages/utilities/LinkFilesWithProviders.tsx
+++ b/src/pages/utilities/LinkFilesWithProviders.tsx
@@ -29,6 +29,7 @@ import createLinksFromFiles, {
 } from '@/core/utilities/releaseInfoHelpers';
 import useNavigateVoid from '@/hooks/useNavigateVoid';
 import useRowSelection from '@/hooks/useRowSelection';
+import useToggleModalKeybinds from '@/hooks/useToggleModalKeybinds';
 import useLinkWorkflow from '@/hooks/utilities/useLinkWorkflow';
 
 import type { FileType, ReleaseInfoType } from '@/core/types/api/file';
@@ -260,6 +261,7 @@ const LinkFilesWithProviders = () => {
     }
   };
 
+  useToggleModalKeybinds(!confirmCancel, 'primary');
   useHotkeys('s', openAutoSearch, { scopes: 'primary' });
   useHotkeys('a', toggleAllSelectedLinks, { scopes: 'primary' });
   useHotkeys('d', removeLinks, { scopes: 'primary' });

--- a/src/pages/utilities/LinkFilesWithProviders.tsx
+++ b/src/pages/utilities/LinkFilesWithProviders.tsx
@@ -213,7 +213,7 @@ const LinkFilesWithProviders = () => {
       for (const link of selectedRows) {
         Object.assign(draft[link.id].release, releaseInfo);
 
-        let matchFailed = false;
+        let matchFailed = true;
         if (crossReference) {
           const { episodeId: selectedEpisodeId, episodes, seriesId } = crossReference;
           let episodeId = selectedEpisodeId;
@@ -236,9 +236,9 @@ const LinkFilesWithProviders = () => {
               PercentageStart: 0,
               PercentageEnd: 100,
             }];
+            matchFailed = false;
           } else {
             failedAutoMatchCount += 1;
-            matchFailed = true;
           }
         }
 


### PR DESCRIPTION
Adds an info icon to the "Edit Release Info" modal header (next to the "Files" count) that shows which files are selected.

- **Single file**: hovering the icon shows a tooltip with the file name (no modal).
- **Multiple files**: clicking the icon opens a "Selected Files" modal listing each file (import folder + relative path on one line, filename below), with the full path shown on hover.

Also fixes two issues in the Link Files With Providers workflow:
- Restore hotkeys after the cancel-confirmation modal closes.
- Only mark files as ready when a cross-reference is actually resolved.

### Changes
- `EditReleaseInfoModal.tsx` — header info icon + nested-modal wiring; `Title` owns the selected-files state and restores the `modal` hotkey scope when the nested modal closes.
- `SelectedFilesModal.tsx` (new) — nested modal listing the selected files.
- `LinkFilesWithProviders.tsx` — fix `matchFailed` default and restore the `primary` hotkey scope after the confirm-cancel modal closes.
