### PR TITLE
Add range fill to Edit Release Info modal

### DIFF
--- a/docs/LinkFilesWithProviders.md
+++ b/docs/LinkFilesWithProviders.md
@@ -25,14 +25,15 @@ src/hooks/utilities/
   useReleaseInfoForm.ts          Form state + touched-field tracking for the Edit Release Info modal
 
 src/core/utilities/
-  releaseInfoHelpers.ts          Pure helpers: createLinksFromFiles, mergeReleaseInfo, isUserEdited; shared constants EDITABLE_STATES, AUTO_MATCH_EPISODE_ID
+  releaseInfoHelpers.ts          Pure helpers: createLinksFromFiles, mergeReleaseInfo, isUserEdited; shared constants EDITABLE_STATES, AUTO_MATCH_EPISODE_ID, RANGE_FILL_EPISODE_ID
   auto-match-logic.ts            detectShow, findMostCommonShowName
 
 src/core/types/utilities/
-  link-files-with-providers.ts    ManualLinkType, ManualLinkProviderType, LinkStateType, CrossReferenceType, TouchableField
+  link-files-with-providers.ts    ManualLinkType, ManualLinkProviderType, LinkStateType, CrossReferenceType, RangeFillType, TouchableField
 
 src/components/Utilities/Unrecognized/
   AnimeSelectPanel.tsx           Shared AniDB series search panel (modal + LinkFilesTab)
+  RangeFillModal.tsx             Range fill options modal (episode type + starting number)
 
   LinkFilesWithProvider/
     LinkCard.tsx                 Per-link card (state-driven styling, selection)
@@ -63,13 +64,19 @@ type ManualLinkType = {
 
 Each link's `state` field drives the entire workflow — the component never directly calls process handlers, only the drive loop dispatches based on current state.
 
-The Edit Release Info modal adds two shared types:
+The Edit Release Info modal adds three shared types:
 
 ```ts
 type CrossReferenceType = {
   seriesId: number;
   episodeId: number;
   episodes: AniDBEpisodeType[];
+  rangeFill?: RangeFillType;
+};
+
+type RangeFillType = {
+  episodeType: EpisodeTypeValues;
+  rangeStart: number;
 };
 
 type TouchableField = 'Comment' | 'CrossReferences' | 'Group' | 'IsChaptered' | 'IsCreditless' | 'Source' | 'Version';
@@ -193,9 +200,15 @@ Opened from the Menu's "Edit Release Info" action (`E`) for the selected links. 
 
 The header shows the selected file count alongside an info button (`mdiInformationOutline`). For a single file the button's tooltip is the filename; for multiple files it opens a nested `SelectedFilesModal` (tooltip "Show files"). The modal lists each file's managed-folder name, parent directory (or `Root Level`), and filename, with the full `RelativePath` in a hover tooltip.
 
-Editable fields: `Version`, `Source`, `IsChaptered`, `IsCreditless`, `Comment`, and `Release Group`. The release group is a searchable `SelectReleaseGroup` combobox that filters known groups by name/shortname and only shows options while typing; typing an unknown name offers a `Create "…"` option that sets the group's `Name`, `ShortName`, and `ID` to the typed value with `Source: User`. Episode selection includes an "Auto-match (from filename)" option (`AUTO_MATCH_EPISODE_ID = -1`). When selected files have differing episode links, the selector shows a disabled "Multiple episodes selected" entry and those per-file links are preserved unless an episode (or auto-match) is explicitly chosen; the release group field shows "Multiple groups selected" for mixed groups. Save stays disabled until a field is touched.
+Editable fields: `Version`, `Source`, `IsChaptered`, `IsCreditless`, `Comment`, and `Release Group`. The release group is a searchable `SelectReleaseGroup` combobox that filters known groups by name/shortname and only shows options while typing; typing an unknown name offers a `Create "…"` option that sets the group's `Name`, `ShortName`, and `ID` to the typed value with `Source: User`. Episode selection includes an "Auto-match (from filename)" option (`AUTO_MATCH_EPISODE_ID = -1`) and, directly below it, a "Range Fill" option (`RANGE_FILL_EPISODE_ID = -2`), whose label reads "Range Fill (from S3)" once a range is configured (episode prefix via `getEpisodePrefix` + starting number) and "Range Fill (not set)" otherwise. Selecting "Range Fill" (from the dropdown or via the `r` hotkey) automatically opens the `RangeFillModal` (episode type + starting number); a pencil edit button, shown only while "Range Fill" is selected, reopens it. On save, consecutive episodes of the chosen type are assigned to the selected files in sorted order. When selected files have differing episode links, the selector shows a disabled "Multiple episodes selected" entry and those per-file links are preserved unless an episode (or auto-match/range-fill) is explicitly chosen; the release group field shows "Multiple groups selected" for mixed groups. Save is gated by a `saveDisabled` flag (`!show`, no touched fields, or "Range Fill" selected without a configured range) that disables the Save button and is also checked at the top of `handleSave` so `Enter` triggers save safely.
 
-State is managed by the `useReleaseInfoForm` hook (form state, touched-field tracking, mixed-selection flags). Clearing the release group or comment and leaving the field removes the stored value on save — `setIfTouched` uses a `writeUndefined` option so an empty value is omitted from the payload and cleared server-side. On save, `handleSaveReleaseInfo` in the page merges the patch into each selected link's `release`, resolves the episode cross-reference (auto-match resolves via `detectShow` → matching episode, writing `CrossReferences` at 0–100%), and appends the `+User` marker to `ProviderName` (unless `isUserEdited`). A link's state is set to `ready` only when a cross-reference is actually resolved (a concrete `episodeId` is written); when no `crossReference` was provided, or auto-match fails to find an episode, the link keeps its previous state (no `ready` transition). Failed auto-matches — where a `crossReference` was present but resolution failed — are reported in an error toast with the file count.
+State is managed by the `useReleaseInfoForm` hook (form state, touched-field tracking, mixed-selection flags). Clearing the release group or comment and leaving the field removes the stored value on save — `setIfTouched` uses a `writeUndefined` option so an empty value is omitted from the payload and cleared server-side. On save, `handleSaveReleaseInfo` in the page merges the patch into each selected link's `release`, resolves the episode cross-reference (auto-match resolves via `detectShow` → matching episode, writing `CrossReferences` at 0–100%), and appends the `+User` marker to `ProviderName` (unless `isUserEdited`). The per-link mutation (apply the `releaseInfo` patch, write `CrossReferences`, append `+User`, transition to `ready`) lives in a local `applyRelease(link, episodeId)` helper shared by the auto-match/single-episode and range-fill branches. A link's state is set to `ready` only when a cross-reference is actually resolved (a concrete `episodeId` is written); when no `crossReference` was provided, or auto-match fails to find an episode, the link keeps its previous state (no `ready` transition). Failed auto-matches — where a `crossReference` was present but resolution failed — are reported in an error toast with the file count. For range fill, the selected links are iterated in sorted (`RelativePath`) order and each gets the next consecutive episode of the chosen type starting from the configured number; if the episode queue runs out before all selected files are processed, a warning toast reports how many files could not be filled.
+
+### Modal Hotkeys
+
+The Edit Release Info modal registers `Esc` (close), `R` (select "Range Fill", gated on a selected series), and `Enter` (save) in the `modal` scope. While the nested `RangeFillModal` is open, `useToggleModalKeybinds(show && !showRangeFill, 'modal')` suspends the `modal` scope so its shortcuts don't fire.
+
+The `RangeFillModal` runs in the `nested-modal` scope with `Esc` (cancel) and `Enter` (fill). Its Fill button is disabled until a positive starting number is entered, and `Enter` inside the "Range Starting Number" input also fills via the input's `onKeyUp` handler. Guards such as `saveDisabled` and `!show || !formState.selectedSeriesId` live inside the handlers themselves (`handleSave`, `handleEpisodeSelect`) rather than in the hotkey callbacks.
 
 ## Supporting Components
 

--- a/src/components/Dialogs/ConfirmationPromptModal.tsx
+++ b/src/components/Dialogs/ConfirmationPromptModal.tsx
@@ -32,6 +32,7 @@ const ConfirmationPromptModal = ({
   const [isConfirmPending, setIsConfirmPending] = useState(false);
 
   const handleConfirm = () => {
+    if (!show) return;
     setIsConfirmPending(true);
     Promise.resolve()
       .then(() => onConfirm())

--- a/src/components/Utilities/LinkFilesWithProvider/AutoSearchReleaseModal.tsx
+++ b/src/components/Utilities/LinkFilesWithProvider/AutoSearchReleaseModal.tsx
@@ -90,6 +90,7 @@ const AutoSearchReleaseModal = (props: Props) => {
   };
 
   const handleSearch = () => {
+    if (!show) return;
     onUpdateProviders(providers);
     onClose();
   };
@@ -101,7 +102,13 @@ const AutoSearchReleaseModal = (props: Props) => {
 
   useToggleModalKeybinds(show && !showProviderInfoModal, 'modal');
   useToggleModalKeybinds(!show, 'primary');
-  useHotkeys('escape', onClose, { scopes: 'modal' });
+  useHotkeys(
+    'escape',
+    () => {
+      if (show) onClose();
+    },
+    { scopes: 'modal' },
+  );
   useHotkeys('enter', handleSearch, { scopes: 'modal' });
 
   return (

--- a/src/components/Utilities/LinkFilesWithProvider/EditReleaseInfoModal.tsx
+++ b/src/components/Utilities/LinkFilesWithProvider/EditReleaseInfoModal.tsx
@@ -4,7 +4,7 @@ import { useHotkeys } from 'react-hotkeys-hook';
 import { mdiInformationOutline, mdiPencilCircleOutline, mdiRefresh } from '@mdi/js';
 import { Icon } from '@mdi/react';
 import cx from 'classnames';
-import { map } from 'lodash';
+import { filter, findIndex, map } from 'lodash';
 import { useToggle } from 'usehooks-ts';
 
 import Button from '@/components/Input/Button';
@@ -15,17 +15,20 @@ import SelectEpisodeList from '@/components/Input/SelectEpisodeList';
 import SelectSmall from '@/components/Input/SelectSmall';
 import ModalPanel from '@/components/Panels/ModalPanel';
 import AnimeSelectPanel from '@/components/Utilities/Unrecognized/AnimeSelectPanel';
+import RangeFillModal from '@/components/Utilities/Unrecognized/RangeFillModal';
 import { useReleaseInfoReleaseGroupsQuery } from '@/core/react-query/release-info/queries';
 import { useGetSeriesAniDBMutation, useRefreshAniDBSeriesMutation } from '@/core/react-query/series/mutations';
 import { useSeriesAniDBEpisodesQuery, useSeriesAniDBQuery } from '@/core/react-query/series/queries';
 import toast from '@/core/toast';
-import { AUTO_MATCH_EPISODE_ID } from '@/core/utilities/releaseInfoHelpers';
+import { getEpisodePrefix } from '@/core/utilities/getEpisodePrefix';
+import { AUTO_MATCH_EPISODE_ID, RANGE_FILL_EPISODE_ID } from '@/core/utilities/releaseInfoHelpers';
 import useToggleModalKeybinds from '@/hooks/useToggleModalKeybinds';
 import useReleaseInfoForm from '@/hooks/utilities/useReleaseInfoForm';
 
 import SelectedFilesModal from './SelectedFilesModal';
 import SelectReleaseGroup from './SelectReleaseGroup';
 
+import type { EpisodeTypeValues } from '@/core/types/api/episode';
 import type { ReleaseGroupType, ReleaseInfoType, ReleaseSourceValues } from '@/core/types/api/file';
 import type { SeriesAniDBSearchResult } from '@/core/types/api/series';
 import type {
@@ -124,6 +127,7 @@ const EditReleaseInfoModal = (props: Props) => {
     touchedFields,
   } = useReleaseInfoForm(selectedLinks, show);
   const [seriesUpdating, setSeriesUpdating] = useState(false);
+  const [showRangeFill, toggleRangeFill, setShowRangeFill] = useToggle(false);
 
   const seriesSearchQuery = useSeriesAniDBQuery(
     formState.selectedSeriesId ?? 0,
@@ -155,6 +159,14 @@ const EditReleaseInfoModal = (props: Props) => {
       type: 'Episode',
       AirDate: '',
     } as const,
+    {
+      label: formState.rangeFill
+        ? `Range Fill (from ${getEpisodePrefix(formState.rangeFill.episodeType)}${formState.rangeFill.rangeStart})`
+        : 'Range Fill (not set)',
+      value: RANGE_FILL_EPISODE_ID,
+      type: 'Episode',
+      AirDate: '',
+    } as const,
     ...map(episodesQuery.data ?? [], episode => ({
       label: episode.Title,
       value: episode.ID,
@@ -180,6 +192,7 @@ const EditReleaseInfoModal = (props: Props) => {
       setFormState((draft) => {
         draft.selectedSeriesId = series.ID;
         draft.selectedEpisodeId = AUTO_MATCH_EPISODE_ID;
+        draft.rangeFill = undefined;
       });
       return;
     }
@@ -191,6 +204,7 @@ const EditReleaseInfoModal = (props: Props) => {
       setFormState((draft) => {
         draft.selectedSeriesId = seriesData.ID;
         draft.selectedEpisodeId = AUTO_MATCH_EPISODE_ID;
+        draft.rangeFill = undefined;
       });
     } catch (_) {
       toast.error('Failed to get series data!');
@@ -199,12 +213,36 @@ const EditReleaseInfoModal = (props: Props) => {
   };
 
   const handleEpisodeSelect = (optionValue: number) => {
+    if (!show || !formState.selectedSeriesId) return;
     markTouched('CrossReferences');
     setHasDifferent((draft) => {
       draft.episodes = false;
     });
     setFormState((draft) => {
       draft.selectedEpisodeId = optionValue;
+      if (optionValue !== RANGE_FILL_EPISODE_ID) {
+        draft.rangeFill = undefined;
+      }
+    });
+    if (optionValue === RANGE_FILL_EPISODE_ID) {
+      setShowRangeFill(true);
+    }
+  };
+
+  const handleRangeFill = (episodeType: EpisodeTypeValues, rangeStart: number) => {
+    const items = filter(episodesQuery.data ?? [], ['Type', episodeType]);
+    if (findIndex(items, ['EpisodeNumber', rangeStart]) === -1) {
+      toast.error('Unable to find starting episode.');
+      return;
+    }
+
+    markTouched('CrossReferences');
+    setHasDifferent((draft) => {
+      draft.episodes = false;
+    });
+    setFormState((draft) => {
+      draft.selectedEpisodeId = RANGE_FILL_EPISODE_ID;
+      draft.rangeFill = { episodeType, rangeStart };
     });
   };
 
@@ -266,6 +304,7 @@ const EditReleaseInfoModal = (props: Props) => {
     setFormState((draft) => {
       draft.selectedSeriesId = undefined;
       draft.selectedEpisodeId = AUTO_MATCH_EPISODE_ID;
+      draft.rangeFill = undefined;
     });
     setHasDifferent((draft) => {
       draft.series = false;
@@ -284,7 +323,13 @@ const EditReleaseInfoModal = (props: Props) => {
     });
   };
 
+  const saveDisabled = !show
+    || touchedFields.size === 0
+    || (formState.selectedEpisodeId === RANGE_FILL_EPISODE_ID && !formState.rangeFill);
+
   const handleSave = () => {
+    if (saveDisabled) return;
+
     const releaseInfo: Partial<ReleaseInfoType> = {};
     let crossReference: CrossReferenceType | undefined;
 
@@ -312,6 +357,9 @@ const EditReleaseInfoModal = (props: Props) => {
         seriesId: formState.selectedSeriesId,
         episodeId: formState.selectedEpisodeId ?? AUTO_MATCH_EPISODE_ID,
         episodes: episodesQuery.data ?? [],
+        ...(formState.selectedEpisodeId === RANGE_FILL_EPISODE_ID && formState.rangeFill
+          ? { rangeFill: formState.rangeFill }
+          : {}),
       };
     }
 
@@ -319,9 +367,17 @@ const EditReleaseInfoModal = (props: Props) => {
     onClose();
   };
 
-  useToggleModalKeybinds(show, 'modal');
+  useToggleModalKeybinds(show && !showRangeFill, 'modal');
   useToggleModalKeybinds(!show, 'primary');
-  useHotkeys('escape', onClose, { scopes: 'modal' });
+  useHotkeys(
+    'escape',
+    () => {
+      if (show) onClose();
+    },
+    { scopes: 'modal' },
+  );
+  useHotkeys('r', () => handleEpisodeSelect(RANGE_FILL_EPISODE_ID), { scopes: 'modal' });
+  useHotkeys('enter', handleSave, { scopes: 'modal' });
 
   return (
     <ModalPanel
@@ -339,7 +395,7 @@ const EditReleaseInfoModal = (props: Props) => {
               onClick={handleSave}
               buttonType="primary"
               buttonSize="normal"
-              disabled={touchedFields.size === 0}
+              disabled={saveDisabled}
             >
               Save
             </Button>
@@ -387,14 +443,23 @@ const EditReleaseInfoModal = (props: Props) => {
                   <Icon path={mdiRefresh} size={1} spin={isRefreshingSeries} className="text-panel-icon-action" />
                 </Button>
               </div>
-              <SelectEpisodeList
-                options={episodeOptions}
-                value={formState.selectedEpisodeId ?? 0}
-                onChange={handleEpisodeSelect}
-                rowIdx={0}
-                standalone
-                disabled={hasDifferent.series}
-              />
+              <div className="flex items-center gap-x-2">
+                <div className="grow">
+                  <SelectEpisodeList
+                    options={episodeOptions}
+                    value={formState.selectedEpisodeId ?? 0}
+                    onChange={handleEpisodeSelect}
+                    rowIdx={0}
+                    standalone
+                    disabled={hasDifferent.series}
+                  />
+                </div>
+                {formState.selectedEpisodeId === RANGE_FILL_EPISODE_ID && (
+                  <Button onClick={toggleRangeFill}>
+                    <Icon path={mdiPencilCircleOutline} size={1} className="shrink-0 text-panel-icon-action" />
+                  </Button>
+                )}
+              </div>
             </div>
             <div className="flex flex-col gap-y-2">
               <span className="font-semibold">Release Group</span>
@@ -455,6 +520,7 @@ const EditReleaseInfoModal = (props: Props) => {
           </>
         )}
       </div>
+      <RangeFillModal show={showRangeFill} onClose={toggleRangeFill} handleRangeFill={handleRangeFill} />
     </ModalPanel>
   );
 };

--- a/src/components/Utilities/Unrecognized/RangeFillModal.tsx
+++ b/src/components/Utilities/Unrecognized/RangeFillModal.tsx
@@ -1,24 +1,40 @@
 import { useState } from 'react';
+import { useHotkeys } from 'react-hotkeys-hook';
+import { toInteger } from 'lodash';
 
 import Button from '@/components/Input/Button';
 import InputSmall from '@/components/Input/InputSmall';
 import SelectSmall from '@/components/Input/SelectSmall';
 import ModalPanel from '@/components/Panels/ModalPanel';
+import useToggleModalKeybinds from '@/hooks/useToggleModalKeybinds';
+
+import type { EpisodeTypeValues } from '@/core/types/api/episode';
 
 type Props = {
   show: boolean;
   onClose: () => void;
-  rangeFill: (rangeStart: string, epType: string) => void;
+  handleRangeFill: (episodeType: EpisodeTypeValues, rangeStart: number) => void;
 };
 
-const RangeFillModal = ({ onClose, rangeFill, show }: Props) => {
+const RangeFillModal = ({ handleRangeFill, onClose, show }: Props) => {
   const [rangeStart, setRangeStart] = useState('');
-  const [epType, setEpType] = useState('Episode');
+  const [episodeType, setEpisodeType] = useState('Episode');
 
   const handleFill = () => {
-    rangeFill(rangeStart, epType);
+    if (!show || toInteger(rangeStart) <= 0) return;
+    handleRangeFill(episodeType as EpisodeTypeValues, toInteger(rangeStart));
     onClose();
   };
+
+  useToggleModalKeybinds(show, 'nested-modal');
+  useHotkeys(
+    'escape',
+    () => {
+      if (show) onClose();
+    },
+    { scopes: 'nested-modal' },
+  );
+  useHotkeys('enter', handleFill, { scopes: 'nested-modal' });
 
   return (
     <ModalPanel
@@ -28,7 +44,7 @@ const RangeFillModal = ({ onClose, rangeFill, show }: Props) => {
       header="Range Fill Options"
     >
       <div className="flex flex-col gap-y-2">
-        <SelectSmall label="Type" id="Type" value={epType} onChange={event => setEpType(event.target.value)}>
+        <SelectSmall label="Type" id="Type" value={episodeType} onChange={event => setEpisodeType(event.target.value)}>
           <option value="Episode">Episode</option>
           <option value="Special">Special</option>
           <option value="Other">Other</option>
@@ -42,13 +58,19 @@ const RangeFillModal = ({ onClose, rangeFill, show }: Props) => {
             type="number"
             value={rangeStart}
             onChange={event => setRangeStart(event.target.value)}
+            onKeyUp={(event) => {
+              if (event.key === 'Enter') handleFill();
+            }}
             className="w-16 px-3 py-1 text-center"
+            autoFocus
           />
         </div>
       </div>
       <div className="flex justify-end gap-x-3 font-semibold">
         <Button onClick={onClose} buttonType="secondary" className="px-5 py-2">Cancel</Button>
-        <Button onClick={handleFill} buttonType="primary" className="px-5 py-2" disabled={!rangeStart}>Fill</Button>
+        <Button onClick={handleFill} buttonType="primary" className="px-5 py-2" disabled={toInteger(rangeStart) <= 0}>
+          Fill
+        </Button>
       </div>
     </ModalPanel>
   );

--- a/src/core/types/utilities/link-files-with-providers.ts
+++ b/src/core/types/utilities/link-files-with-providers.ts
@@ -1,4 +1,4 @@
-import type { AniDBEpisodeType } from '@/core/types/api/episode';
+import type { AniDBEpisodeType, EpisodeTypeValues } from '@/core/types/api/episode';
 import type { FileType, ReleaseInfoType } from '@/core/types/api/file';
 
 export type LinkStateType = 'init' | 'searching' | 'ready' | 'submitting' | 'submitted' | 'fetching';
@@ -17,10 +17,16 @@ export type ManualLinkType = {
   state: LinkStateType;
 };
 
+export type RangeFillType = {
+  episodeType: EpisodeTypeValues;
+  rangeStart: number;
+};
+
 export type CrossReferenceType = {
   seriesId: number;
   episodeId: number;
   episodes: AniDBEpisodeType[];
+  rangeFill?: RangeFillType;
 };
 
 export type TouchableField =

--- a/src/core/utilities/releaseInfoHelpers.ts
+++ b/src/core/utilities/releaseInfoHelpers.ts
@@ -11,6 +11,7 @@ import type {
 
 export const EDITABLE_STATES = new Set<LinkStateType>(['ready', 'init']);
 export const AUTO_MATCH_EPISODE_ID = -1;
+export const RANGE_FILL_EPISODE_ID = -2;
 
 export const isUserEdited = (providerName: string) => providerName.split('+').includes('User');
 

--- a/src/hooks/utilities/useReleaseInfoForm.ts
+++ b/src/hooks/utilities/useReleaseInfoForm.ts
@@ -5,11 +5,12 @@ import { detectShow, findMostCommonShowName } from '@/core/utilities/auto-match-
 import { AUTO_MATCH_EPISODE_ID } from '@/core/utilities/releaseInfoHelpers';
 
 import type { ReleaseGroupType, ReleaseInfoType } from '@/core/types/api/file';
-import type { ManualLinkType, TouchableField } from '@/core/types/utilities/link-files-with-providers';
+import type { ManualLinkType, RangeFillType, TouchableField } from '@/core/types/utilities/link-files-with-providers';
 
 type FormState = {
   selectedSeriesId?: number;
   selectedEpisodeId?: number;
+  rangeFill?: RangeFillType;
   version: ReleaseInfoType['Version'] | '';
   isChaptered?: ReleaseInfoType['IsChaptered'];
   isCreditless?: ReleaseInfoType['IsCreditless'];

--- a/src/pages/utilities/LinkFilesWithProviders.tsx
+++ b/src/pages/utilities/LinkFilesWithProviders.tsx
@@ -5,7 +5,7 @@ import { useLocation } from 'react-router';
 import { mdiLoading } from '@mdi/js';
 import { Icon } from '@mdi/react';
 import { useVirtualizer } from '@tanstack/react-virtual';
-import { find, forEach } from 'lodash';
+import { filter, find, findIndex, forEach } from 'lodash';
 import { useImmer } from 'use-immer';
 import { useToggle } from 'usehooks-ts';
 
@@ -25,6 +25,7 @@ import { detectShow } from '@/core/utilities/auto-match-logic';
 import createLinksFromFiles, {
   AUTO_MATCH_EPISODE_ID,
   EDITABLE_STATES,
+  RANGE_FILL_EPISODE_ID,
   isUserEdited,
 } from '@/core/utilities/releaseInfoHelpers';
 import useNavigateVoid from '@/hooks/useNavigateVoid';
@@ -208,16 +209,45 @@ const LinkFilesWithProviders = () => {
     crossReference?: CrossReferenceType,
   ) => {
     let failedAutoMatchCount = 0;
+    let unfilledRangeFillCount = 0;
 
     setLinks((draft) => {
+      const applyRelease = (link: ManualLinkType, episodeId: number) => {
+        Object.assign(draft[link.id].release, releaseInfo);
+        if (crossReference && episodeId > 0) {
+          draft[link.id].release.CrossReferences = [{
+            AnidbEpisodeID: episodeId,
+            AnidbAnimeID: crossReference.seriesId,
+            PercentageStart: 0,
+            PercentageEnd: 100,
+          }];
+          draft[link.id].state = 'ready';
+        }
+        if (!isUserEdited(draft[link.id].release.ProviderName)) {
+          draft[link.id].release.ProviderName += '+User';
+        }
+      };
+
+      if (crossReference?.episodeId === RANGE_FILL_EPISODE_ID && crossReference.rangeFill) {
+        const items = filter(crossReference.episodes, ['Type', crossReference.rangeFill.episodeType]);
+        const startIndex = findIndex(items, ['EpisodeNumber', crossReference.rangeFill.rangeStart]);
+        const queue = startIndex === -1 ? [] : items.slice(startIndex);
+        let filled = 0;
+        for (const link of selectedRows) {
+          const episode = queue[filled];
+          applyRelease(link, episode?.ID ?? 0);
+          if (episode) filled += 1;
+        }
+        unfilledRangeFillCount = selectedRows.length - filled;
+        return;
+      }
+
       let specials = 0;
       for (const link of selectedRows) {
-        Object.assign(draft[link.id].release, releaseInfo);
-
-        let matchFailed = true;
+        let episodeId = 0;
         if (crossReference) {
-          const { episodeId: selectedEpisodeId, episodes, seriesId } = crossReference;
-          let episodeId = selectedEpisodeId;
+          const { episodeId: selectedEpisodeId, episodes } = crossReference;
+          episodeId = selectedEpisodeId;
           if (episodeId === AUTO_MATCH_EPISODE_ID) {
             const details = detectShow(link.file?.Locations?.[0]?.RelativePath);
             if (details) {
@@ -230,25 +260,11 @@ const LinkFilesWithProviders = () => {
               )?.ID ?? 0;
             }
           }
-          if (episodeId > 0) {
-            draft[link.id].release.CrossReferences = [{
-              AnidbEpisodeID: episodeId,
-              AnidbAnimeID: seriesId,
-              PercentageStart: 0,
-              PercentageEnd: 100,
-            }];
-            matchFailed = false;
-          } else {
+          if (episodeId <= 0) {
             failedAutoMatchCount += 1;
           }
         }
-
-        if (!isUserEdited(draft[link.id].release.ProviderName)) {
-          draft[link.id].release.ProviderName += '+User';
-        }
-        if (!matchFailed) {
-          draft[link.id].state = 'ready';
-        }
+        applyRelease(link, episodeId);
       }
     });
 
@@ -257,6 +273,12 @@ const LinkFilesWithProviders = () => {
         failedAutoMatchCount === 1
           ? 'Failed to auto-match an episode for 1 file'
           : `Failed to auto-match an episode for ${failedAutoMatchCount} files`,
+      );
+    }
+
+    if (unfilledRangeFillCount > 0) {
+      toast.warning(
+        `Only ${selectedRows.length - unfilledRangeFillCount} of ${selectedRows.length} files could be range-filled`,
       );
     }
   };

--- a/src/pages/utilities/UnrecognizedUtilityTabs/LinkFilesTab.tsx
+++ b/src/pages/utilities/UnrecognizedUtilityTabs/LinkFilesTab.tsx
@@ -13,7 +13,7 @@ import {
 } from '@mdi/js';
 import { Icon } from '@mdi/react';
 import cx from 'classnames';
-import { countBy, filter, find, findIndex, forEach, groupBy, map, orderBy, reduce, toInteger, uniqBy } from 'lodash';
+import { countBy, filter, find, findIndex, forEach, groupBy, map, orderBy, reduce, uniqBy } from 'lodash';
 import { useImmer } from 'use-immer';
 
 import Button from '@/components/Input/Button';
@@ -40,6 +40,7 @@ import { getAnidbAnimeLink } from '@/core/util';
 import { detectShow, findMostCommonShowName } from '@/core/utilities/auto-match-logic';
 import useNavigateVoid from '@/hooks/useNavigateVoid';
 
+import type { EpisodeTypeValues } from '@/core/types/api/episode';
 import type { FileType } from '@/core/types/api/file';
 import type { SeriesAniDBSearchResult } from '@/core/types/api/series';
 
@@ -291,14 +292,9 @@ const LinkFilesTab = () => {
     }
   };
 
-  const rangeFill = (rangeStart: string, epType: string) => {
-    if (toInteger(rangeStart) <= 0) {
-      toast.error('Value is not a positive integer.');
-      return;
-    }
-
-    const items = filter(episodeOptions, ['type', epType]);
-    const idx = findIndex(items, ['number', toInteger(rangeStart)]);
+  const handleRangeFill = (episodeType: EpisodeTypeValues, rangeStart: number) => {
+    const items = filter(episodeOptions, ['type', episodeType]);
+    const idx = findIndex(items, ['number', rangeStart]);
     if (idx === -1) {
       toast.error('Unable to find starting episode.');
       return;
@@ -690,7 +686,7 @@ const LinkFilesTab = () => {
           )}
         </div>
       </TransitionDiv>
-      <RangeFillModal show={showRangeFillModal} onClose={closeRangeFill} rangeFill={rangeFill} />
+      <RangeFillModal show={showRangeFillModal} onClose={closeRangeFill} handleRangeFill={handleRangeFill} />
     </>
   );
 };


### PR DESCRIPTION
## Summary

Adds a **Range Fill** option to the Edit Release Info modal in the Link Files With Providers workflow, letting users assign consecutive episodes of a chosen type (Episode/Special/Other/Credits/Trailer) to multiple selected files in one action.

## Changes

- **Range Fill option** in the episode selector (`RANGE_FILL_EPISODE_ID = -2`), selectable from the dropdown or via the `r` hotkey. Label reads `Range Fill (from S3)` once configured.
- **Reusable `RangeFillModal`** (episode type + starting number), now shared with the Unrecognized Files `LinkFilesTab`. Runs in a `nested-modal` scope with `Esc`/`Enter` bindings; the Fill button is disabled until a positive start number is entered.
- **`handleSaveReleaseInfo` refactor** — a shared `applyRelease(link, episodeId)` helper deduplicates the release-patch/cross-reference/`+User` logic across the auto-match, single-episode, and range-fill branches. Range fill iterates selected files in `RelativePath` order and warns when the episode queue runs out before all files are filled.
- **Stale-state hardening** — `rangeFill` is cleared whenever the series selection changes; a missing start episode degrades gracefully instead of silently assigning the last episode.
- **Save gating** — `saveDisabled` now disables the Save button and is also checked in `handleSave` so the `Enter` hotkey is safe.
- **Defensive guards** — `ConfirmationPromptModal`/`AutoSearchReleaseModal`/`EditReleaseInfoModal` now guard their confirm/close handlers against firing while hidden.

## Verification

- `dprint` + `oxlint` clean on all touched files.
- Pre-commit Husky hooks passed.