### PR TITLE
ci: add opencode GitHub workflow (#1442) [no ci]

### DIFF
--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -1,0 +1,29 @@
+name: opencode
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+
+jobs:
+  opencode:
+    if: |
+      contains(github.event.comment.body, '/oc') ||
+      contains(github.event.comment.body, '/opencode')
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Run OpenCode
+        uses: anomalyco/opencode/github@latest
+        env:
+          OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
+        with:
+          model: opencode-go/deepseek-v4-pro


### PR DESCRIPTION
## Description

Adds a GitHub Actions workflow that runs [opencode](https://opencode.ai/docs/github) on `/oc` or `/opencode` comments in issues and PR review comments.

- Triggers on `issue_comment` and `pull_request_review_comment` (created)
- Uses the `anomalyco/opencode/github@latest` action with model `opencode-go/deepseek-v4-pro`
- Authenticates via the OpenCode gateway using an `OPENCODE_API_KEY` repo secret
- Uses OIDC (`id-token: write`) for GitHub App token exchange — no PAT required

## Setup required before first use

1. Add `OPENCODE_API_KEY` to repository secrets (key from https://opencode.ai/auth)
2. Install the [OpenCode GitHub App](https://github.com/apps/opencode) if not already installed