### PR TITLE
fix(renamer): simplify configEdited to only compare when renamer has config

### DIFF
--- a/src/pages/utilities/Renamer.tsx
+++ b/src/pages/utilities/Renamer.tsx
@@ -344,7 +344,7 @@ const Renamer = () => {
   const [showPresetModal, togglePresetModal] = useToggle(false);
   const [presetRename, setPresetRename] = useState(false);
 
-  const configEdited = configQuery.isSuccess ? !isEqual(configQuery.data ?? {}, newConfig) : true;
+  const configEdited = renamerHasConfig && !isEqual(configQuery.data, newConfig);
   const configInitialized = !isEqual({}, newConfig);
 
   const fetchPreviewPage = async (index: number) => {


### PR DESCRIPTION
## Description
Follow-up to #1441.

Simplifies the `configEdited` check in the Renamer page:

```tsx
const configEdited = renamerHasConfig && !isEqual(configQuery.data, newConfig);
```

- For renamers **without** config, `configEdited` is always `false`, so renaming is never blocked (the original bug from #1441).
- For renamers **with** config, comparison only happens once the config query resolves; while pending, `isEqual(undefined, ...)` is false so renaming stays blocked until the config loads.