### PR TITLE
ci: grant actions:write so opencode cache saves succeed (#1444) [no ci]

### DIFF
--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -14,6 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       id-token: write
+      actions: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6


### PR DESCRIPTION
## Description

Follow-up to #1442.

The opencode workflow job only granted `id-token: write`, leaving the job's `GITHUB_TOKEN` with no writable scopes. The internal `actions/cache` step (which caches the opencode binary) therefore failed every run with:

```
Cache reservation failed: cache write denied: token has no writable scopes
Failed to save: Unable to reserve cache with key opencode-Linux-X64-v1.18.21
```

Adds `actions: write` to the job permissions so the binary cache can actually be saved between runs. No other changes — opencode still posts via the OpenCode GitHub App (OIDC), which doesn't need any additional scopes.