### PR TITLE
fix(series): stop tab clicks from resetting scroll position

### DIFF
--- a/src/components/Collection/Credits/CreditsStaffVirtualizer.tsx
+++ b/src/components/Collection/Credits/CreditsStaffVirtualizer.tsx
@@ -30,6 +30,7 @@ const StaffPanelVirtualizer = ({ castArray, mode }: { castArray: SeriesCast[], m
     count: castArray.length,
     getScrollElement: () => scrollRef.current,
     estimateSize: () => dynamicCardSize.y,
+    initialOffset: () => scrollRef.current?.scrollTop ?? 0,
     overscan,
     lanes,
     gap: dynamicCardSize.gap,

--- a/src/core/router/index.tsx
+++ b/src/core/router/index.tsx
@@ -118,7 +118,7 @@ const router = sentryCreateBrowserRouter(
               <Route path="overview" element={<SeriesOverview />} />
               <Route path="episodes" element={<SeriesEpisodes />} />
               <Route path="credits" element={<SeriesCredits />} />
-              <Route path="images" element={<Navigate to="posters" replace />} />
+              <Route path="images" element={<SeriesImages />} />
               <Route path="images/:imageType" element={<SeriesImages />} />
               <Route path="files" element={<SeriesFileSummary />} />
               <Route path="tags" element={<SeriesTags />} />

--- a/src/pages/collection/series/SeriesEpisodes.tsx
+++ b/src/pages/collection/series/SeriesEpisodes.tsx
@@ -134,6 +134,7 @@ const SeriesEpisodes = () => {
     count: episodeCount,
     getScrollElement: () => scrollRef.current,
     estimateSize: () => 370, // 370px is the minimum height of a loaded row
+    initialOffset: () => scrollRef.current?.scrollTop ?? 0,
     overscan: 5,
     gap: 16,
   });

--- a/src/pages/collection/series/SeriesImages.tsx
+++ b/src/pages/collection/series/SeriesImages.tsx
@@ -61,7 +61,7 @@ const SeriesImages = () => {
   const { scrollRef, series } = useOutletContext<SeriesContextType>();
   const navigate = useNavigateVoid();
 
-  const tabType = (capitalize(imageType) ?? 'Posters') as ImageTabType;
+  const tabType = (imageType ? capitalize(imageType) : 'Posters') as ImageTabType;
 
   const { fetchNextPage, isFetchingNextPage, ...imagesQuery } = useSeriesImagesInfiniteQuery(
     series.IDs.ID,
@@ -124,16 +124,16 @@ const SeriesImages = () => {
 
   const { height: itemHeight, width: itemWidth } = imageItemSize[tabType];
 
-  const itemsPerRow = Math.max(
-    1,
-    Math.floor((gridContainerBounds.width / pxPerRem + itemGap) / (itemWidth + itemGap)),
-  );
-  const rowCount = Math.ceil(imagesTotal / itemsPerRow);
+  const itemsPerRow = gridContainerBounds.width > 0
+    ? Math.max(1, Math.floor((gridContainerBounds.width / pxPerRem + itemGap) / (itemWidth + itemGap)))
+    : 0;
+  const rowCount = itemsPerRow > 0 ? Math.ceil(imagesTotal / itemsPerRow) : 0;
 
   const virtualizer = useVirtualizer({
     count: rowCount,
     getScrollElement: () => scrollRef.current,
-    estimateSize: () => (itemHeight + itemGap) * pxPerRem,
+    estimateSize: () => itemHeight * pxPerRem,
+    initialOffset: () => scrollRef.current?.scrollTop ?? 0,
     overscan: 4,
     gap: 24,
   });

--- a/src/pages/collection/series/TmdbLinking.tsx
+++ b/src/pages/collection/series/TmdbLinking.tsx
@@ -133,6 +133,7 @@ const TmdbLinking = () => {
     count: episodeCount,
     getScrollElement: () => scrollRef.current,
     estimateSize,
+    initialOffset: () => scrollRef.current?.scrollTop ?? 0,
     overscan: 10,
     gap: 8,
   });


### PR DESCRIPTION
## Summary
- Episodes, Credits, Images, and the TMDB linking tab each mounted a fresh `useVirtualizer()` bound to the page-level scroll container on every route change, which forced `scrollTop` to 0 on mount. Each now seeds `initialOffset` from the container's current scroll position.
- Removed an extra redirect hop on the Images tab (`images` -> `posters`) that briefly collapsed the page content and clipped the scroll position.
- Fixed an `estimateSize` in the Images tab that double-counted the row gap (already handled by the virtualizer's `gap` option), which caused a further ~16px correction once rows were measured against the estimate.

Fixes #1094

## Test plan
- [x] `pnpm lint` (dprint, oxlint, stylelint via pre-commit)
- [x] `tsc --noEmit`
- [x] Manually verified in the browser: scroll down in Episodes/Credits/Images, switch tabs and back, scroll position is preserved (previously reset to top / jumped ~15px on Images)