### PR TITLE
ci: upgrade actions to v7 and consolidate pnpm/node setup

### DIFF
--- a/.github/workflows/Lint-PR.yml
+++ b/.github/workflows/Lint-PR.yml
@@ -10,22 +10,14 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
-      - name: Install pnpm
-        uses: pnpm/action-setup@v6
+      - name: Install pnpm and Node.js
+        uses: pnpm/setup@v1
         with:
           version: 11
-          run_install: false
-
-      - name: Install Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: 24
-          cache: 'pnpm'
-
-      - name: Install dependencies
-        run: pnpm install
+          runtime: node@24
+          cache: true
 
       - name: Lint
         run: pnpm lint --quiet

--- a/.github/workflows/Release-Dev-Auto.yml
+++ b/.github/workflows/Release-Dev-Auto.yml
@@ -14,24 +14,16 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
-      - name: Install pnpm
-        uses: pnpm/action-setup@v6
+      - name: Install pnpm and Node.js
+        uses: pnpm/setup@v1
         with:
           version: 11
-          run_install: false
-
-      - name: Install Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: 24
-          cache: 'pnpm'
-
-      - name: Install dependencies
-        run: pnpm install
+          runtime: node@24
+          cache: true
 
       - name: Determine bump type
         uses: zwaldowski/match-label-action@v6

--- a/.github/workflows/Release-Manual.yml
+++ b/.github/workflows/Release-Manual.yml
@@ -49,7 +49,7 @@ jobs:
         if: ${{ steps.regex-match1.outputs.match == '' && steps.regex-match2.outputs.match == '' }}
 
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.event.inputs.ref }}
           fetch-depth: 0
@@ -62,20 +62,12 @@ jobs:
         id: prev-tag
         run: echo "tag=$(git describe --tags --abbrev=0)" >> $GITHUB_OUTPUT
 
-      - name: Install pnpm
-        uses: pnpm/action-setup@v6
+      - name: Install pnpm and Node.js
+        uses: pnpm/setup@v1
         with:
           version: 11
-          run_install: false
-
-      - name: Install Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: 24
-          cache: 'pnpm'
-
-      - name: Install dependencies
-        run: pnpm install
+          runtime: node@24
+          cache: true
 
       - name: Lint
         run: pnpm lint --quiet

--- a/.github/workflows/Update-Manifest.yml
+++ b/.github/workflows/Update-Manifest.yml
@@ -50,7 +50,7 @@ jobs:
           echo "min_server_version=$MIN_SERVER" >> "$GITHUB_OUTPUT"
 
       - name: Checkout metadata branch
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: metadata
           persist-credentials: true

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -38,7 +38,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -17,10 +17,17 @@ jobs:
       actions: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
           persist-credentials: false
+
+      - name: Install pnpm and Node.js
+        uses: pnpm/setup@v1
+        with:
+          version: 11
+          runtime: node@24
+          cache: true
 
       - name: Run OpenCode
         uses: anomalyco/opencode/github@latest


### PR DESCRIPTION
## Changes

- **actions/checkout**: v6 → v7 across all workflows
- **pnpm/node setup**: Replaced 3-step setup (`pnpm/action-setup` + `actions/setup-node` + `pnpm install`) with consolidated `pnpm/setup@v1`

## Affected workflows

- `Lint-PR.yml`
- `Release-Dev-Auto.yml`
- `Release-Manual.yml`
- `Update-Manifest.yml`
- `codeql-analysis.yml`
- `opencode.yml`

## Benefits

- **Simpler**: One action instead of three for pnpm + Node.js setup
- **Faster**: `pnpm/setup@v1` installs pnpm as a standalone binary and can install Node.js in the same step
- **Modern**: Uses latest action versions with Node 24 runtime support