### PR TITLE
feat: Split file path display in Link Files tab

### DIFF
--- a/src/components/Utilities/DuplicateFiles/DuplicatesInfo.tsx
+++ b/src/components/Utilities/DuplicateFiles/DuplicatesInfo.tsx
@@ -8,6 +8,7 @@ import Button from '@/components/Input/Button';
 import { useDeleteFileLocationMutation } from '@/core/react-query/file/mutations';
 import { useManagedFoldersQuery } from '@/core/react-query/managed-folder/queries';
 import { invalidateQueries } from '@/core/react-query/queryClient';
+import { extractFileNameFromPath } from '@/core/util';
 import useToggleModalKeybinds from '@/hooks/useToggleModalKeybinds';
 
 import type { FileLocationType, FileType } from '@/core/types/api/file';
@@ -35,9 +36,7 @@ const DuplicatesInfo = ({ file, location }: Props) => {
   useToggleModalKeybinds(!confirmDelete, 'modal');
 
   const path = location.RelativePath ?? '';
-  const match = /[/\\](?=[^/\\]*$)/g.exec(path);
-  const relativePath = match ? path?.substring(0, match.index) : 'Root Level';
-  const fileName = path?.split(/[/\\]/g).pop();
+  const { fileName, relativePath } = extractFileNameFromPath(path);
   const folderName = managedFoldersQuery.data?.find(
     folder => folder.ID === location.ManagedFolderID,
   )?.Name ?? '';

--- a/src/components/Utilities/LinkFilesWithProvider/SelectedFilesModal.tsx
+++ b/src/components/Utilities/LinkFilesWithProvider/SelectedFilesModal.tsx
@@ -2,6 +2,7 @@ import { useHotkeys } from 'react-hotkeys-hook';
 
 import ModalPanel from '@/components/Panels/ModalPanel';
 import { useManagedFoldersQuery } from '@/core/react-query/managed-folder/queries';
+import { extractFileNameFromPath } from '@/core/util';
 import useToggleModalKeybinds from '@/hooks/useToggleModalKeybinds';
 
 import type { FileType } from '@/core/types/api/file';
@@ -31,9 +32,7 @@ const SelectedFilesModal = ({ files, onClose, show }: Props) => {
         {files.map((file) => {
           const location = file.Locations[0];
           const path = location?.RelativePath ?? '';
-          const match = /[/\\](?=[^/\\]*$)/g.exec(path);
-          const relativePath = match ? path.substring(0, match.index) : 'Root Level';
-          const fileName = path.split(/[/\\]/g).pop() ?? `<missing file path for ${file.ID}>`;
+          const { fileName, relativePath } = extractFileNameFromPath(path);
           const folderName = managedFoldersQuery.data?.find(
             folder => folder.ID === location?.ManagedFolderID,
           )?.Name ?? '';
@@ -51,7 +50,7 @@ const SelectedFilesModal = ({ files, onClose, show }: Props) => {
                 &nbsp;-&nbsp;
                 {relativePath}
               </span>
-              <span className="line-clamp-1 truncate text-sm">{fileName}</span>
+              <span className="line-clamp-1 truncate text-sm">{fileName ?? `<missing file path for ${file.ID}>`}</span>
             </div>
           );
         })}

--- a/src/components/Utilities/LinkFilesWithProvider/VideoMetadata.tsx
+++ b/src/components/Utilities/LinkFilesWithProvider/VideoMetadata.tsx
@@ -1,3 +1,5 @@
+import { extractFileNameFromPath } from '@/core/util';
+
 import type { ReleaseSourceValues } from '@/core/types/api/file';
 import type { ManualLinkType } from '@/core/types/utilities/link-files-with-providers';
 
@@ -13,8 +15,7 @@ const parseReleaseSource = (releaseSource: ReleaseSourceValues) => {
 const VideoMetadata = ({ link }: { link: ManualLinkType }) => {
   const { file } = link;
   const path = file.Locations[0]?.RelativePath ?? '';
-  const match = /[/\\](?=[^/\\]*$)/g.exec(path);
-  const relativePath = match ? path?.substring(0, match.index) : 'Root Level';
+  const { fileName, relativePath } = extractFileNameFromPath(path);
 
   return (
     <div className="flex flex-col gap-2 border-y border-panel-border text-sm">
@@ -29,7 +30,7 @@ const VideoMetadata = ({ link }: { link: ManualLinkType }) => {
             {relativePath}
           </span>
           <span className="line-clamp-1">
-            {path?.split(/[/\\]/g).pop()}
+            {fileName}
           </span>
         </div>
       </div>

--- a/src/components/Utilities/constants.tsx
+++ b/src/components/Utilities/constants.tsx
@@ -2,7 +2,7 @@ import type { ReactNode } from 'react';
 import { find } from 'lodash';
 import prettyBytes from 'pretty-bytes';
 
-import { dayjs } from '@/core/util';
+import { dayjs, extractFileNameFromPath } from '@/core/util';
 
 import type { EpisodeType } from '@/core/types/api/episode';
 import type { FileType } from '@/core/types/api/file';
@@ -54,8 +54,7 @@ export const fileNameColumn: UtilityHeaderType<FileType> = {
   className: 'line-clamp-2 grow basis-0 overflow-hidden',
   item: (file) => {
     const path = file.Locations[0]?.RelativePath ?? '';
-    const match = /[/\\](?=[^/\\]*$)/g.exec(path);
-    const relativePath = match ? path?.substring(0, match.index) : 'Root Level';
+    const { fileName, relativePath } = extractFileNameFromPath(path);
     return (
       <div
         className="flex flex-col"
@@ -67,7 +66,7 @@ export const fileNameColumn: UtilityHeaderType<FileType> = {
           {relativePath}
         </span>
         <span className="line-clamp-1">
-          {path?.split(/[/\\]/g).pop()}
+          {fileName}
         </span>
       </div>
     );

--- a/src/core/util.ts
+++ b/src/core/util.ts
@@ -150,3 +150,13 @@ export const handleShiftSelect = (params: {
 
 /** Root font size in px, read once from the document. */
 export const pxPerRem = parseFloat(getComputedStyle(document.documentElement).fontSize);
+
+export const extractFileNameFromPath = (path: string) => {
+  const match = /[/\\](?=[^/\\]*$)/g.exec(path);
+  const relativePath = match ? path.substring(0, match.index) : 'Root Level';
+  const fileName = path.split(/[/\\]/g).pop();
+  return {
+    fileName,
+    relativePath,
+  };
+};

--- a/src/pages/utilities/Renamer.tsx
+++ b/src/pages/utilities/Renamer.tsx
@@ -122,13 +122,11 @@ const getResultColumn = (
     }
 
     const path = result.RelativePath ?? '';
-    const match = /[/\\](?=[^/\\]*$)/g.exec(path);
-    const relativePath = match ? path?.substring(0, match.index) : 'Root Level';
+    const { fileName, relativePath } = extractFileNameFromPath(path);
     const managedFolder = find(
       managedFolders,
       { ID: result.ManagedFolderID ?? -1 },
     )?.Name ?? '<Unknown>';
-    const fileName = path ? path?.split(/[/\\]/g).pop() : 'No change!';
 
     return (
       <div
@@ -197,15 +195,14 @@ const getStatusColumn = (
 
     if (result) {
       const path = file.Locations[0]?.RelativePath ?? '';
-      const match = /[/\\](?=[^/\\]*$)/g.exec(path);
-      const relativePath = match ? path?.substring(0, match.index) : 'Root Level';
+      const { relativePath } = extractFileNameFromPath(path);
       const managedFolder = find(
         managedFolders,
         { ID: file?.Locations[0]?.ManagedFolderID ?? -1 },
       )?.Name ?? '<Unknown>';
 
       const newPath = result.RelativePath ?? '';
-      const newRelativePath = match ? newPath?.substring(0, match.index) : 'Root Level';
+      const { relativePath: newRelativePath } = extractFileNameFromPath(newPath);
       const newManagedFolder = find(
         managedFolders,
         { ID: result?.ManagedFolderID ?? -1 },

--- a/src/pages/utilities/Renamer.tsx
+++ b/src/pages/utilities/Renamer.tsx
@@ -50,6 +50,7 @@ import { useSettingsQuery } from '@/core/react-query/settings/queries';
 import { clearFiles, clearResults, removeFiles } from '@/core/slices/utilities/renamer';
 import { useDispatch, useSelector } from '@/core/store';
 import toast from '@/core/toast';
+import { extractFileNameFromPath } from '@/core/util';
 import useRowSelection from '@/hooks/useRowSelection';
 
 import type { UtilityHeaderType } from '@/components/Utilities/constants';
@@ -67,8 +68,7 @@ const getFileColumn = (managedFolders: ManagedFolderType[]) => ({
   className: 'line-clamp-2 grow basis-0 overflow-hidden',
   item: (file) => {
     const path = file.Locations[0]?.RelativePath ?? '';
-    const match = /[/\\](?=[^/\\]*$)/g.exec(path);
-    const relativePath = match ? path?.substring(0, match.index) : 'Root Level';
+    const { fileName, relativePath } = extractFileNameFromPath(path);
     const managedFolder = find(
       managedFolders,
       { ID: file?.Locations[0]?.ManagedFolderID ?? -1 },
@@ -84,7 +84,7 @@ const getFileColumn = (managedFolders: ManagedFolderType[]) => ({
           {`${managedFolder} - ${relativePath}`}
         </span>
         <span className="line-clamp-1 break-all">
-          {path?.split(/[/\\]/g).pop()}
+          {fileName}
         </span>
       </div>
     );

--- a/src/pages/utilities/UnrecognizedUtilityTabs/LinkFilesTab.tsx
+++ b/src/pages/utilities/UnrecognizedUtilityTabs/LinkFilesTab.tsx
@@ -36,21 +36,13 @@ import {
 } from '@/core/react-query/series/mutations';
 import { useSeriesAniDBEpisodesQuery, useSeriesEpisodesInfiniteQuery } from '@/core/react-query/series/queries';
 import toast from '@/core/toast';
-import { getAnidbAnimeLink } from '@/core/util';
+import { extractFileNameFromPath, getAnidbAnimeLink } from '@/core/util';
 import { detectShow, findMostCommonShowName } from '@/core/utilities/auto-match-logic';
 import useNavigateVoid from '@/hooks/useNavigateVoid';
 
 import type { EpisodeTypeValues } from '@/core/types/api/episode';
 import type { FileType } from '@/core/types/api/file';
 import type { SeriesAniDBSearchResult } from '@/core/types/api/series';
-
-const splitFilePath = (path: string) => {
-  const separatorIndex = Math.max(path.lastIndexOf('/'), path.lastIndexOf('\\'));
-  return {
-    filename: separatorIndex === -1 ? path : path.slice(separatorIndex + 1),
-    relativePath: separatorIndex === -1 ? 'Root Level' : path.slice(0, separatorIndex),
-  };
-};
 
 type ManualLink = {
   LinkID: number;
@@ -507,7 +499,7 @@ const LinkFilesTab = () => {
     map(orderedLinks, (link, idx) => {
       const file = find(selectedRows, ['ID', link.FileID]);
       const path = file?.Locations?.[0]?.RelativePath ?? '<missing file path>';
-      const { filename, relativePath } = splitFilePath(path);
+      const { fileName, relativePath } = extractFileNameFromPath(path);
 
       return (
         <div
@@ -518,13 +510,13 @@ const LinkFilesTab = () => {
           key={`${link.FileID}-${link.EpisodeID}-${idx}-static`}
           onClick={() => updateSelectedLink(idx)}
           data-tooltip-id="tooltip"
-          data-tooltip-content={filename}
+          data-tooltip-content={path}
         >
           <span className="line-clamp-1 text-sm font-semibold opacity-65">
             {relativePath}
           </span>
           <span className="line-clamp-1">
-            {filename}
+            {fileName}
           </span>
         </div>
       );
@@ -534,12 +526,12 @@ const LinkFilesTab = () => {
     reduce<ManualLink, ReactNode[]>(orderedLinks, (result, link, idx) => {
       const file = find(selectedRows, ['ID', link.FileID]);
       const path = file?.Locations?.[0]?.RelativePath ?? '<missing file path>';
-      const { filename, relativePath } = splitFilePath(path);
+      const { fileName, relativePath } = extractFileNameFromPath(path);
       const isSameFile = idx > 0 && orderedLinks[idx - 1].FileID === link.FileID;
       result.push(
         <div
           className={cx([
-            'col-start-1 w-full cursor-pointer items-center rounded-lg border border-panel-border p-4 leading-5 transition-colors',
+            'col-start-1 w-full cursor-pointer rounded-lg border border-panel-border p-4 leading-5 transition-colors',
             idx % 2 === 0 ? 'bg-panel-background' : 'bg-panel-background-alt',
             selectedLink === idx && 'border-panel-text-primary',
           ])}
@@ -547,13 +539,13 @@ const LinkFilesTab = () => {
           data-file-id={link.FileID}
           onClick={() => updateSelectedLink(idx)}
           data-tooltip-id="tooltip"
-          data-tooltip-content={filename}
+          data-tooltip-content={path}
         >
           <span className="line-clamp-1 text-sm font-semibold opacity-65">
             {relativePath}
           </span>
           <span className="line-clamp-1">
-            {filename}
+            {fileName}
             {isSameFile && <Icon path={mdiLink} size={1} className="ml-auto text-panel-text-important" />}
           </span>
         </div>,

--- a/src/pages/utilities/UnrecognizedUtilityTabs/LinkFilesTab.tsx
+++ b/src/pages/utilities/UnrecognizedUtilityTabs/LinkFilesTab.tsx
@@ -44,6 +44,14 @@ import type { EpisodeTypeValues } from '@/core/types/api/episode';
 import type { FileType } from '@/core/types/api/file';
 import type { SeriesAniDBSearchResult } from '@/core/types/api/series';
 
+const splitFilePath = (path: string) => {
+  const separatorIndex = Math.max(path.lastIndexOf('/'), path.lastIndexOf('\\'));
+  return {
+    filename: separatorIndex === -1 ? path : path.slice(separatorIndex + 1),
+    relativePath: separatorIndex === -1 ? 'Root Level' : path.slice(0, separatorIndex),
+  };
+};
+
 type ManualLink = {
   LinkID: number;
   FileID: number;
@@ -499,9 +507,10 @@ const LinkFilesTab = () => {
     map(orderedLinks, (link, idx) => {
       const file = find(selectedRows, ['ID', link.FileID]);
       const path = file?.Locations?.[0]?.RelativePath ?? '<missing file path>';
+      const { filename, relativePath } = splitFilePath(path);
+
       return (
         <div
-          title={path}
           className={cx([
             'w-full rounded-lg border border-panel-border p-4 leading-5 odd:bg-panel-background-alt even:bg-panel-background',
             selectedLink === idx && 'border-panel-text-primary',
@@ -509,11 +518,14 @@ const LinkFilesTab = () => {
           key={`${link.FileID}-${link.EpisodeID}-${idx}-static`}
           onClick={() => updateSelectedLink(idx)}
           data-tooltip-id="tooltip"
-          data-tooltip-content={path}
+          data-tooltip-content={filename}
         >
-          <div className="line-clamp-1">
-            {path}
-          </div>
+          <span className="line-clamp-1 text-sm font-semibold opacity-65">
+            {relativePath}
+          </span>
+          <span className="line-clamp-1">
+            {filename}
+          </span>
         </div>
       );
     });
@@ -522,12 +534,12 @@ const LinkFilesTab = () => {
     reduce<ManualLink, ReactNode[]>(orderedLinks, (result, link, idx) => {
       const file = find(selectedRows, ['ID', link.FileID]);
       const path = file?.Locations?.[0]?.RelativePath ?? '<missing file path>';
+      const { filename, relativePath } = splitFilePath(path);
       const isSameFile = idx > 0 && orderedLinks[idx - 1].FileID === link.FileID;
       result.push(
         <div
-          title={path}
           className={cx([
-            'col-start-1 flex w-full cursor-pointer items-center rounded-lg border border-panel-border p-4 leading-5 transition-colors',
+            'col-start-1 w-full cursor-pointer items-center rounded-lg border border-panel-border p-4 leading-5 transition-colors',
             idx % 2 === 0 ? 'bg-panel-background' : 'bg-panel-background-alt',
             selectedLink === idx && 'border-panel-text-primary',
           ])}
@@ -535,12 +547,15 @@ const LinkFilesTab = () => {
           data-file-id={link.FileID}
           onClick={() => updateSelectedLink(idx)}
           data-tooltip-id="tooltip"
-          data-tooltip-content={path}
+          data-tooltip-content={filename}
         >
-          <div className="line-clamp-1">
-            {path}
+          <span className="line-clamp-1 text-sm font-semibold opacity-65">
+            {relativePath}
+          </span>
+          <span className="line-clamp-1">
+            {filename}
             {isSameFile && <Icon path={mdiLink} size={1} className="ml-auto text-panel-text-important" />}
-          </div>
+          </span>
         </div>,
       );
       if (episodes.length > 0) {


### PR DESCRIPTION
Separate the relative path and filename to improve readability of file entries. (Same as in unrecognized files tab)
Tooltips now also display only the filename.

From:
<img width="1862" height="337" alt="image" src="https://github.com/user-attachments/assets/501ae0ce-bd87-433c-8c1d-87973583ce85" />

To:
<img width="1866" height="367" alt="image" src="https://github.com/user-attachments/assets/cf3d4cae-9e35-4795-b039-0b787b000b5f" />

(and after duplicate entry)
From:
<img width="1846" height="140" alt="image" src="https://github.com/user-attachments/assets/e8602f05-8cdf-4486-aee1-858493dd1bff" />

To:
<img width="1831" height="168" alt="image" src="https://github.com/user-attachments/assets/cee3af08-8616-4561-867e-958de0abeb0c" />
