### PR TITLE
ci(opencode): skip bot comments and require write access before running (#1449) [no ci]

### DIFF
--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -8,9 +8,17 @@ on:
 
 jobs:
   opencode:
-    if: |
-      contains(github.event.comment.body, '/oc') ||
-      contains(github.event.comment.body, '/opencode')
+    if: |-
+      github.event.comment.user.type != 'Bot' &&
+      (
+        github.event.comment.author_association == 'OWNER' ||
+        github.event.comment.author_association == 'MEMBER' ||
+        github.event.comment.author_association == 'COLLABORATOR'
+      ) &&
+      (
+        contains(github.event.comment.body, '/oc') ||
+        contains(github.event.comment.body, '/opencode')
+      )
     runs-on: ubuntu-latest
     permissions:
       id-token: write


### PR DESCRIPTION
## Problem

The `opencode` workflow re-triggered itself after every successful run. The agent's summary comments contain URLs like `https://opencode.ai/s/...` and `.../opencode-share/...`, and the substring `/oc` inside `/opencode-share` matched the trigger condition, so the bot's own comment started a second run. That run failed because the bot's `GITHUB_TOKEN` has no write access, producing noisy comments like:

> User opencode-agent[bot] does not have write permissions

Separately, comments from users without write access (e.g. #1448) started a runner that was then rejected by the OpenCode action's built-in permission check — a wasted failed run.

## Fix

- Skip comments authored by bots (`github.event.comment.user.type != 'Bot'`) so agents can't invoke agents.
- Only run for `OWNER` / `MEMBER` / `COLLABORATOR` commenters, matching what the OpenCode action would accept anyway — non-maintainer invocations now skip silently instead of burning a failed run.

## Verification

- Confirmed via [workflow runs](https://github.com/ShokoAnime/Shoko-WebUI/actions) that every failure run was triggered by `opencode-agent[bot]` immediately after its own summary comment.
- Trigger conditions only; no job steps changed.