### PR TITLE
fix(auto-match): recognize web-dl filenames with a trailing native title

### DIFF
--- a/src/core/utilities/auto-match-regexes.ts
+++ b/src/core/utilities/auto-match-regexes.ts
@@ -207,6 +207,13 @@ try {
       transform: defaultTransform,
     },
     {
+      name: 'trailing-native-title',
+      // Catches releases (e.g. CR) that append a native/romaji title after the codec, which no other rule terminates before.
+      regex:
+        /^(?:[{[(](?<releaseGroup>[^)}\]]+)[)}\]][\s_.]*)?(?<showName>[^\n]+?(?: \((?<year>(?:19|20)\d{2})\))?)(?:- ?)? S(?<season>\d+)E(?<episode>\d+)(?:v(?<version>\d+))? (?<resolution>\d{3,4}p) .+\.(?<extension>[a-zA-Z0-9_\-+]+)$/id,
+      transform: defaultTransform,
+    },
+    {
       name: 'default',
       regex:
         // oxlint-disable-next-line no-useless-escape


### PR DESCRIPTION
**Current behavior:** When importing a file AniDB can't hash-match, Shoko drops it into the Unrecognized Files list for manual identification. Opening that file's search in the WebUI pre-fills the search box - but for filenames like `[AnoZu] I Want to Love You Till Your Dying Day S01E08 1080p CR WEB-DL AAC 2.0 H.264  Kimi ga Shinu made Koi wo Shitai.mkv` (a common Crunchyroll web-dl pattern: no release-group suffix, native/romaji title appended after the codec tags), the client-side filename parser (`detectShow()` in `auto-match-regexes.ts`) fails to extract a show name at all - none of the existing rules terminate before that trailing native title. When parsing fails, the search box falls back to the **entire raw filename** verbatim, group tag, resolution, codec, native title and all, instead of just the show name. 

Searching AniDB with that raw string either returns nothing useful or matches the wrong entry (often the native-title show instead of the English one), so on every file matching this pattern the user has to manually delete the noise and retype the correct show name before search works.

**Expected behavior:** The search box should pre-fill with just the clean show name (`I Want to Love You Till Your Dying Day`), so the search resolves to the correct show without any manual editing.

**What this PR adds:** a new `trailing-native-title` rule, placed before `default`, that extracts `[Group]? ShowName (year)? [- ]SxxEyy <resolution> <discarded rest>.ext` and stops before the trailing native title. It also:
- Handles an optional leading `[Group]` tag and an optional `(year)` in the show name, keeping both consistent with how the existing `default` rule reports them.
- Handles an optional `-` separator before the season marker (e.g. `Show Title - S01E08` or `Show Title- S01E08`), matching the sibling `raws-1` rule's behavior.
- Leaves CRC tags (bracketed or parenthesized) alone - they're still extracted correctly regardless of position.

Verified against real on-disk files and a 146-file sample of already-recognized library files (no regressions).

**Correction (2026-08-25):** the dash-separator handling originally required a leading space before the `-` (`(?: -)?`), which would leave a dangling trailing hyphen in showName for a filename like `Show Name- S01E08 ...` (dash attached directly, no space). Updated to `(?:- ?)?` to match `raws-1`'s more lenient handling - per @harshithmohan/opencode-agent's review.

Before:

<img width="1506" height="168" alt="image" src="https://github.com/user-attachments/assets/c40f1330-e069-4351-9eac-8ffb21ed45ee" />

After:

<img width="1524" height="194" alt="image" src="https://github.com/user-attachments/assets/47eab307-a250-46fc-8912-b7e25616ee5d" />
