### PR TITLE
fix: improve API error handling (readable messages, toast dedup, 401 logout, retry allowlist)

### DIFF
--- a/src/core/axios.ts
+++ b/src/core/axios.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/react';
 import { create } from 'axios';
 
+import Events from '@/core/events';
 import store from '@/core/store';
 import { isDebug } from '@/core/util';
 
@@ -87,6 +88,24 @@ const unwrapResponse = (response: AxiosResponse) => {
 
 const handleResponseError = (error: AxiosError) => {
   addApiBreadcrumb(error.config, (error.response as AxiosResponse | undefined)?.data, error.response?.status, 'error');
+
+  // Log out when an authenticated Shoko API request is rejected with 401 (eg. an invalid or revoked apikey).
+  // Guards:
+  // - `AUTH_URL_PATTERN` excludes auth endpoints themselves - failed logins also return 401.
+  // - Path check excludes Plex requests (/plex), which use their own authentication.
+  // - `apikey` check ensures this fires only while logged in, and therefore at most once per session.
+  const status = error.response?.status;
+  const url = error.config?.url ?? '';
+  const fullPath = `${error.config?.baseURL ?? ''}${url}`;
+  if (
+    status === 401
+    && !AUTH_URL_PATTERN.test(url)
+    && fullPath.startsWith('/api')
+    && store.getState().apiSession.apikey
+  ) {
+    store.dispatch({ type: Events.AUTH_LOGOUT });
+  }
+
   return Promise.reject(error);
 };
 

--- a/src/core/react-query/queryClient.ts
+++ b/src/core/react-query/queryClient.ts
@@ -1,8 +1,6 @@
 import { MutationCache, QueryClient } from '@tanstack/react-query';
 import { isAxiosError } from 'axios';
 
-import Events from '@/core/events';
-import store from '@/core/store';
 import toast from '@/core/toast';
 
 import type { QueryKey } from '@tanstack/react-query';
@@ -61,6 +59,20 @@ const processError = (error: AxiosError | Error) => {
   };
 };
 
+const RETRY_LIMIT = 4;
+// Transient client-side failures worth retrying (server will accept the same request later).
+const RETRYABLE_STATUSES = new Set([408, 425, 429]);
+
+// Retries only transient failures: network errors (no response), request timeouts,
+// rate limiting, and server errors. Other client errors (4xx) fail identically on
+// retry and are given up immediately.
+const shouldRetryQuery = (failureCount: number, status: number) => {
+  if (failureCount >= RETRY_LIMIT) return false;
+  // status 0 = network error / no HTTP response
+  if (status === 0) return true;
+  return status >= 500 || RETRYABLE_STATUSES.has(status);
+};
+
 const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
@@ -69,15 +81,7 @@ const queryClient = new QueryClient({
       retry: (failureCount, error: AxiosError | Error) => {
         const { header, message, status } = processError(error);
 
-        if (
-          isAxiosError(error) && (error.request as XMLHttpRequest).responseURL.endsWith('/Settings')
-          && status === 401
-        ) {
-          store.dispatch({ type: Events.AUTH_LOGOUT });
-          return false;
-        }
-
-        if (status !== 404 && failureCount < 4) return true; // 1 initial request + retry 4 times
+        if (shouldRetryQuery(failureCount, status)) return true; // 1 initial request + retry up to 4 times
 
         // Deduplicates identical error toasts: react-toastify skips a new toast while
         // one with the same `toastId` is still active.

--- a/src/core/react-query/queryClient.ts
+++ b/src/core/react-query/queryClient.ts
@@ -79,7 +79,10 @@ const queryClient = new QueryClient({
 
         if (status !== 404 && failureCount < 4) return true; // 1 initial request + retry 4 times
 
-        toast.error(header, message);
+        // Deduplicates identical error toasts: react-toastify skips a new toast while
+        // one with the same `toastId` is still active.
+        const errorToastId = `query-error-${`${header} ${message}`.replace(/[^a-zA-Z\d]+/g, '-')}`;
+        toast.error(header, message, { toastId: errorToastId });
 
         return false;
       },

--- a/src/core/react-query/queryClient.ts
+++ b/src/core/react-query/queryClient.ts
@@ -6,7 +6,35 @@ import store from '@/core/store';
 import toast from '@/core/toast';
 
 import type { QueryKey } from '@tanstack/react-query';
-import type { AxiosError, AxiosRequestConfig, AxiosResponse } from 'axios';
+import type { AxiosError, AxiosResponse } from 'axios';
+
+type ShokoErrorData = {
+  Detail?: string;
+  Message?: string;
+  detail?: string;
+  errors?: Record<string, string[]>;
+};
+
+// Extracts a readable message across all known Shoko server error shapes:
+// - v3 ValidationProblemDetails: `{ detail | Detail, errors: { field: [msg] } }`
+//   (Detail is often null; useful text lives in `errors`)
+// - v3 object errors (412/409/424 plugin/package): `{ Message }` (PascalCase)
+// - v3 simple errors (NotFound/BadRequest(msg), 503 middleware): JSON/plain string body
+const extractServerErrorMessage = (data: unknown): string | undefined => {
+  if (typeof data === 'string') return data.length > 0 ? data : undefined;
+  if (data === null || typeof data !== 'object') return undefined;
+
+  const errorData = data as ShokoErrorData;
+  const detail = errorData.detail ?? errorData.Detail;
+  if (detail != null && detail.length > 0) return detail;
+
+  if (errorData.errors) {
+    const fieldMessages = Object.values(errorData.errors).flat().filter(fieldMessage => fieldMessage.length > 0);
+    if (fieldMessages.length > 0) return fieldMessages.join(' ');
+  }
+
+  return errorData.Message ?? undefined;
+};
 
 const processError = (error: AxiosError | Error) => {
   let errorHeader: string;
@@ -14,13 +42,13 @@ const processError = (error: AxiosError | Error) => {
   let errorStatus = 0;
 
   if (isAxiosError(error)) {
-    const { message } = error;
-    const { method, url } = error.config as AxiosRequestConfig;
-    const { data, status } = error.response as AxiosResponse<{ detail: string }> ?? {};
+    const { config, message } = error;
+    const { method, url } = config ?? {};
+    const { data, status } = (error.response ?? {}) as Partial<AxiosResponse<unknown>>;
 
     errorHeader = `Error ${status}: ${method?.toUpperCase()} ${url}`;
-    errorMessage = data?.detail ?? message;
-    errorStatus = status;
+    errorMessage = extractServerErrorMessage(data) ?? message;
+    errorStatus = status ?? 0;
   } else {
     errorHeader = '[API]';
     errorMessage = `Error ${error.message}`;


### PR DESCRIPTION
## Summary

Improves how the WebUI surfaces and handles API errors, based on an audit of the actual error response shapes Shoko Server emits.

### Readable error messages (`68cdb24a`)
`processError` previously only read `response.data.detail`, which is `undefined` for almost every server error (v3 errors are JSON strings, PascalCase objects, or PascalCase `ValidationProblemDetails`) — toasts fell back to axios' generic "Request failed with status code 400". Message extraction now tries, in order:
- plain string body (v3 `NotFound("…")` / `BadRequest("…")`, 503 middleware text)
- `detail` / `Detail` (ValidationProblemDetails)
- `errors` dict field messages joined (validation errors)
- `Message` (v3 object errors, e.g. plugin/package 412/409/424)
- falls back to the axios error message

Also hardens config access with `?? {}` instead of unchecked casts.

### Toast deduplication (`53dd6719`)
Query failures that give up retrying now pass a deterministic `toastId` (`query-error-<slug>`), so identical concurrent failures produce a single toast instead of one per query.

### 401 logout in axios interceptor (`530eff2b`)
Replaces the fragile `/Settings`+401 check in the query retry function. `handleResponseError` dispatches `AUTH_LOGOUT` only when **all** hold:
- status is 401
- URL doesn't match `AUTH_URL_PATTERN` (failed logins also return 401)
- full path starts with `/api` (excludes `/plex`)
- an apikey is present in the store (fires at most once per session; never on login page)

### Retry allowlist (`67aa5d43`)
Queries were retried up to 4 times for everything except 404 — including deterministic client errors. Retries now happen only for:
- network errors (no response)
- 408 / 425 / 429
- all 5xx

Max 4 retries with TanStack's default exponential backoff (1/2/4/8s), which was already in effect.

## Testing
- `pnpm lint` passes
- Manual smoke checks recommended: server restart mid-session (backoff retries), 404 (single attempt + one deduped toast), wrong-password login (no logout), invalid apikey on `/api` call (single logout), `/plex` 401 (no logout)
