### PR TITLE
feat: dedicated server StatusPage for lifecycle states

### DIFF
--- a/src/core/axios.ts
+++ b/src/core/axios.ts
@@ -96,11 +96,12 @@ const handleResponseError = (error: AxiosError) => {
   // - `apikey` check ensures this fires only while logged in, and therefore at most once per session.
   const status = error.response?.status;
   const url = error.config?.url ?? '';
-  const fullPath = `${error.config?.baseURL ?? ''}${url}`;
+  const fullPath = `${error.config?.baseURL ?? ''}/${url}`;
   if (
     status === 401
     && !AUTH_URL_PATTERN.test(url)
     && fullPath.startsWith('/api')
+    && fullPath !== '/api/v3/Settings'
     && store.getState().apiSession.apikey
   ) {
     store.dispatch({ type: Events.AUTH_LOGOUT });

--- a/src/core/localStorage.ts
+++ b/src/core/localStorage.ts
@@ -12,7 +12,10 @@ export const loadState = (): RootState => {
 
     // If the version is the same, we can return the state as is from session storage.
     if (serializedState.apiSession?.version === UI_VERSION) {
-      return serializedState;
+      // serverLifecycle is ephemeral UI intent (restarting/shutting-down) — don't rehydrate it.
+      // Otherwise a reload mid-restart restores stale 'restarting' and traps the user on a stuck StatusPage.
+      const { serverLifecycle: _, ...persistedState } = serializedState;
+      return persistedState as RootState;
     }
 
     // If the version is different, we update the apiSession state to the current version and reset other slices.
@@ -48,7 +51,9 @@ export const saveState = (state: RootState) => {
     if (state.apiSession.rememberUser) {
       globalThis.localStorage.setItem('apiSession', JSON.stringify(state.apiSession));
     }
-    globalThis.sessionStorage.setItem('state', JSON.stringify(state));
+    // Don't persist serverLifecycle — ephemeral intent; see loadState above.
+    const { serverLifecycle: _, ...persistedState } = state;
+    globalThis.sessionStorage.setItem('state', JSON.stringify(persistedState));
   } catch (_) { // Ignore write errors.
   }
 };

--- a/src/core/react-query/init/mutations.ts
+++ b/src/core/react-query/init/mutations.ts
@@ -13,3 +13,13 @@ export const useSetDefaultUserMutation = () =>
   useMutation({
     mutationFn: (user: UserRequestType) => axios.post('Init/DefaultUser', user),
   });
+
+export const useServerRestartMutation = () =>
+  useMutation({
+    mutationFn: () => axios.post('Init/Restart'),
+  });
+
+export const useServerShutdownMutation = () =>
+  useMutation({
+    mutationFn: () => axios.post('Init/Shutdown'),
+  });

--- a/src/core/react-query/init/queries.ts
+++ b/src/core/react-query/init/queries.ts
@@ -1,4 +1,4 @@
-import { useQuery } from '@tanstack/react-query';
+import { type Query, useQuery } from '@tanstack/react-query';
 
 import { axios } from '@/core/axios';
 
@@ -17,7 +17,9 @@ export const useDefaultUserQuery = () =>
     queryFn: () => axios.get('Init/DefaultUser'),
   });
 
-export const useServerStatusQuery = (refetchInterval = 0) =>
+export const useServerStatusQuery = (
+  refetchInterval: number | false | ((query: Query<ServerStatusType>) => number | false | undefined) = false,
+) =>
   useQuery<ServerStatusType>({
     queryKey: ['init', 'server-status'],
     queryFn: () => axios.get('Init/Status'),

--- a/src/core/reducers.ts
+++ b/src/core/reducers.ts
@@ -6,6 +6,7 @@ import firstrunReducer from './slices/firstrun';
 import mainpageReducer from './slices/mainpage';
 import miscReducer from './slices/misc';
 import modalsReducer from './slices/modals';
+import serverLifecycleReducer from './slices/serverLifecycle';
 import settingsReducer from './slices/settings';
 import utilitiesReducer from './slices/utilities';
 
@@ -19,6 +20,7 @@ const reducers = combineReducers({
   mainpage: mainpageReducer,
   misc: miscReducer,
   modals: modalsReducer,
+  serverLifecycle: serverLifecycleReducer,
   settings: settingsReducer,
   utilities: utilitiesReducer,
 });

--- a/src/core/router/AuthenticatedRoute.tsx
+++ b/src/core/router/AuthenticatedRoute.tsx
@@ -3,6 +3,7 @@ import { Navigate, useLocation } from 'react-router';
 
 import { useServerStatusQuery } from '@/core/react-query/init/queries';
 import { useSelector } from '@/core/store';
+import StatusPage from '@/pages/StatusPage';
 
 type Props = {
   children: ReactNode;
@@ -12,12 +13,25 @@ const AuthenticatedRoute = ({ children }: Props) => {
   const location = useLocation();
   const from = encodeURIComponent(location.pathname + location.search + location.hash);
   const isAuthenticated = useSelector(state => state.apiSession.apikey !== '');
+  const serverLifecycle = useSelector(state => state.serverLifecycle);
   const serverStatusQuery = useServerStatusQuery();
-  const serverState = serverStatusQuery.data?.State ?? 'Started';
+  const serverState = serverStatusQuery.data?.State;
 
-  return (serverState === 'Started' && isAuthenticated)
-    ? children
-    : <Navigate to={from === '/' || from === '/webui/' ? '/webui/login' : `/webui/login?redirectTo=${from}`} replace />;
+  const loginRedirect = from === '/' || from === '/webui/'
+    ? '/webui/login'
+    : `/webui/login?redirectTo=${from}`;
+
+  // Unreachable server wins over stale cached state.
+  if (serverStatusQuery.isError) return <StatusPage />;
+  // A user-initiated restart/shutdown must not be interrupted by route guards.
+  if (serverLifecycle.action !== 'idle') return <StatusPage />;
+  if (serverState === 'Waiting') return <Navigate to="/webui/login" replace />;
+  if (serverState === 'Started') {
+    return isAuthenticated ? children : <Navigate to={loginRedirect} replace />;
+  }
+  if (serverState === 'Starting' || serverState === 'Failed') return <StatusPage />;
+  // State not yet loaded — optimistically render children when authenticated.
+  return isAuthenticated ? children : <Navigate to={loginRedirect} replace />;
 };
 
 export default AuthenticatedRoute;

--- a/src/core/router/index.tsx
+++ b/src/core/router/index.tsx
@@ -42,6 +42,7 @@ import IntegrationsSettings from '@/pages/settings/tabs/IntegrationsSettings';
 import PluginManagementSettings from '@/pages/settings/tabs/PluginManagementSettings';
 import TmdbSettings from '@/pages/settings/tabs/TmdbSettings';
 import UserManagementSettings from '@/pages/settings/tabs/UserManagementSettings';
+import StatusPage from '@/pages/StatusPage';
 import UnsupportedPage from '@/pages/unsupported/UnsupportedPage';
 import DuplicateFilesLinkedTab from '@/pages/utilities/DuplicateFilesTabs/DuplicateFilesLinkedTab';
 import DuplicateFilesUnrecognizedTab from '@/pages/utilities/DuplicateFilesTabs/DuplicateFilesUnrecognizedTab';
@@ -68,6 +69,7 @@ const router = sentryCreateBrowserRouter(
       <Route path="webui" element={<SentryErrorBoundaryWrapper />}>
         <Route path="index.html" element={<Navigate to="/webui" replace />} />
         <Route path="login" element={<LoginPage />} />
+        <Route path="status" element={<StatusPage />} />
         <Route path="firstrun" element={<FirstRunPage />}>
           <Route index element={<Navigate to="acknowledgement" replace />} />
           <Route path="acknowledgement" element={<Acknowledgement />} />

--- a/src/core/signalr/signalr.ts
+++ b/src/core/signalr/signalr.ts
@@ -74,7 +74,9 @@ const onAniDBHttpStateUpdate = (dispatch: typeof store.dispatch) => (state: AniD
 
 let restartToastId: number | string | undefined;
 
-const onRestartRequiredUpdate = (state: RestartRequiredType) => {
+const onRestartRequiredUpdate = (getState: () => RootState) => (state: RestartRequiredType) => {
+  // Suppress during a user-initiated restart/shutdown; StatusPage is the canonical UX then
+  if (getState().serverLifecycle.action !== 'idle') return;
   if (state.RequiresRestart) {
     if (restartToastId) return;
     restartToastId = toast.info('Restart required!', 'A restart is pending. Please restart the application.', {
@@ -188,24 +190,29 @@ async (action: UnknownAction) => {
       connectionEvents.on('metadata:series.updated', () => handleEvent('SeriesUpdated'));
       connectionEvents.on('metadata:series.removed', () => handleEvent('SeriesUpdated'));
 
-      connectionEvents.on('configuration:connected', onRestartRequiredUpdate);
-      connectionEvents.on('configuration:requiresRestart', onRestartRequiredUpdate);
+      connectionEvents.on('configuration:connected', onRestartRequiredUpdate(getState));
+      connectionEvents.on('configuration:requiresRestart', onRestartRequiredUpdate(getState));
 
-      connectionEvents.onreconnecting(
-        () =>
-          toast.error('SignalR connection lost!', 'Trying to reconnect...', {
-            autoClose: 200000,
-            toastId: 'signalr-reconnecting',
-          }),
-      );
+      connectionEvents.onreconnecting(() => {
+        // Suppress during a user-initiated restart/shutdown; StatusPage is the canonical UX then
+        if (getState().serverLifecycle.action !== 'idle') return;
+        toast.error('SignalR connection lost!', 'Trying to reconnect...', {
+          autoClose: 200000,
+          toastId: 'signalr-reconnecting',
+        });
+      });
 
       connectionEvents.onreconnected(() => {
         toast.dismiss('signalr-reconnecting');
+        // Suppress during a user-initiated restart/shutdown; StatusPage is the canonical UX then
+        if (getState().serverLifecycle.action !== 'idle') return;
         toast.success('SignalR connection restored!', undefined, { toastId: 'signalr-connected' });
       });
 
       connectionEvents.onclose(() => {
         toast.dismiss('signalr-reconnecting');
+        // Suppress during a user-initiated restart/shutdown; StatusPage is the canonical UX then
+        if (getState().serverLifecycle.action !== 'idle') return;
         toast.error(
           'SignalR connection could not be re-established!',
           'Check if your server is running and refresh the page once it has started',

--- a/src/core/slices/serverLifecycle.ts
+++ b/src/core/slices/serverLifecycle.ts
@@ -1,0 +1,34 @@
+import { createSlice } from '@reduxjs/toolkit';
+
+import type { PayloadAction } from '@reduxjs/toolkit';
+
+export type ServerLifecycleAction = 'idle' | 'restarting' | 'shutting-down';
+
+type State = {
+  action: ServerLifecycleAction;
+  initiatedAt: number | null;
+};
+
+const initialState: State = {
+  action: 'idle',
+  initiatedAt: null,
+};
+
+const serverLifecycleSlice = createSlice({
+  name: 'serverLifecycle',
+  initialState,
+  reducers: {
+    clearAction(sliceState) {
+      sliceState.action = 'idle';
+      sliceState.initiatedAt = null;
+    },
+    setAction(sliceState, action: PayloadAction<ServerLifecycleAction>) {
+      sliceState.action = action.payload;
+      sliceState.initiatedAt = action.payload === 'idle' ? null : Date.now();
+    },
+  },
+});
+
+export const { clearAction, setAction } = serverLifecycleSlice.actions;
+
+export default serverLifecycleSlice.reducer;

--- a/src/core/types/api/init.ts
+++ b/src/core/types/api/init.ts
@@ -6,11 +6,15 @@ export type UserType = {
 export type ServerStatusType = {
   StartupMessage: string;
   State: 'Starting' | 'Started' | 'Failed' | 'Waiting';
-  Uptime: string;
-  DatabaseBlocked: {
-    Progress: number;
+  CanShutdown?: boolean;
+  CanRestart?: boolean;
+  BootstrappedAt?: string;
+  StartedAt?: string;
+  Uptime?: string;
+  StartupTime?: string;
+  DatabaseBlocked?: {
     Blocked: boolean;
-    Status: string;
+    Reason?: string;
   };
 };
 

--- a/src/pages/StatusPage.tsx
+++ b/src/pages/StatusPage.tsx
@@ -48,13 +48,13 @@ const variantDetailMap: Record<Variant, VariantDetail> = {
     button: 'Retry Now',
     headline: 'Shoko appears to be offline',
     title: 'Offline | Shoko',
-    whisper: 'You can also retry manually — automatic checks keep running either way.',
+    whisper: 'You can also retry manually. Automatic checks keep running either way.',
   },
   restarting: {
     headline: 'Shoko is restarting…',
     statusFallback: 'Waiting for the server to come back…',
     title: 'Restarting… | Shoko',
-    whisper: 'This can take a minute or two.',
+    whisper: 'This may take a moment.',
   },
   'shutting-down': {
     activity: 'Waiting for the server to stop…',
@@ -69,7 +69,7 @@ const variantDetailMap: Record<Variant, VariantDetail> = {
     title: 'Shut Down | Shoko',
   },
   starting: {
-    activity: 'This usually takes less than a minute.',
+    activity: 'This may take a moment.',
     headline: 'Shoko is starting up…',
     statusFallback: 'Preparing…',
     title: 'Starting… | Shoko',
@@ -126,10 +126,26 @@ const StatusPage = () => {
 
   const [consecutiveErrors, setConsecutiveErrors] = useState(0);
   const [offlineStartedAt, setOfflineStartedAt] = useState<number | null>(null);
-  const [refetchInterval, setRefetchInterval] = useState(0);
   const [isManualRetryPending, setIsManualRetryPending] = useState(false);
 
-  const serverStatusQuery = useServerStatusQuery(refetchInterval);
+  const serverStatusQuery = useServerStatusQuery((query) => {
+    const isError = !!query.state.error;
+    const serverState = query.state.data?.State;
+    const variant = deriveVariant(lifecycle.action, lifecycle.initiatedAt, isError, serverState, consecutiveErrors);
+    switch (variant) {
+      case 'restarting':
+      case 'shutting-down':
+      case 'starting':
+        return POLL_INTERVAL_FAST_MS;
+      case 'failed':
+        return RETRY_INTERVAL_SLOW_MS;
+      case 'offline':
+        if (offlineStartedAt === null) return RETRY_INTERVAL_FAST_MS;
+        return Date.now() - offlineStartedAt < OFFLINE_BACKOFF_MS ? RETRY_INTERVAL_FAST_MS : RETRY_INTERVAL_SLOW_MS;
+      default:
+        return false;
+    }
+  });
   const { isPending: isRestartPending, mutateAsync: restartServer } = useServerRestartMutation();
 
   const lastSeenStartedAtRef = useRef(serverStatusQuery.dataUpdatedAt);
@@ -158,22 +174,6 @@ const StatusPage = () => {
 
   const icon = variantIconMap[variant];
 
-  const nextRefetchInterval = (() => {
-    switch (variant) {
-      case 'restarting':
-      case 'shutting-down':
-      case 'starting':
-        return POLL_INTERVAL_FAST_MS;
-      case 'failed':
-        return RETRY_INTERVAL_SLOW_MS;
-      case 'offline':
-        if (offlineStartedAt === null) return RETRY_INTERVAL_FAST_MS;
-        return Date.now() - offlineStartedAt < OFFLINE_BACKOFF_MS ? RETRY_INTERVAL_FAST_MS : RETRY_INTERVAL_SLOW_MS;
-      default:
-        return 0;
-    }
-  })();
-
   // Counts completed poll cycles that settled on error; a successful cycle resets it.
   // Used for the shutdown Phase A -> B transition (2 *consecutive* failures).
   useEffect(() => {
@@ -192,10 +192,6 @@ const StatusPage = () => {
       setOfflineStartedAt(null);
     }
   }, [variant, offlineStartedAt]);
-
-  useEffect(() => {
-    setRefetchInterval(nextRefetchInterval);
-  }, [nextRefetchInterval]);
 
   // When the server is back to Started, redirect immediately — no recovery UI.
   // Fires on a *transition* into Started after a disruption, so stale pre-restart 'Started'

--- a/src/pages/StatusPage.tsx
+++ b/src/pages/StatusPage.tsx
@@ -1,0 +1,353 @@
+import { useEffect, useRef, useState } from 'react';
+import { useSearchParams } from 'react-router';
+import { mdiAlertCircleOutline, mdiCogPlayOutline, mdiLoading, mdiPower, mdiRestart, mdiServerOff } from '@mdi/js';
+import { Icon } from '@mdi/react';
+import { useQueryClient } from '@tanstack/react-query';
+
+import ShokoMascot from '@/../images/shoko_mascot.png';
+import Button from '@/components/Input/Button';
+import { useServerRestartMutation } from '@/core/react-query/init/mutations';
+import { useServerStatusQuery } from '@/core/react-query/init/queries';
+import { clearAction, setAction } from '@/core/slices/serverLifecycle';
+import { useDispatch, useSelector } from '@/core/store';
+import useNavigateVoid from '@/hooks/useNavigateVoid';
+
+import type { ServerLifecycleAction } from '@/core/slices/serverLifecycle';
+import type { ServerStatusType } from '@/core/types/api/init';
+
+type Variant = 'failed' | 'loading' | 'offline' | 'restarting' | 'shutdown' | 'shutting-down' | 'starting';
+
+type VariantDetail = {
+  activity?: string;
+  body?: string;
+  bodyTimeout?: string;
+  button?: string;
+  headline: string;
+  statusFallback?: string;
+  title: string;
+  whisper?: string;
+};
+
+const RESTART_TIMEOUT_MS = 180_000;
+const OFFLINE_BACKOFF_MS = 60_000;
+const STATUS_FRESH_MS = 5_000;
+const POLL_INTERVAL_FAST_MS = 2_000;
+const RETRY_INTERVAL_FAST_MS = 5_000;
+const RETRY_INTERVAL_SLOW_MS = 15_000;
+
+const variantDetailMap: Record<Variant, VariantDetail> = {
+  loading: {
+    headline: 'Checking server status…',
+    title: 'Checking… | Shoko',
+  },
+  offline: {
+    activity: 'Retrying automatically…',
+    body: 'The server stopped responding. This usually means it crashed or the connection to it dropped.',
+    bodyTimeout:
+      'The server didn\'t come back within 3 minutes of restarting. It may still be starting, or something went wrong.',
+    button: 'Retry Now',
+    headline: 'Shoko appears to be offline',
+    title: 'Offline | Shoko',
+    whisper: 'You can also retry manually — automatic checks keep running either way.',
+  },
+  restarting: {
+    headline: 'Shoko is restarting…',
+    statusFallback: 'Waiting for the server to come back…',
+    title: 'Restarting… | Shoko',
+    whisper: 'This can take a minute or two.',
+  },
+  'shutting-down': {
+    activity: 'Waiting for the server to stop…',
+    headline: 'Shoko is shutting down…',
+    title: 'Shutting Down… | Shoko',
+  },
+  shutdown: {
+    body:
+      'The server process has stopped. To use Shoko again, start Shoko Server on the host machine, then retry the connection.',
+    button: 'Retry Connection',
+    headline: 'Shoko has shut down',
+    title: 'Shut Down | Shoko',
+  },
+  starting: {
+    activity: 'This usually takes less than a minute.',
+    headline: 'Shoko is starting up…',
+    statusFallback: 'Preparing…',
+    title: 'Starting… | Shoko',
+  },
+  failed: {
+    body: 'The server process is still running, so you can restart it from here.',
+    button: 'Restart Server',
+    headline: 'Shoko failed to start',
+    title: 'Failed to Start | Shoko',
+  },
+};
+
+type VariantIcon = {
+  className: string;
+  path: string;
+  spin: boolean | number;
+};
+
+const variantIconMap: Record<Variant, VariantIcon> = {
+  loading: { className: 'text-panel-text-primary', path: mdiLoading, spin: true },
+  offline: { className: 'text-panel-text-warning', path: mdiServerOff, spin: false },
+  restarting: { className: 'text-panel-text-primary', path: mdiRestart, spin: -2 },
+  shutdown: { className: 'text-panel-text', path: mdiPower, spin: false },
+  'shutting-down': { className: 'text-panel-text-danger', path: mdiPower, spin: false },
+  starting: { className: 'text-panel-text-primary', path: mdiCogPlayOutline, spin: false },
+  failed: { className: 'text-panel-text-danger', path: mdiAlertCircleOutline, spin: false },
+};
+
+const deriveVariant = (
+  action: ServerLifecycleAction,
+  initiatedAt: number | null,
+  isError: boolean,
+  serverState: ServerStatusType['State'] | undefined,
+  consecutiveErrors: number,
+): Variant => {
+  if (action === 'restarting') {
+    const timedOut = initiatedAt !== null && Date.now() - initiatedAt > RESTART_TIMEOUT_MS;
+    return timedOut ? 'offline' : 'restarting';
+  }
+  if (action === 'shutting-down') return consecutiveErrors >= 2 ? 'shutdown' : 'shutting-down';
+  if (isError) return 'offline';
+  if (serverState === 'Starting') return 'starting';
+  if (serverState === 'Failed') return 'failed';
+  return 'loading';
+};
+
+const StatusPage = () => {
+  const dispatch = useDispatch();
+  const navigate = useNavigateVoid();
+  const queryClient = useQueryClient();
+  const [searchParams] = useSearchParams();
+  const apikey = useSelector(state => state.apiSession.apikey);
+  const lifecycle = useSelector(state => state.serverLifecycle);
+
+  const [consecutiveErrors, setConsecutiveErrors] = useState(0);
+  const [offlineStartedAt, setOfflineStartedAt] = useState<number | null>(null);
+  const [refetchInterval, setRefetchInterval] = useState(0);
+  const [isManualRetryPending, setIsManualRetryPending] = useState(false);
+
+  const serverStatusQuery = useServerStatusQuery(refetchInterval);
+  const { isPending: isRestartPending, mutateAsync: restartServer } = useServerRestartMutation();
+
+  const lastSeenStartedAtRef = useRef(serverStatusQuery.dataUpdatedAt);
+  const sawDisruptionRef = useRef(false);
+
+  const serverState = serverStatusQuery.data?.State;
+  const startupMessage = serverStatusQuery.data?.StartupMessage;
+  const isDatabaseBlocked = serverStatusQuery.data?.DatabaseBlocked?.Blocked ?? false;
+  const blockedReason = serverStatusQuery.data?.DatabaseBlocked?.Reason;
+  const canRestart = serverStatusQuery.data?.CanRestart ?? false;
+  const hasFailedMessage = !!startupMessage || isDatabaseBlocked;
+
+  const variant = deriveVariant(
+    lifecycle.action,
+    lifecycle.initiatedAt,
+    serverStatusQuery.isError,
+    serverState,
+    consecutiveErrors,
+  );
+
+  const detail = variantDetailMap[variant];
+
+  const bodyText = variant === 'offline' && lifecycle.action === 'restarting'
+    ? detail.bodyTimeout
+    : detail.body;
+
+  const icon = variantIconMap[variant];
+
+  const nextRefetchInterval = (() => {
+    switch (variant) {
+      case 'restarting':
+      case 'shutting-down':
+      case 'starting':
+        return POLL_INTERVAL_FAST_MS;
+      case 'failed':
+        return RETRY_INTERVAL_SLOW_MS;
+      case 'offline':
+        if (offlineStartedAt === null) return RETRY_INTERVAL_FAST_MS;
+        return Date.now() - offlineStartedAt < OFFLINE_BACKOFF_MS ? RETRY_INTERVAL_FAST_MS : RETRY_INTERVAL_SLOW_MS;
+      default:
+        return 0;
+    }
+  })();
+
+  // Counts completed poll cycles that settled on error; a successful cycle resets it.
+  // Used for the shutdown Phase A -> B transition (2 *consecutive* failures).
+  useEffect(() => {
+    if (serverStatusQuery.fetchStatus !== 'idle') return;
+    if (serverStatusQuery.isError) {
+      setConsecutiveErrors(prev => prev + 1);
+    } else {
+      setConsecutiveErrors(0);
+    }
+  }, [serverStatusQuery.fetchStatus, serverStatusQuery.isError]);
+
+  useEffect(() => {
+    if (variant === 'offline') {
+      if (offlineStartedAt === null) setOfflineStartedAt(Date.now());
+    } else if (offlineStartedAt !== null) {
+      setOfflineStartedAt(null);
+    }
+  }, [variant, offlineStartedAt]);
+
+  useEffect(() => {
+    setRefetchInterval(nextRefetchInterval);
+  }, [nextRefetchInterval]);
+
+  // When the server is back to Started, redirect immediately — no recovery UI.
+  // Fires on a *transition* into Started after a disruption, so stale pre-restart 'Started'
+  // cache can't fake a recovery. Also covers a fresh direct landing on an idle Started server.
+  useEffect(() => {
+    if (serverStatusQuery.isError) {
+      sawDisruptionRef.current = true;
+      return;
+    }
+    const currentState = serverStatusQuery.data?.State;
+    if (currentState !== 'Started') {
+      if (currentState) sawDisruptionRef.current = true;
+      return;
+    }
+    const { dataUpdatedAt } = serverStatusQuery;
+    const justRecovered = sawDisruptionRef.current && dataUpdatedAt > lastSeenStartedAtRef.current;
+    const freshIdle = lifecycle.action === 'idle' && Date.now() - dataUpdatedAt < STATUS_FRESH_MS;
+    lastSeenStartedAtRef.current = dataUpdatedAt;
+    if (justRecovered || freshIdle) {
+      dispatch(clearAction());
+      queryClient.removeQueries();
+      navigate(apikey !== '' ? searchParams.get('redirectTo') ?? '/webui' : '/webui/login', { replace: true });
+    }
+  }, [
+    apikey,
+    dispatch,
+    lifecycle.action,
+    navigate,
+    queryClient,
+    searchParams,
+    serverStatusQuery.data?.State,
+    serverStatusQuery.dataUpdatedAt,
+    serverStatusQuery.isError,
+  ]);
+
+  useEffect(() => {
+    if (serverState === 'Waiting' && lifecycle.action === 'idle') {
+      navigate('/webui/login', { replace: true });
+    }
+  }, [lifecycle.action, navigate, serverState]);
+
+  const handleRestartServer = () => {
+    dispatch(setAction('restarting'));
+    restartServer(undefined).catch((error) => {
+      console.error(error);
+      dispatch(clearAction());
+    });
+  };
+
+  const retry = (resetBackoff: boolean) => {
+    if (resetBackoff) setOfflineStartedAt(Date.now());
+    setIsManualRetryPending(true);
+    serverStatusQuery.refetch()
+      .catch(console.error)
+      .finally(() => setIsManualRetryPending(false));
+  };
+
+  const showButton = !!detail.button && (variant !== 'failed' || canRestart);
+  const buttonPending = variant === 'failed' ? isRestartPending : isManualRetryPending;
+
+  const handleButtonClick = () => {
+    if (variant === 'failed') {
+      handleRestartServer();
+    } else {
+      retry(variant === 'offline');
+    }
+  };
+
+  return (
+    <>
+      <title>{detail.title}</title>
+      <div className="relative flex h-screen w-screen items-center justify-center overflow-hidden p-6">
+        <div className="flex h-full max-w-230 flex-col items-center justify-center gap-y-4 overflow-y-auto text-center md:gap-y-6">
+          <div className="flex flex-col items-center gap-y-4 md:gap-y-6">
+            <Icon
+              path={icon.path}
+              size={4}
+              spin={icon.spin}
+              className={icon.className}
+            />
+
+            <div className="text-4xl text-panel-text md:text-5xl">{detail.headline}</div>
+
+            {!!detail.statusFallback && (
+              <div className="text-lg">
+                {startupMessage ?? detail.statusFallback}
+              </div>
+            )}
+
+            {variant === 'failed'
+              ? (
+                <div className="flex flex-col gap-y-4">
+                  {canRestart && <div className="text-lg">{detail.body}</div>}
+                  <div>
+                    Still stuck? Hop on our&nbsp;
+                    <a
+                      href="https://discord.gg/vpeHDsg"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="font-semibold text-panel-text-primary"
+                    >
+                      Discord
+                    </a>
+                    &nbsp;and share the message above.
+                  </div>
+                </div>
+              )
+              : bodyText && <div className="text-lg">{bodyText}</div>}
+
+            {detail.activity && (
+              <div className="flex items-center gap-x-2 text-panel-text-primary">
+                <Icon path={mdiLoading} size={1} spin />
+                <span className="text-lg">{detail.activity}</span>
+              </div>
+            )}
+
+            {variant === 'failed' && hasFailedMessage && (
+              <pre className="max-h-100 max-w-full overflow-y-auto rounded-lg border border-panel-border bg-panel-input p-4 whitespace-pre-wrap md:p-6">
+                {isDatabaseBlocked && (
+                  <>
+                    Database blocked: {blockedReason ?? 'Unknown reason'}
+                    <br />
+                    <br />
+                  </>
+                )}
+                {startupMessage}
+              </pre>
+            )}
+
+            {showButton && (
+              <Button
+                buttonType="primary"
+                buttonSize="normal"
+                loading={buttonPending}
+                onClick={handleButtonClick}
+              >
+                {detail.button}
+              </Button>
+            )}
+
+            {detail.whisper && <div className="text-sm opacity-65">{detail.whisper}</div>}
+          </div>
+        </div>
+
+        <img
+          src={ShokoMascot}
+          alt="mascot"
+          className="absolute -right-36 -bottom-40 z-10 opacity-30"
+        />
+      </div>
+    </>
+  );
+};
+
+export default StatusPage;

--- a/src/pages/login/LoginPage.tsx
+++ b/src/pages/login/LoginPage.tsx
@@ -2,14 +2,7 @@ import { useEffect, useState } from 'react';
 import type { SubmitEvent } from 'react';
 import { useSearchParams } from 'react-router';
 import { Slide, ToastContainer } from 'react-toastify';
-import {
-  mdiAlertCircleOutline,
-  mdiCloseCircleOutline,
-  mdiGithub,
-  mdiHelpCircleOutline,
-  mdiLoading,
-  mdiOpenInNew,
-} from '@mdi/js';
+import { mdiAlertCircleOutline, mdiGithub, mdiHelpCircleOutline, mdiLoading, mdiOpenInNew } from '@mdi/js';
 import { Icon } from '@mdi/react';
 import cx from 'classnames';
 import { siDiscord } from 'simple-icons';
@@ -67,12 +60,21 @@ const LoginPage = () => {
 
   useEffect(() => {
     if (!serverStatusQuery.data) setPollingInterval(500);
-    else if (serverStatusQuery.data?.State !== 'Starting') setPollingInterval(0);
+    else setPollingInterval(0);
+
+    // Only Started and Waiting are handled here; anything else belongs on the status page.
+    if (
+      serverStatusQuery.isError
+      || (serverStatusQuery.data && !['Started', 'Waiting'].includes(serverStatusQuery.data.State))
+    ) {
+      navigate('/webui/status', { replace: true });
+      return;
+    }
 
     if (serverStatusQuery.data?.State === 'Started' && apiSession.apikey !== '') {
       navigate(searchParams.get('redirectTo') ?? '/webui', { replace: true });
     }
-  }, [serverStatusQuery.data, apiSession, navigate, searchParams]);
+  }, [serverStatusQuery.data, serverStatusQuery.isError, apiSession, navigate, searchParams]);
 
   const handleSignIn = (event: SubmitEvent) => {
     event.preventDefault();
@@ -139,16 +141,6 @@ const LoginPage = () => {
                   <Icon path={mdiLoading} spin className="text-panel-text-primary" size={4} />
                 </div>
               )}
-              {serverStatusQuery.data?.State === 'Starting' && (
-                <div className="flex flex-col items-center justify-center gap-y-2">
-                  <Icon path={mdiLoading} spin className="text-panel-text-primary" size={4} />
-                  <div className="mt-2 text-xl font-semibold">Server is starting. Please wait!</div>
-                  <div className="text-lg">
-                    <span className="font-semibold">Status:</span>
-                    {serverStatusQuery.data?.StartupMessage ?? 'Unknown'}
-                  </div>
-                </div>
-              )}
               {serverStatusQuery.data?.State === 'Started' && (
                 <form onSubmit={handleSignIn} className="flex flex-col gap-y-6">
                   <Input
@@ -189,16 +181,6 @@ const LoginPage = () => {
                     Login
                   </Button>
                 </form>
-              )}
-              {serverStatusQuery.data?.State === 'Failed' && (
-                <div className="flex max-h-80 flex-col items-center justify-center gap-y-2 pb-2">
-                  <Icon path={mdiCloseCircleOutline} className="shrink-0 text-panel-text-warning" size={4} />
-                  <div className="mt-2 text-xl font-semibold">Server startup failed!</div>
-                  Check the error message below
-                  <div className="overflow-y-auto text-lg font-semibold break-all">
-                    {serverStatusQuery.data?.StartupMessage ?? 'Unknown'}
-                  </div>
-                </div>
               )}
               {serverStatusQuery.data?.State === 'Waiting' && (
                 <div className="flex flex-col gap-y-6">

--- a/src/pages/settings/tabs/GeneralSettings.tsx
+++ b/src/pages/settings/tabs/GeneralSettings.tsx
@@ -1,13 +1,15 @@
-import { useMemo, useRef } from 'react';
+import { useMemo, useRef, useState } from 'react';
 import type { ChangeEvent, MouseEvent } from 'react';
-import { mdiBrushOutline, mdiOpenInNew, mdiRefresh } from '@mdi/js';
+import { mdiBrushOutline, mdiOpenInNew, mdiPower, mdiRefresh, mdiRestart } from '@mdi/js';
 import { Icon } from '@mdi/react';
 import cx from 'classnames';
 
+import ConfirmationPromptModal from '@/components/Dialogs/ConfirmationPromptModal';
 import Button from '@/components/Input/Button';
 import Checkbox from '@/components/Input/Checkbox';
 import SelectSmall from '@/components/Input/SelectSmall';
-import { useVersionQuery } from '@/core/react-query/init/queries';
+import { useServerRestartMutation, useServerShutdownMutation } from '@/core/react-query/init/mutations';
+import { useServerStatusQuery, useVersionQuery } from '@/core/react-query/init/queries';
 import { useWebuiUploadThemeMutation } from '@/core/react-query/webui/mutations';
 import {
   useServerUpdateCheckQuery,
@@ -43,8 +45,13 @@ const GeneralSettings = () => {
   const themePathHref = useMemo(() => document.getElementById('theme-css')!.attributes.getNamedItem('href')!, []);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const versionQuery = useVersionQuery();
+  const serverStatusQuery = useServerStatusQuery();
+  const { isPending: isRestarting, mutateAsync: restartServer } = useServerRestartMutation();
+  const { isPending: isShuttingDown, mutateAsync: shutdownServer } = useServerShutdownMutation();
   const themesQuery = useWebuiThemesQuery();
   const { isPending: isUploading, mutate: uploadTheme } = useWebuiUploadThemeMutation();
+  const [showRestartConfirm, setShowRestartConfirm] = useState(false);
+  const [showShutdownConfirm, setShowShutdownConfirm] = useState(false);
 
   const onOpenFileDialog = (event: MouseEvent<HTMLButtonElement>) => {
     if (isUploading) {
@@ -94,7 +101,61 @@ const GeneralSettings = () => {
     <>
       <title>Settings &gt; General | Shoko</title>
       <div className="flex flex-col gap-y-1">
-        <div className="text-xl font-semibold">General</div>
+        <div className="flex items-center justify-between">
+          <div className="text-xl font-semibold">General</div>
+          <div className="flex items-center gap-2">
+            {serverStatusQuery.data?.CanRestart && (
+              <>
+                <Button
+                  className="text-button-primary"
+                  tooltip="Restart Shoko"
+                  onClick={() => setShowRestartConfirm(true)}
+                >
+                  <Icon path={mdiRestart} size={1} spin={isRestarting} />
+                </Button>
+                <ConfirmationPromptModal
+                  onConfirm={async () => {
+                    await restartServer(undefined)
+                      .then(() => toast.success('Shoko is restarting'))
+                      .catch(() => toast.error('Failed to restart Shoko'));
+                  }}
+                  onClose={() => setShowRestartConfirm(false)}
+                  show={showRestartConfirm}
+                  confirmButtonType="primary"
+                  confirmText="Restart"
+                  title="Restart Shoko"
+                >
+                  Are you sure you want to restart Shoko?
+                </ConfirmationPromptModal>
+              </>
+            )}
+            {serverStatusQuery.data?.CanShutdown && (
+              <>
+                <Button
+                  className="text-button-danger"
+                  tooltip="Shutdown Shoko"
+                  onClick={() => setShowShutdownConfirm(true)}
+                >
+                  <Icon path={mdiPower} size={1} spin={isShuttingDown} />
+                </Button>
+                <ConfirmationPromptModal
+                  onConfirm={async () => {
+                    await shutdownServer(undefined)
+                      .then(() => toast.success('Shoko is shutting down'))
+                      .catch(() => toast.error('Failed to shutdown Shoko'));
+                  }}
+                  onClose={() => setShowShutdownConfirm(false)}
+                  show={showShutdownConfirm}
+                  confirmButtonType="danger"
+                  confirmText="Shutdown"
+                  title="Shutdown Shoko"
+                >
+                  Are you sure you want to shutdown Shoko?
+                </ConfirmationPromptModal>
+              </>
+            )}
+          </div>
+        </div>
         <div>
           Here you can find settings for version details, theme customization, notification management, and log
           configurations.

--- a/src/pages/settings/tabs/GeneralSettings.tsx
+++ b/src/pages/settings/tabs/GeneralSettings.tsx
@@ -16,8 +16,11 @@ import {
   useWebuiThemesQuery,
   useWebuiUpdateCheckQuery,
 } from '@/core/react-query/webui/queries';
+import { clearAction, setAction } from '@/core/slices/serverLifecycle';
+import { useDispatch } from '@/core/store';
 import toast from '@/core/toast';
 import { getUiVersion, isDebug } from '@/core/util';
+import useNavigate from '@/hooks/useNavigateVoid';
 import useSettingsContext from '@/hooks/useSettingsContext';
 
 let themeUpdateCounter = 0;
@@ -26,6 +29,8 @@ const UI_VERSION = getUiVersion();
 
 const GeneralSettings = () => {
   const { newSettings, updateSetting } = useSettingsContext();
+  const dispatch = useDispatch();
+  const navigate = useNavigate();
 
   const {
     Logging,
@@ -93,6 +98,30 @@ const GeneralSettings = () => {
     });
   };
 
+  const onConfirmRestart = async () => {
+    dispatch(setAction('restarting'));
+    try {
+      await restartServer(undefined);
+      navigate('/webui/status');
+    } catch (error) {
+      console.error(error);
+      dispatch(clearAction());
+      toast.error('Failed to restart Shoko');
+    }
+  };
+
+  const onConfirmShutdown = async () => {
+    dispatch(setAction('shutting-down'));
+    try {
+      await shutdownServer(undefined);
+      navigate('/webui/status');
+    } catch (error) {
+      console.error(error);
+      dispatch(clearAction());
+      toast.error('Failed to shutdown Shoko');
+    }
+  };
+
   const currentTheme = useMemo(() => (
     themesQuery.data?.find(theme => `theme-${theme.ID}` === WebUI_Settings.theme)
   ), [themesQuery.data, WebUI_Settings.theme]);
@@ -114,11 +143,7 @@ const GeneralSettings = () => {
                   <Icon path={mdiRestart} size={1} spin={isRestarting} />
                 </Button>
                 <ConfirmationPromptModal
-                  onConfirm={async () => {
-                    await restartServer(undefined)
-                      .then(() => toast.success('Shoko is restarting'))
-                      .catch(() => toast.error('Failed to restart Shoko'));
-                  }}
+                  onConfirm={onConfirmRestart}
                   onClose={() => setShowRestartConfirm(false)}
                   show={showRestartConfirm}
                   confirmButtonType="primary"
@@ -139,11 +164,7 @@ const GeneralSettings = () => {
                   <Icon path={mdiPower} size={1} spin={isShuttingDown} />
                 </Button>
                 <ConfirmationPromptModal
-                  onConfirm={async () => {
-                    await shutdownServer(undefined)
-                      .then(() => toast.success('Shoko is shutting down'))
-                      .catch(() => toast.error('Failed to shutdown Shoko'));
-                  }}
+                  onConfirm={onConfirmShutdown}
                   onClose={() => setShowShutdownConfirm(false)}
                   show={showShutdownConfirm}
                   confirmButtonType="danger"

--- a/src/pages/settings/tabs/GeneralSettings.tsx
+++ b/src/pages/settings/tabs/GeneralSettings.tsx
@@ -2,6 +2,7 @@ import { useMemo, useRef, useState } from 'react';
 import type { ChangeEvent, MouseEvent } from 'react';
 import { mdiBrushOutline, mdiOpenInNew, mdiPower, mdiRefresh, mdiRestart } from '@mdi/js';
 import { Icon } from '@mdi/react';
+import { isAxiosError } from 'axios';
 import cx from 'classnames';
 
 import ConfirmationPromptModal from '@/components/Dialogs/ConfirmationPromptModal';
@@ -26,6 +27,11 @@ import useSettingsContext from '@/hooks/useSettingsContext';
 let themeUpdateCounter = 0;
 
 const UI_VERSION = getUiVersion();
+
+const isNetworkError = (error: unknown): boolean => {
+  if (!isAxiosError(error)) return false;
+  return !error.response || error.code === 'ERR_NETWORK' || error.message === 'Network Error';
+};
 
 const GeneralSettings = () => {
   const { newSettings, updateSetting } = useSettingsContext();
@@ -105,6 +111,11 @@ const GeneralSettings = () => {
       navigate('/webui/status');
     } catch (error) {
       console.error(error);
+      if (isNetworkError(error)) {
+        // Server likely dropped the connection mid-restart; treat as success
+        navigate('/webui/status');
+        return;
+      }
       dispatch(clearAction());
       toast.error('Failed to restart Shoko');
     }
@@ -117,6 +128,11 @@ const GeneralSettings = () => {
       navigate('/webui/status');
     } catch (error) {
       console.error(error);
+      if (isNetworkError(error)) {
+        // Server likely dropped the connection mid-shutdown; treat as success
+        navigate('/webui/status');
+        return;
+      }
       dispatch(clearAction());
       toast.error('Failed to shutdown Shoko');
     }


### PR DESCRIPTION
## Summary

Adds a dedicated, full-bleed **StatusPage** (`/webui/status`) that is the single canonical surface for all non-ready server states — `Starting`, `Failed`, `Restarting`, `Shutting-down`, `Shutdown`, and `Offline` — plus an automatic recovery redirect back into the app once the server is `Started`. This fixes the auto-login gap that occurred when the server transitioned `Starting → Started` while the user was on the login page.

## Why

- `LoginPage` lived outside `AuthenticatedRoute`, so the `Starting` state was handled ad-hoc there and the `Starting → Started` transition was never reliably caught (auto-login gap during the boot window).
- A 502 during `Starting` produced a blank crossfade / stuck state because nothing canonical owned the "server not reachable yet" state.
- Auto-login could fire during the boot window, racing server readiness.
- Restart/shutdown had no canonical UX; SignalR toasts and route guards fought the in-progress action.

## Changes

- **New `serverLifecycle` slice** (`src/core/slices/serverLifecycle.ts`) — ephemeral UI intent (`idle` | `restarting` | `shutting-down`, `initiatedAt`). Deliberately **excluded from sessionStorage persistence** (both `loadState` and `saveState` in `src/core/localStorage.ts`) so a reload mid-restart never rehydrates a stale `restarting` and traps the user on a stuck StatusPage.
- **New `StatusPage.tsx`** (`src/pages/StatusPage.tsx`) — 7 variants (`loading`, `starting`, `failed`, `restarting`, `shutting-down`, `shutdown`, `offline`). Drive text via `variantDetailMap` and icons via `variantIconMap`. Polling at **2s / retry 5s** that backs off to **15s / 15s** once the server is unreachable. A **3-minute restart timeout** promotes `restarting → offline`; **2 consecutive failures** promotes `shutting-down → shutdown`. Immediate redirect on `Started` is guarded by `lastSeenStartedAtRef` + `sawDisruptionRef` + `STATUS_FRESH_MS` so the redirect only fires after a genuine disruption. Variants `failed`/`offline`/`shutdown` render action buttons — **"Restart Server"** (gated on `CanRestart`), **"Retry Now"**, and **"Retry Connection"** respectively — so recovery is possible directly from the page.
- **`AuthenticatedRoute` guard** (`src/core/router/AuthenticatedRoute.tsx`) — `isError` or active lifecycle `action` → `StatusPage`; `Waiting` → login; `Started` → authenticated children / login redirected; `Starting`/`Failed` → `StatusPage`; otherwise optimistically render when authenticated.
- **`/webui/status` route** added in `src/core/router/index.tsx`.
- **SignalR suppression** (`src/core/signalr/signalr.ts`) — `onreconnecting` / `onreconnected` / `onclose` and `requiresRestart` are gated on `serverLifecycle.action === 'idle'`, so StatusPage is the only UX during a user-initiated restart/shutdown.
- **`GeneralSettings` handoff** (`src/pages/settings/tabs/GeneralSettings.tsx`) — new Restart/Shutdown buttons (gated on `CanRestart`/`CanShutdown`) with `ConfirmationPromptModal`; `onConfirmRestart/onConfirmShutdown` dispatch `setAction` → mutate (`Init/Restart`, `Init/Shutdown`) → `navigate('/webui/status')`.
- **`LoginPage` redirect** (`src/pages/login/LoginPage.tsx`) — any non-`Started`/non-`Waiting` state (or `isError`) redirects to `/webui/status`; removed the bespoke `Starting`/`Failed` blocks from the login UI.
- **axios 401 fix** (`src/core/axios.ts`) — `fullPath` now uses a proper `/${url}` slash, adds `Settings` exclusion (`/api/v3/Settings`) for the boot window so settings reads don't trigger a logout.
- **Simplifications** — detail destructure, `!!` truthiness checks, retry-interval consolidation, icon map, etc.
- **Verified** — `pnpm lint` and `pnpm build` pass; dev override removed before commit; a11y/aria removed per codebase conventions.

## Testing

- `pnpm lint` and `pnpm build` pass.
- Manual restart / shutdown / starting flows verified end-to-end (StatusPage surfaces, redirects recover on `Started`).

