### PR TITLE
feat(file): use v3 File AudioLanguages/SubtitleLanguages and separate subtitle section

### DIFF
--- a/src/components/FileInfo.tsx
+++ b/src/components/FileInfo.tsx
@@ -50,6 +50,10 @@ const FileInfo = ({ compact, file }: { compact?: boolean, file: FileType }) => {
             {mediaInfo.AudioInfo.join(' | ')}
           </div>
           <div className="flex">
+            <div className="min-w-37.5 font-semibold">Subtitles</div>
+            {mediaInfo.SubtitleInfo || 'N/A'}
+          </div>
+          <div className="flex">
             <div className="min-w-37.5 font-semibold">Chapters</div>
             {mediaInfo.Chapters ? 'Yes' : 'No'}
           </div>

--- a/src/core/types/api/file.ts
+++ b/src/core/types/api/file.ts
@@ -28,6 +28,8 @@ export type FileType = {
   Updated: string;
   Imported?: string;
   IsVariation: boolean;
+  AudioLanguages: string[];
+  SubtitleLanguages: string[];
   SeriesIDs?: XRefsType[];
   Release?: ReleaseInfoType;
   MediaInfo?: FileMediaInfoType;

--- a/src/core/types/models/file.ts
+++ b/src/core/types/models/file.ts
@@ -11,5 +11,6 @@ export type FileInfo = {
   };
   VideoInfo: string[];
   AudioInfo: string[];
+  SubtitleInfo: string;
   Chapters: boolean;
 };

--- a/src/hooks/useMediaInfo.ts
+++ b/src/hooks/useMediaInfo.ts
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import { map, toNumber } from 'lodash';
+import { toNumber } from 'lodash';
 
 import type { FileType } from '@/core/types/api/file';
 import type { FileInfo } from '@/core/types/models/file';
@@ -36,14 +36,8 @@ const getAudioInfo = (file: FileType) => {
     info.push(file.MediaInfo.Audio[0].Format.Name);
   }
 
-  const audioLanguages = map(file.MediaInfo?.Audio, item => item.LanguageCode).filter(item => !!item);
-  if (audioLanguages && audioLanguages.length > 0) {
-    info.push(`${audioLanguages.length > 1 ? 'Multi Audio' : 'Audio'} (${audioLanguages.join(', ')})`);
-  }
-
-  const subtitleLanguages = map(file.MediaInfo?.Subtitles, item => item.LanguageCode).filter(item => !!item);
-  if (subtitleLanguages && subtitleLanguages.length > 0) {
-    info.push(`${subtitleLanguages.length > 1 ? 'Multi Subs' : 'Subs'} (${subtitleLanguages.join(', ')})`);
+  if (file.AudioLanguages.length > 0) {
+    info.push(`${file.AudioLanguages.length > 1 ? 'Multi Audio' : 'Audio'} (${file.AudioLanguages.join(', ')})`);
   }
 
   return info;
@@ -53,6 +47,7 @@ const useMediaInfo = (file: FileType): FileInfo =>
   useMemo(() => {
     const videoInfo = getVideoInfo(file);
     const audioInfo = getAudioInfo(file);
+    const subtitleInfo = file.SubtitleLanguages.join(', ');
 
     const absolutePath = file.Locations?.[0]?.AbsolutePath ?? '??';
     const fileName = absolutePath.split(/[/\\]+/).pop();
@@ -75,6 +70,7 @@ const useMediaInfo = (file: FileType): FileInfo =>
       },
       VideoInfo: videoInfo,
       AudioInfo: audioInfo,
+      SubtitleInfo: subtitleInfo,
       Chapters: file.Release?.IsChaptered ?? false,
     };
   }, [file]);

--- a/src/pages/utilities/FileSearch.tsx
+++ b/src/pages/utilities/FileSearch.tsx
@@ -219,6 +219,14 @@ const MediaInfoDetails = ({ file }: { file: FileType }) => {
         </span>
       </div>
       <div className="flex flex-col gap-y-1">
+        <div className="flex justify-between capitalize">
+          <span className="font-semibold">Subtitles</span>
+        </div>
+        <span className="break-all">
+          {mediaInfo.SubtitleInfo || 'N/A'}
+        </span>
+      </div>
+      <div className="flex flex-col gap-y-1">
         <div className="flex break-after-all justify-between capitalize">
           <span className="font-semibold">ED2K</span>
         </div>

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -77,7 +77,7 @@ export default defineConfig(async () => {
 async function setupEnv(isDebug) {
   const gitHash = childProcess.execSync("git log --pretty=format:'%h' -n 1").toString().replace(/["']/g, '');
   const appVersion = pkg.version;
-  const minimumServerVersion = '6.0.0-dev.422';
+  const minimumServerVersion = '6.0.0-dev.437';
 
   process.env.VITE_GITHASH = gitHash;
   process.env.VITE_APPVERSION = appVersion;


### PR DESCRIPTION
## Summary

The v3 File API now returns top-level `AudioLanguages` and `SubtitleLanguages` fields (merged from release info and local media info, dropping `Unknown` when release info is present). This switches the file detail views off the older `file.MediaInfo` audio/subtitle stream codes to these authoritative fields.

## Changes

- **`src/core/types/api/file.ts`** — add `AudioLanguages` and `SubtitleLanguages` (`string[]`) to `FileType`.
- **`src/hooks/useMediaInfo.ts`** — read audio/subtitle languages from `file.AudioLanguages` / `file.SubtitleLanguages` instead of `file.MediaInfo.Audio/Subtitles`. The codec label still comes from `MediaInfo`. Subtitle info is returned as a comma-joined `SubtitleInfo` string (``N/A`` when empty).
- **`src/core/types/models/file.ts`** — split the combined audio array: keep `AudioInfo` (codec + audio languages) and add a separate `SubtitleInfo`.
- **`src/components/FileInfo.tsx`** and **`src/pages/utilities/FileSearch.tsx`** — render audio and subtitles in their own rows (header `Subtitles`, bare language list) instead of bundling subs under Audio.
- **`vite.config.mjs`** — bump `minimumServerVersion` to `6.0.0-dev.437`.

## Why

`MediaInfo` audio/subtitle languages come from raw stream codes and require the `MediaInfo` include flag, while the new top-level fields are always returned and already merge release info. Separating subtitles into their own section also makes the two easier to scan in the file detail views.

## Testing

- `pnpm lint` passes.
- `tsc --noEmit` passes.
- Verified the Audio row shows codec + `Audio (...)`/`Multi Audio (...)` and the new Subtitles row shows bare languages (or `N/A`).
