### PR TITLE
fix(auto-match): broaden trailing-native-title and related rules

### DIFF
--- a/src/core/utilities/auto-match-regexes.ts
+++ b/src/core/utilities/auto-match-regexes.ts
@@ -135,8 +135,12 @@ try {
       modifiedDetails.episodeStart = episode;
       modifiedDetails.episodeEnd = episode;
       // Rules that match theme songs via their own regex (raws-*, trailing-native-title) have no isThemeSong
-      // group, so detectEpisodeType never sees it - set the type here where the theme song is actually detected.
-      modifiedDetails.episodeType = 'Credits';
+      // group, so detectEpisodeType never sees it - set the type here. Only from the plain 'Episode' default,
+      // so a more specific classification (Special from an isSpecial group, etc.) still wins, matching the
+      // isSpecial > isThemeSong precedence in detectEpisodeType.
+      if (modifiedDetails.episodeType === 'Episode') {
+        modifiedDetails.episodeType = 'Credits';
+      }
     }
     if (modifiedDetails.episodeStart === 0) {
       const trailerCheckResult = TrailerCheckRegex.exec(originalDetails.filePath);
@@ -215,10 +219,12 @@ try {
       // Take the episode number from the SxxExx marker, not the trailing absolute number: the search and the
       // cross-reference matcher both poll AniDB, which catalogues a multi-cour show as separate entries each
       // numbered from 1, so "... - S02E08 - 021 - ..." is episode 8, not 21. A single absolute-numbered entry
-      // keeps season 1 in Sonarr, so the two numbers are identical there.
+      // keeps season 1 in Sonarr, so the two numbers are identical there. The E-range stays inside `episode`
+      // (defaultTransform splits it), and `year` is a bare \d{4} - not (?:19|20)\d{2} - because Sonarr can emit
+      // any 4-digit year here.
       regex:
         // oxlint-disable-next-line no-useless-escape
-        /^(?<showName>.+?(?: \((?<year>\d{4})\))) - (?:(?<isSpecial>S00?)|S(?<season>\d+))E(?<episode>\d+)(?:-E?\d+)? - \d+(?:-\d+)? - (?<episodeName>.+?(?=\[)).*?(?:-(?<releaseGroup>[^\[\] ]+))?\s*\.(?<extension>[a-zA-Z0-9_\-+]+)$/id,
+        /^(?<showName>.+?(?: \((?<year>\d{4})\))) - (?:(?<isSpecial>S00?)|S(?<season>\d+))E(?<episode>\d+(?:-E?\d+)?) - \d+(?:-\d+)? - (?<episodeName>.+?(?=\[)).*?(?:-(?<releaseGroup>[^\[\] ]+))?\s*\.(?<extension>[a-zA-Z0-9_\-+]+)$/id,
       transform: defaultTransform,
     },
     {

--- a/src/core/utilities/auto-match-regexes.ts
+++ b/src/core/utilities/auto-match-regexes.ts
@@ -134,6 +134,9 @@ try {
 
       modifiedDetails.episodeStart = episode;
       modifiedDetails.episodeEnd = episode;
+      // Rules that match theme songs via their own regex (raws-*, trailing-native-title) have no isThemeSong
+      // group, so detectEpisodeType never sees it - set the type here where the theme song is actually detected.
+      modifiedDetails.episodeType = 'Credits';
     }
     if (modifiedDetails.episodeStart === 0) {
       const trailerCheckResult = TrailerCheckRegex.exec(originalDetails.filePath);
@@ -171,6 +174,14 @@ try {
     return modifiedDetails;
   };
 
+  // Ordered, first-match-wins rule set, consumed only by detectShow() in ./auto-match-logic.ts: it tries each
+  // rule's `regex` in array order and uses the FIRST that matches, so position IS precedence - a new rule in
+  // the wrong slot silently steals matches from, or loses them to, an adjacent rule. Every match produces the
+  // same shape (showName / season / episodeStart+episodeEnd / episodeType / releaseGroup / version); callers
+  // use it only to seed the AniDB series search and auto-fill episode links, with no per-rule routing.
+  // `transform` returns the details to accept, `null` to abandon detection entirely, `false` to skip this rule
+  // but keep trying later ones. Rough order: specific anchored shapes, then the greedy `default`, niche shapes,
+  // then `fallback` (same as `default` with the episode number optional) last.
   PathMatchRuleSet.push(
     {
       name: 'anti-timestamp',
@@ -201,9 +212,13 @@ try {
     },
     {
       name: 'trash-anime',
+      // Take the episode number from the SxxExx marker, not the trailing absolute number: the search and the
+      // cross-reference matcher both poll AniDB, which catalogues a multi-cour show as separate entries each
+      // numbered from 1, so "... - S02E08 - 021 - ..." is episode 8, not 21. A single absolute-numbered entry
+      // keeps season 1 in Sonarr, so the two numbers are identical there.
       regex:
         // oxlint-disable-next-line no-useless-escape
-        /^(?<showName>.+?(?: \((?<year>\d{4})\))) - (?:(?<isSpecial>S00?)|S\d+)E\d+(?:-E?\d+)? - (?<episode>\d+(?:-\d+)?) - (?<episodeName>.+?(?=\[)).*?(?:-(?<releaseGroup>[^\[\] ]+))?\s*\.(?<extension>[a-zA-Z0-9_\-+]+)$/id,
+        /^(?<showName>.+?(?: \((?<year>\d{4})\))) - (?:(?<isSpecial>S00?)|S(?<season>\d+))E(?<episode>\d+)(?:-E?\d+)? - \d+(?:-\d+)? - (?<episodeName>.+?(?=\[)).*?(?:-(?<releaseGroup>[^\[\] ]+))?\s*\.(?<extension>[a-zA-Z0-9_\-+]+)$/id,
       transform: defaultTransform,
     },
     {
@@ -245,7 +260,9 @@ try {
     },
     {
       name: 'reversed-1',
-      regex: /^\[?(?<episode>\d+)\s*-\s*(?<showName>[^[]+])\s*(?:\[[^\]]*\])*\.(?<extension>[a-zA-Z0-9_\-+]+)$/id,
+      // The show-name class had a stray `]` (`[^[]+]`), which required the name to end with a literal `]`, so
+      // plain "05 - Show Name [1080p].mkv" never matched and fell through to `fallback` as "05- Show Name".
+      regex: /^\[?(?<episode>\d+)\s*-\s*(?<showName>[^[\n]+)\s*(?:\[[^\]]*\])*\.(?<extension>[a-zA-Z0-9_\-+]+)$/id,
       transform: defaultTransform,
     },
     // TODO: Add more rules here.

--- a/tests/core/utilities/auto-match.test.ts
+++ b/tests/core/utilities/auto-match.test.ts
@@ -192,8 +192,17 @@ describe('detectShow', () => {
         // extension; a plain trailing "[HorribleSubs]" is not captured.
         releaseGroup: null,
         ruleName: 'trash-anime',
-        season: null,
+        season: 1,
         showName: 'That Time I Got Reincarnated as a Slime (2018)',
+      });
+    });
+
+    it('takes the episode number from the SxxExx marker, not the trailing absolute number', () => {
+      expectParsed('Generic Show Title (2020) - S02E08 - 021 - The Episode Title [Group].mkv', {
+        episodeEnd: 8,
+        episodeStart: 8,
+        ruleName: 'trash-anime',
+        season: 2,
       });
     });
 
@@ -400,25 +409,11 @@ describe('detectShow', () => {
   });
 
   describe('reversed-1', () => {
-    // APPARENT BUG: the capture group is written `(?<showName>[^[]+])` — the
-    // stray `]` after the `+` is a REQUIRED literal, so showName must end with
-    // a literal "]". Realistic "NN - Title.ext" names therefore never match
-    // this rule; they fall all the way through to `fallback`.
-    it('only matches when the title is followed by a stray literal "]"', () => {
-      expectParsed('01 - Show Name].mkv', {
+    it('parses "NN - Title [res].ext" names', () => {
+      expectParsed('01 - Generic Show Title [1080p].mkv', {
         episodeStart: 1,
         ruleName: 'reversed-1',
-        showName: 'Show Name]',
-      });
-    });
-
-    it('realistic "NN - Title [res].ext" names are handled by `fallback` instead (see discrepancy comment)', () => {
-      expectParsed('01 - Cowboy Bebop [1080p].mkv', {
-        episodeStart: 1,
-        ruleName: 'fallback',
-        // quirk: fallback parses "01 " as the show name and "Cowboy Bebop" as
-        // the episode name, which defaultTransform re-stitches to "01- Cowboy Bebop"
-        showName: '01- Cowboy Bebop',
+        showName: 'Generic Show Title',
       });
     });
   });
@@ -517,6 +512,13 @@ describe('detectShow — defaultTransform effects (module-private, asserted thro
       episodeType: 'Credits',
       ruleName: 'default',
       showName: 'Show Name NC',
+    });
+  });
+
+  it('theme song matched by a rule without an isThemeSong group (raws-2) still gets episodeType Credits', () => {
+    expectParsed('Show.Name.S01E01.NCED.1080p.WEB.h264-Group.mkv', {
+      episodeType: 'Credits',
+      ruleName: 'raws-2',
     });
   });
 

--- a/tests/core/utilities/auto-match.test.ts
+++ b/tests/core/utilities/auto-match.test.ts
@@ -206,9 +206,25 @@ describe('detectShow', () => {
       });
     });
 
+    it('keeps the SxxExx range for multi-episode files', () => {
+      expectParsed('Generic Show Title (2020) - S02E05-E06 - 021-022 - The Episode Title [Group].mkv', {
+        episodeEnd: 6,
+        episodeStart: 5,
+        ruleName: 'trash-anime',
+        season: 2,
+      });
+    });
+
     it('flags S00 specials via the isSpecial group -> episodeType Special', () => {
       expectParsed('That Time I Got Reincarnated as a Slime (2018) - S00E01 - 1 - A New Beginning [HorribleSubs].mkv', {
         episodeStart: 1,
+        episodeType: 'Special',
+        ruleName: 'trash-anime',
+      });
+    });
+
+    it('an isSpecial S00 keeps episodeType Special even when the title carries a theme-song token', () => {
+      expectParsed('Generic Show Title (2020) - S00E01 - 12 - NCED [Group].mkv', {
         episodeType: 'Special',
         ruleName: 'trash-anime',
       });


### PR DESCRIPTION
## Targeted follow-up to #1450

Rescoped from the original broad-rule rewrite. Per review discussion, the WebUI auto-match rules are a **fallback path** (series select + auto-match episode in the edit-release-info modal) — the offline importer normally does the matching, and adding a WebUI regex per filename shape just grows maintenance. So this drops the speculative broadening (`marker-first`, `raws-3` tightening, scene-edition-tag / dot-underscore delimiter tolerance) and keeps only fixes that are bugs regardless of filename shape.

### Fixes in `src/core/utilities/auto-match-regexes.ts`

- **`reversed-1`**: the show-name class was `[^[]+]` — the trailing `]` is a required literal, so a plain `05 - Show Name [1080p].mkv` never matched and fell through to `fallback` as `05- Show Name`. Dropped the stray `]`.
- **`trash-anime`**: take the episode number from the `SxxExx` marker, not the trailing absolute number. The search and the cross-reference matcher both poll AniDB, which catalogues a multi-cour show as separate entries each numbered from 1, so `... - S02E08 - 021 - ...` is episode **8**, not 21. A single absolute-numbered entry keeps season 1 in Sonarr, so the two numbers are identical there. Also captures the season, and keeps the `SxxExx` range for multi-episode files.
- **`defaultTransform`**: theme songs matched by a rule with no `isThemeSong` group (`raws-*`, `trailing-native-title`) came out as `Episode`. `episodeType` is now set to `Credits` in the theme block where the theme song is actually detected — but only from the plain `Episode` default, so an `isSpecial`/`isTrailer` classification still wins.

### Also

- Documents the ordered / first-match-wins rule-set contract on `PathMatchRuleSet` (requested in review).
- Tests moved onto the Vitest suite added in #1459 (`tests/core/utilities/auto-match.test.ts`): updated `reversed-1` / `trash-anime` expectations and added multi-cour, multi-episode-range + theme-song-via-raws cases. New cases use generic placeholder filenames (`Generic Show Title`, `Show Name`) rather than real release names.

Verification: `pnpm test` (184 pass), `pnpm lint`.