### PR TITLE
fix: normalize relative path display and managed folder context

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ React 19 + Vite frontend for the Shoko Anime Management Server.
 
 ## Build & Development
 
-> **Node >=22, pnpm only.** CI uses Node 24 and pnpm 11.
+> **Node >=22, pnpm only.** CI uses Node 24 and pnpm 11. pnpm version is not pinned locally (no `packageManager`/`.npmrc`); `mise.toml` pins Node 24 for local dev.
 
 ```bash
 pnpm install          # Also sets up Husky via the `prepare` script
@@ -40,11 +40,11 @@ pnpm lint           # dprint -> oxlint -> stylelint
   - `axiosV2` — Shoko API v2 (`/api`)
   - `axiosPlex` — Plex endpoints (`/plex`)
   - `axiosExternal` — Unconfigured base for external calls
-  - v3/v2/Plex clients auto-attach `apikey` from Redux; all unwrap `response.data`.
-- **Real-time:** SignalR client in `src/core/signalr`, integrated as Redux middleware.
+  - v3/v2/Plex clients auto-attach `apikey` from Redux; all unwrap `response.data`. A 401 on an authenticated request dispatches `AUTH_LOGOUT`.
+- **Real-time:** SignalR client in `src/core/signalr`, integrated as Redux middleware. Connects on `MAINPAGE_LOADED` to `/signalr/aggregate` (feed list via query param), authenticates with the apikey, and stops on `AUTH_LOGOUT`. Event handlers invalidate React Query caches and dispatch slice actions.
 - **Redux:** Single-file store at `src/core/store.ts`. Root reducer clears all state on `AUTH_LOGOUT`. Full store persisted to `sessionStorage`; only `apiSession` persisted to `localStorage` (when `rememberUser` is true). Store is throttled to persist at most once per second. Re-exports typed `useDispatch`/`useSelector` — import from `@/core/store`, never from `react-redux` directly.
-- **React Query:** Organized by API sub-path under `src/core/react-query/<endpoint>/` with `queries.ts`, `mutations.ts`, `types.ts`, and optional `helpers.ts`.
-- **Build:** Vite 8 with Rolldown. Base path `/webui/`. Hidden sourcemaps. React Compiler enabled via `@rolldown/plugin-babel`. Sentry plugin requires `SENTRY_AUTH_TOKEN`. `version.json` is auto-generated at build time from git hash + package version.
+- **React Query:** Organized by API sub-path under `src/core/react-query/<endpoint>/`, typically with `queries.ts`, `mutations.ts`, `types.ts`, and optional `helpers.ts` (subsets are common; shared files live at `src/core/react-query/` top level, e.g. `queryClient.ts`).
+- **Build:** Vite 8 with Rolldown. Base path `/webui/`. Hidden sourcemaps. React Compiler enabled via `@rolldown/plugin-babel`. Sentry plugin requires `SENTRY_AUTH_TOKEN`. `version.json` is auto-generated at build time from git hash + package version. The minimum server version gate is hardcoded in `vite.config.mjs` (`VITE_MIN_SERVER_VERSION`).
 - **Tailwind:** v4 via Vite plugin. Entry point is `src/css/tailwind.css`.
 - **Path alias:** `@/` maps to `src/` (configured in `vite.config.mjs` and `tsconfig.json`).
 
@@ -55,19 +55,19 @@ This project uses the **React Compiler** (via `@rolldown/plugin-babel`). The com
 ## Code Style
 
 - **Formatter:** `dprint` (`.dprint.json`). Covers `src/**` only. Line width 120, single quotes (double quotes in JSX), always semicolons.
-- **Linter:** Oxlint (`.oxlintrc.json`). Migrated from ESLint. Uses built-in plugins (typescript, react, import, jsx-a11y) and JS plugins (@tanstack/query, better-tailwindcss, sort-destructure-keys, @stylistic).
+- **Linter:** Oxlint (`.oxlintrc.json`). Migrated from ESLint. Uses built-in plugins (eslint, typescript, react, import) and JS plugins (@tanstack/query, better-tailwindcss, sort-destructure-keys, @stylistic, react-hooks, perfectionist).
 - **TypeScript:** Prefer `type` over `interface`. Prefer `T[]` syntax. Use consistent type imports. Multiline type members use semicolons; single-line members use commas.
 - **Functions:** Arrow-function expressions only (`const Foo = () => ...`). Omit parens for single parameters; require them for block bodies.
-- **Identifiers:** Minimum 3 characters. Exceptions: `cx`, `ID`, `id`, `_`, `__`. Object properties are exempt.
+- **Identifiers:** Minimum 3 characters. Exceptions: `cx`, `ID`, `id`, `to`, `TV`, `_`, `__`. Object properties are exempt.
 - **Unused variables:** Prefix with `_` to suppress `no-unused-vars` (applies to args, vars, and caught errors).
 - **Nullish coalescing:** Use `??` instead of `||`, except for boolean values where `||` is acceptable.
-- **Imports:** Use `@/` alias instead of relative `../` paths. Import order is enforced with blank lines between groups (builtin → external → internal → parent → sibling → index → type), alphabetized within each group. `react*` imports sort first among externals. Named imports/exports are sorted alphabetically (case-sensitive) within each declaration.
+- **Imports:** Use `@/` alias instead of relative `../` paths. Don't hand-order imports — import order is enforced by `perfectionist/sort-imports` and auto-fixed by oxlint (see the Agent lint workflow; write imports in any order and let the fixer sort them).
 - **Destructuring:** Object destructuring keys must be sorted alphabetically.
 - **Restricted imports** (will error if imported directly):
   - `../*` (relative parent imports) → use `@/` alias instead
   - `react-redux`: `useDispatch`, `useSelector` → use `@/core/store`
   - `react-router`: `useNavigate` → use `@/hooks/useNavigateVoid`
-  - `react-toastify`: `toast` → use `@/components/Toast`
+  - `react-toastify`: `toast` → use `@/core/toast`
   - `usehooks-ts`: `useCopyToClipboard` → use `copyToClipboard` from `@/core/util`
 - **State mutations:** `no-param-reassign` allows `sliceState` and `draft*` properties for Immer/Redux.
 - **Console:** Only `console.warn` and `console.error` are allowed.
@@ -76,12 +76,13 @@ This project uses the **React Compiler** (via `@rolldown/plugin-babel`). The com
 
 ## Verification & CI
 
-- **No unit/integration tests** are configured. Verification is `pnpm lint`.
+- **No unit/integration tests** are configured. Verification is `pnpm lint` (typecheck: `pnpm tscheck`).
+- **Other CI workflows:** `Release-Dev-Auto.yml` (auto build on `master` push), `Release-Manual.yml`, `Update-Manifest.yml`, CodeQL.
 - **Pre-commit:** Husky runs `lint-staged` (configured in `lint-staged.config.js`), which executes `dprint fmt`, `oxlint`, and `stylelint` on staged files. `stylelint` only covers `src/css/*.css` (flat, not recursive).
 - **PR CI:** `.github/workflows/Lint-PR.yml` runs `pnpm lint --quiet`.
 - **Agent lint workflow:**
   - After every file edit, run `./node_modules/.bin/dprint fmt <file>` to format just that file.
-  - After completing edits on a file, run `./node_modules/.bin/oxlint <file>` to catch lint errors early — fix them before moving on.
+  - After completing edits on a file, run `./node_modules/.bin/oxlint --fix <file>` to catch lint errors early (auto-fixes import order and other fixable rules) — fix any remaining errors before moving on.
 - **Never skip pre-commit hooks.** Always let Husky run — do not use `--no-verify` or equivalent.
 
 ## Guardrails
@@ -91,6 +92,7 @@ This project uses the **React Compiler** (via `@rolldown/plugin-babel`). The com
 - Do not add explicit type annotations where TS inference is sufficient.
 - Treat changes to `src/core/axios.ts`, `src/core/store.ts`, and auth-related logic with extra scrutiny.
 - If you modify files, styles, structures, configurations, or workflows mentioned in this file, update the corresponding `AGENTS.md` sections to keep them accurate.
+- **`@/core/util` is a single file (`src/core/util.ts`), not a directory** — do not confuse with `src/core/utilities/`.
 - **Use `semver` for version comparisons** — hand-rolling version parsing with `Number.parseInt`/`split('.')` silently mishandles pre-release suffixes.
 - **Use `dayjs` for date formatting/manipulation** — never use `new Date()` / `.toLocaleString()` for display. Always import from `@/core/util`: `import { dayjs } from '@/core/util'`. Plugins and locale are pre-configured there.
 - **`lodash`** — before writing custom utility functions for grouping, sorting, filtering, debouncing, throttling, or deep equality, check if lodash already provides it.

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@
     ```bash
     pnpm start
     ```
-    Open [http://localhost:3000](http://localhost:3000) to view it in the browser.
+    Open [http://localhost:3000/webui/](http://localhost:3000/webui/) to view it in the browser.
 
 ## 🏗️ Architecture
 

--- a/src/components/Utilities/DuplicateFiles/DuplicatesInfo.tsx
+++ b/src/components/Utilities/DuplicateFiles/DuplicatesInfo.tsx
@@ -5,10 +5,11 @@ import cx from 'classnames';
 
 import ConfirmationPromptModal from '@/components/Dialogs/ConfirmationPromptModal';
 import Button from '@/components/Input/Button';
+import { formatFolderPath } from '@/components/Utilities/constants';
 import { useDeleteFileLocationMutation } from '@/core/react-query/file/mutations';
-import { useManagedFoldersQuery } from '@/core/react-query/managed-folder/queries';
 import { invalidateQueries } from '@/core/react-query/queryClient';
 import { extractFileNameFromPath } from '@/core/util';
+import useManagedFolderName from '@/hooks/useManagedFolderName';
 import useToggleModalKeybinds from '@/hooks/useToggleModalKeybinds';
 
 import type { FileLocationType, FileType } from '@/core/types/api/file';
@@ -20,8 +21,6 @@ type Props = {
 
 const DuplicatesInfo = ({ file, location }: Props) => {
   const [confirmDelete, setConfirmDelete] = useState(false);
-
-  const managedFoldersQuery = useManagedFoldersQuery();
 
   const { mutateAsync: deleteFileLocation } = useDeleteFileLocationMutation();
 
@@ -37,9 +36,7 @@ const DuplicatesInfo = ({ file, location }: Props) => {
 
   const path = location.RelativePath ?? '';
   const { fileName, relativePath } = extractFileNameFromPath(path);
-  const folderName = managedFoldersQuery.data?.find(
-    folder => folder.ID === location.ManagedFolderID,
-  )?.Name ?? '';
+  const folderName = useManagedFolderName(location.ManagedFolderID);
   const isDeleted = !location.AbsolutePath;
 
   return (
@@ -62,9 +59,7 @@ const DuplicatesInfo = ({ file, location }: Props) => {
             data-tooltip-delay-show={500}
           >
             <span className="line-clamp-1 truncate text-sm font-semibold opacity-65">
-              {folderName}
-              &nbsp;-&nbsp;
-              {relativePath}
+              {formatFolderPath(folderName, relativePath)}
             </span>
             <span className="line-clamp-1 truncate">
               {fileName}
@@ -96,9 +91,7 @@ const DuplicatesInfo = ({ file, location }: Props) => {
         Do you want to delete the following file location?
         <div className="flex flex-col gap-1">
           <div className="text-sm opacity-65">
-            {folderName}
-            &nbsp;-&nbsp;
-            {relativePath}
+            {formatFolderPath(folderName, relativePath)}
           </div>
           <div className="text-panel-text-important">
             {fileName}

--- a/src/components/Utilities/LinkFilesWithProvider/SelectedFilesModal.tsx
+++ b/src/components/Utilities/LinkFilesWithProvider/SelectedFilesModal.tsx
@@ -1,8 +1,9 @@
 import { useHotkeys } from 'react-hotkeys-hook';
 
 import ModalPanel from '@/components/Panels/ModalPanel';
+import { formatFolderPath } from '@/components/Utilities/constants';
 import { useManagedFoldersQuery } from '@/core/react-query/managed-folder/queries';
-import { extractFileNameFromPath } from '@/core/util';
+import { extractFileNameFromPath, getManagedFolderName } from '@/core/util';
 import useToggleModalKeybinds from '@/hooks/useToggleModalKeybinds';
 
 import type { FileType } from '@/core/types/api/file';
@@ -33,9 +34,7 @@ const SelectedFilesModal = ({ files, onClose, show }: Props) => {
           const location = file.Locations[0];
           const path = location?.RelativePath ?? '';
           const { fileName, relativePath } = extractFileNameFromPath(path);
-          const folderName = managedFoldersQuery.data?.find(
-            folder => folder.ID === location?.ManagedFolderID,
-          )?.Name ?? '';
+          const folderName = getManagedFolderName(managedFoldersQuery.data ?? [], location?.ManagedFolderID);
 
           return (
             <div
@@ -46,9 +45,7 @@ const SelectedFilesModal = ({ files, onClose, show }: Props) => {
               data-tooltip-delay-show={200}
             >
               <span className="line-clamp-1 truncate text-xs font-semibold opacity-65">
-                {folderName}
-                &nbsp;-&nbsp;
-                {relativePath}
+                {formatFolderPath(folderName, relativePath)}
               </span>
               <span className="line-clamp-1 truncate text-sm">{fileName ?? `<missing file path for ${file.ID}>`}</span>
             </div>

--- a/src/components/Utilities/LinkFilesWithProvider/VideoMetadata.tsx
+++ b/src/components/Utilities/LinkFilesWithProvider/VideoMetadata.tsx
@@ -1,4 +1,6 @@
+import { formatFolderPath } from '@/components/Utilities/constants';
 import { extractFileNameFromPath } from '@/core/util';
+import useManagedFolderName from '@/hooks/useManagedFolderName';
 
 import type { ReleaseSourceValues } from '@/core/types/api/file';
 import type { ManualLinkType } from '@/core/types/utilities/link-files-with-providers';
@@ -16,6 +18,7 @@ const VideoMetadata = ({ link }: { link: ManualLinkType }) => {
   const { file } = link;
   const path = file.Locations[0]?.RelativePath ?? '';
   const { fileName, relativePath } = extractFileNameFromPath(path);
+  const folderName = useManagedFolderName(file.Locations[0]?.ManagedFolderID);
 
   return (
     <div className="flex flex-col gap-2 border-y border-panel-border text-sm">
@@ -27,7 +30,7 @@ const VideoMetadata = ({ link }: { link: ManualLinkType }) => {
           data-tooltip-delay-show={500}
         >
           <span className="line-clamp-1 text-sm font-semibold opacity-65">
-            {relativePath}
+            {formatFolderPath(folderName, relativePath)}
           </span>
           <span className="line-clamp-1">
             {fileName}

--- a/src/components/Utilities/constants.tsx
+++ b/src/components/Utilities/constants.tsx
@@ -1,8 +1,7 @@
 import type { ReactNode } from 'react';
-import { find } from 'lodash';
 import prettyBytes from 'pretty-bytes';
 
-import { dayjs, extractFileNameFromPath } from '@/core/util';
+import { dayjs, extractFileNameFromPath, getManagedFolderName } from '@/core/util';
 
 import type { EpisodeType } from '@/core/types/api/episode';
 import type { FileType } from '@/core/types/api/file';
@@ -30,10 +29,7 @@ export const getManagedFolderColumn = (managedFolders: ManagedFolderType[]): Uti
   name: 'Managed Folder',
   className: 'w-46',
   item: (file) => {
-    const managedFolder = find(
-      managedFolders,
-      { ID: file?.Locations[0]?.ManagedFolderID ?? -1 },
-    )?.Name ?? '<Unknown>';
+    const managedFolder = getManagedFolderName(managedFolders, file?.Locations[0]?.ManagedFolderID);
 
     return (
       <div
@@ -48,13 +44,21 @@ export const getManagedFolderColumn = (managedFolders: ManagedFolderType[]): Uti
   },
 });
 
-export const fileNameColumn: UtilityHeaderType<FileType> = {
+/** Standard display label pairing the managed folder name with the folder-relative path. */
+export const formatFolderPath = (folderName: string, relativePath: string) => (
+  folderName ? `${folderName} - ${relativePath}` : relativePath
+);
+
+export const getFileNameColumn = (managedFolders?: ManagedFolderType[]): UtilityHeaderType<FileType> => ({
   id: 'filename',
   name: 'Filename',
   className: 'line-clamp-2 grow basis-0 overflow-hidden',
   item: (file) => {
     const path = file.Locations[0]?.RelativePath ?? '';
     const { fileName, relativePath } = extractFileNameFromPath(path);
+    const folderName = managedFolders
+      ? getManagedFolderName(managedFolders, file?.Locations[0]?.ManagedFolderID)
+      : '';
     return (
       <div
         className="flex flex-col"
@@ -63,7 +67,7 @@ export const fileNameColumn: UtilityHeaderType<FileType> = {
         data-tooltip-delay-show={500}
       >
         <span className="line-clamp-1 text-sm font-semibold opacity-65">
-          {relativePath}
+          {formatFolderPath(folderName, relativePath)}
         </span>
         <span className="line-clamp-1">
           {fileName}
@@ -71,10 +75,10 @@ export const fileNameColumn: UtilityHeaderType<FileType> = {
       </div>
     );
   },
-};
+});
 
 export const staticColumns: UtilityHeaderType<FileType>[] = [
-  fileNameColumn,
+  getFileNameColumn(),
   {
     id: 'crc32',
     name: 'CRC32',

--- a/src/core/react-query/managed-folder/queries.ts
+++ b/src/core/react-query/managed-folder/queries.ts
@@ -5,9 +5,10 @@ import { INFINITE_STALE_TIME } from '@/core/util';
 
 import type { ManagedFolderType } from '@/core/types/api/managed-folder';
 
-export const useManagedFoldersQuery = () =>
+export const useManagedFoldersQuery = (enabled = true) =>
   useQuery<ManagedFolderType[]>({
     queryKey: ['managed-folder'],
     queryFn: () => axios.get('ManagedFolder'),
     staleTime: INFINITE_STALE_TIME,
+    enabled,
   });

--- a/src/core/react-query/managed-folder/queries.ts
+++ b/src/core/react-query/managed-folder/queries.ts
@@ -1,7 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 
 import { axios } from '@/core/axios';
-import { INFINITE_STALE_TIME } from '@/core/util';
 
 import type { ManagedFolderType } from '@/core/types/api/managed-folder';
 
@@ -9,6 +8,6 @@ export const useManagedFoldersQuery = (enabled = true) =>
   useQuery<ManagedFolderType[]>({
     queryKey: ['managed-folder'],
     queryFn: () => axios.get('ManagedFolder'),
-    staleTime: INFINITE_STALE_TIME,
+    staleTime: Infinity,
     enabled,
   });

--- a/src/core/react-query/plugin/queries.ts
+++ b/src/core/react-query/plugin/queries.ts
@@ -1,7 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 
 import { axios } from '@/core/axios';
-import { INFINITE_STALE_TIME } from '@/core/util';
 
 import type { PluginListFilterType } from '@/core/react-query/plugin/types';
 import type { PluginInfoType, PluginPageType, SharedPluginPageType } from '@/core/types/api/plugin';
@@ -17,13 +16,13 @@ export const usePluginPagesQuery = () =>
   useQuery<SharedPluginPageType[]>({
     queryKey: ['plugin', 'pages'],
     queryFn: () => axios.get('Plugin/Pages'),
-    staleTime: INFINITE_STALE_TIME,
+    staleTime: Infinity,
   });
 
 export const usePluginPagesForPluginQuery = (pluginId: string, enabled = true) =>
   useQuery<PluginPageType[]>({
     queryKey: ['plugin', 'pages', pluginId],
     queryFn: () => axios.get(`Plugin/${pluginId}/Pages`),
-    staleTime: INFINITE_STALE_TIME,
+    staleTime: Infinity,
     enabled,
   });

--- a/src/core/util.ts
+++ b/src/core/util.ts
@@ -30,7 +30,11 @@ export { default as dayjs } from 'dayjs';
 
 export * from '@/core/anidbUtils';
 
-/** Shared stale time: ~100 days. Used for relatively static data that rarely changes server-side. */
+/**
+ * Shared stale time: ~100 days. Used for relatively static data that rarely changes server-side.
+ * Must remain finite: unlike `staleTime: Infinity`, a finite value keeps `initialData`
+ * (paired with `initialDataUpdatedAt`) behaving as placeholder data — see useSettingsQuery.
+ */
 export const INFINITE_STALE_TIME = 86400 * 100000;
 
 // Enables immer plugin to support Map and Set

--- a/src/core/util.ts
+++ b/src/core/util.ts
@@ -7,13 +7,14 @@ import customParseFormatPlugin from 'dayjs/plugin/customParseFormat';
 import durationPlugin from 'dayjs/plugin/duration';
 import formatThousands from 'format-thousands';
 import { enableMapSet } from 'immer';
-import { reduce, toNumber } from 'lodash';
+import { find, reduce, toNumber } from 'lodash';
 
 import toast from '@/core/toast';
 
 import type { CollectionGroupType } from './types/api/collection';
 import type { EpisodeType } from './types/api/episode';
 import type { FileType } from './types/api/file';
+import type { ManagedFolderType } from './types/api/managed-folder';
 import type { SeriesType } from './types/api/series';
 import type { ManualLinkType } from './types/utilities/link-files-with-providers';
 import type { ShokoError } from '@/core/types/api';
@@ -151,10 +152,14 @@ export const handleShiftSelect = (params: {
 /** Root font size in px, read once from the document. */
 export const pxPerRem = parseFloat(getComputedStyle(document.documentElement).fontSize);
 
+/** Standard display label pairing the managed folder name with the folder-relative path. */
+export const getManagedFolderName = (managedFolders: ManagedFolderType[], managedFolderID?: number) =>
+  find(managedFolders, { ID: managedFolderID ?? -1 })?.Name ?? '<Unknown>';
+
 export const extractFileNameFromPath = (path: string) => {
-  const match = /[/\\](?=[^/\\]*$)/g.exec(path);
-  const relativePath = match ? path.substring(0, match.index) : 'Root Level';
-  const fileName = path.split(/[/\\]/g).pop();
+  const parts = path.split(/[/\\]/g);
+  const fileName = parts.pop();
+  const relativePath = parts.filter(Boolean).join('/') || 'Root Level';
   return {
     fileName,
     relativePath,

--- a/src/hooks/useManagedFolderName.ts
+++ b/src/hooks/useManagedFolderName.ts
@@ -1,0 +1,9 @@
+import { useManagedFoldersQuery } from '@/core/react-query/managed-folder/queries';
+import { getManagedFolderName } from '@/core/util';
+
+const useManagedFolderName = (managedFolderID?: number) => {
+  const managedFoldersQuery = useManagedFoldersQuery(managedFolderID != null);
+  return getManagedFolderName(managedFoldersQuery.data ?? [], managedFolderID);
+};
+
+export default useManagedFolderName;

--- a/src/pages/utilities/DuplicateFilesTabs/DuplicateFilesUnrecognizedTab.tsx
+++ b/src/pages/utilities/DuplicateFilesTabs/DuplicateFilesUnrecognizedTab.tsx
@@ -6,7 +6,7 @@ import { useToggle } from 'usehooks-ts';
 
 import Input from '@/components/Input/Input';
 import ShokoPanel from '@/components/Panels/ShokoPanel';
-import { fileNameColumn, getManagedFolderColumn } from '@/components/Utilities/constants';
+import { getFileNameColumn, getManagedFolderColumn } from '@/components/Utilities/constants';
 import DuplicateFilesModal from '@/components/Utilities/DuplicateFiles/DuplicateFilesModal';
 import Title from '@/components/Utilities/DuplicateFiles/Title';
 import ItemCount from '@/components/Utilities/ItemCount';
@@ -52,7 +52,7 @@ const DuplicateFilesUnrecognizedTab = () => {
 
   const columns: UtilityHeaderType<FileType>[] = [
     getManagedFolderColumn(managedFolders),
-    fileNameColumn,
+    getFileNameColumn(),
     {
       id: 'duplicate-count',
       name: 'Duplicate Count',

--- a/src/pages/utilities/FileSearch.tsx
+++ b/src/pages/utilities/FileSearch.tsx
@@ -26,7 +26,7 @@ import Button from '@/components/Input/Button';
 import Input from '@/components/Input/Input';
 import ShokoPanel from '@/components/Panels/ShokoPanel';
 import ShokoIcon from '@/components/ShokoIcon';
-import { staticColumns } from '@/components/Utilities/constants';
+import { getFileNameColumn, staticColumns } from '@/components/Utilities/constants';
 import FilesSummary from '@/components/Utilities/FilesSummary';
 import ItemCount from '@/components/Utilities/ItemCount';
 import MenuButton from '@/components/Utilities/Unrecognized/MenuButton';
@@ -38,6 +38,7 @@ import {
   useRescanFileMutation,
 } from '@/core/react-query/file/mutations';
 import { useFileQuery, useFilesInfiniteQuery } from '@/core/react-query/file/queries';
+import { useManagedFoldersQuery } from '@/core/react-query/managed-folder/queries';
 import { invalidateQueries } from '@/core/react-query/queryClient';
 import { useSeriesQuery } from '@/core/react-query/series/queries';
 import { addFiles } from '@/core/slices/utilities/renamer';
@@ -51,6 +52,7 @@ import useNavigateVoid from '@/hooks/useNavigateVoid';
 import useRowSelection from '@/hooks/useRowSelection';
 import useTableSearchSortCriteria from '@/hooks/utilities/useTableSearchSortCriteria';
 
+import type { UtilityHeaderType } from '@/components/Utilities/constants';
 import type { FileType } from '@/core/types/api/file';
 import type { Updater } from 'use-immer';
 
@@ -363,6 +365,12 @@ const FileSearch = () => {
     pageSize: 50,
   }, debouncedSearch);
   const [files, fileCount] = useFlattenListResult<FileType>(filesQuery.data);
+  const managedFoldersQuery = useManagedFoldersQuery();
+  const columns: UtilityHeaderType<FileType>[] = [
+    getFileNameColumn(managedFoldersQuery.data ?? []),
+    // Assumes the filename column is the first entry of staticColumns; update if staticColumns is reordered
+    ...staticColumns.slice(1),
+  ];
 
   const {
     handleRowSelect,
@@ -428,7 +436,7 @@ const FileSearch = () => {
                 count={fileCount}
                 fetchNextPage={filesQuery.fetchNextPage}
                 handleRowSelect={handleRowSelect}
-                columns={staticColumns}
+                columns={columns}
                 isFetchingNextPage={filesQuery.isFetchingNextPage}
                 rows={files}
                 rowSelection={rowSelection}

--- a/src/pages/utilities/Renamer.tsx
+++ b/src/pages/utilities/Renamer.tsx
@@ -27,6 +27,7 @@ import Button from '@/components/Input/Button';
 import Checkbox from '@/components/Input/Checkbox';
 import Select from '@/components/Input/Select';
 import ShokoPanel from '@/components/Panels/ShokoPanel';
+import { formatFolderPath } from '@/components/Utilities/constants';
 import AddFilesModal from '@/components/Utilities/Renamer/AddFilesModal';
 import PresetModal from '@/components/Utilities/Renamer/PresetModal';
 import RenamerScript from '@/components/Utilities/Renamer/RenamerScript';
@@ -50,7 +51,7 @@ import { useSettingsQuery } from '@/core/react-query/settings/queries';
 import { clearFiles, clearResults, removeFiles } from '@/core/slices/utilities/renamer';
 import { useDispatch, useSelector } from '@/core/store';
 import toast from '@/core/toast';
-import { extractFileNameFromPath } from '@/core/util';
+import { extractFileNameFromPath, getManagedFolderName } from '@/core/util';
 import useRowSelection from '@/hooks/useRowSelection';
 
 import type { UtilityHeaderType } from '@/components/Utilities/constants';
@@ -69,10 +70,7 @@ const getFileColumn = (managedFolders: ManagedFolderType[]) => ({
   item: (file) => {
     const path = file.Locations[0]?.RelativePath ?? '';
     const { fileName, relativePath } = extractFileNameFromPath(path);
-    const managedFolder = find(
-      managedFolders,
-      { ID: file?.Locations[0]?.ManagedFolderID ?? -1 },
-    )?.Name ?? '<Unknown>';
+    const managedFolder = getManagedFolderName(managedFolders, file?.Locations[0]?.ManagedFolderID);
     return (
       <div
         className="flex flex-col"
@@ -81,7 +79,7 @@ const getFileColumn = (managedFolders: ManagedFolderType[]) => ({
         data-tooltip-delay-show={500}
       >
         <span className="line-clamp-1 text-sm font-semibold opacity-65">
-          {`${managedFolder} - ${relativePath}`}
+          {formatFolderPath(managedFolder, relativePath)}
         </span>
         <span className="line-clamp-1 break-all">
           {fileName}
@@ -123,10 +121,7 @@ const getResultColumn = (
 
     const path = result.RelativePath ?? '';
     const { fileName, relativePath } = extractFileNameFromPath(path);
-    const managedFolder = find(
-      managedFolders,
-      { ID: result.ManagedFolderID ?? -1 },
-    )?.Name ?? '<Unknown>';
+    const managedFolder = getManagedFolderName(managedFolders, result.ManagedFolderID);
 
     return (
       <div
@@ -136,7 +131,7 @@ const getResultColumn = (
         data-tooltip-delay-show={500}
       >
         <span className="line-clamp-1 text-sm font-semibold opacity-65">
-          {`${managedFolder} - ${relativePath}`}
+          {formatFolderPath(managedFolder, relativePath)}
         </span>
         <span className="line-clamp-1 break-all">
           {fileName}
@@ -183,34 +178,13 @@ const getStatusIcon = (result?: RelocationResultType, noChange = false) => {
 
 const getStatusColumn = (
   renameResults: Record<number, RelocationResultType>,
-  managedFolders: ManagedFolderType[],
-  moveFiles: boolean,
 ) => ({
   id: 'status',
   name: 'Status',
   className: 'w-16',
   item: (file) => {
     const result = renameResults[file.ID];
-    let noChange = false;
-
-    if (result) {
-      const path = file.Locations[0]?.RelativePath ?? '';
-      const { relativePath } = extractFileNameFromPath(path);
-      const managedFolder = find(
-        managedFolders,
-        { ID: file?.Locations[0]?.ManagedFolderID ?? -1 },
-      )?.Name ?? '<Unknown>';
-
-      const newPath = result.RelativePath ?? '';
-      const { relativePath: newRelativePath } = extractFileNameFromPath(newPath);
-      const newManagedFolder = find(
-        managedFolders,
-        { ID: result?.ManagedFolderID ?? -1 },
-      )?.Name ?? '<Unknown>';
-
-      noChange = (path === newPath) && (!moveFiles
-        || (managedFolder === newManagedFolder && relativePath === newRelativePath));
-    }
+    const noChange = result?.IsRelocated === false;
 
     return (
       <div className="flex justify-center">
@@ -471,9 +445,9 @@ const Renamer = () => {
     return [
       getFileColumn(managedFolders),
       getResultColumn(relocationResults, managedFolders),
-      getStatusColumn(relocationResults, managedFolders, moveFiles),
+      getStatusColumn(relocationResults),
     ];
-  }, [managedFoldersQuery?.data, moveFiles, relocationResults]);
+  }, [managedFoldersQuery?.data, relocationResults]);
 
   const handleRename = () => {
     if (!selectedPreset || !addedFiles.length) return;

--- a/src/pages/utilities/UnrecognizedUtilityTabs/LinkFilesTab.tsx
+++ b/src/pages/utilities/UnrecognizedUtilityTabs/LinkFilesTab.tsx
@@ -20,6 +20,7 @@ import Button from '@/components/Input/Button';
 import SelectEpisodeList from '@/components/Input/SelectEpisodeList';
 import ShokoPanel from '@/components/Panels/ShokoPanel';
 import TransitionDiv from '@/components/TransitionDiv';
+import { formatFolderPath } from '@/components/Utilities/constants';
 import ItemCount from '@/components/Utilities/ItemCount';
 import AnimeSelectPanel from '@/components/Utilities/Unrecognized/AnimeSelectPanel';
 import MenuButton from '@/components/Utilities/Unrecognized/MenuButton';
@@ -29,6 +30,7 @@ import {
   useLinkManyFilesToOneEpisodeMutation,
   useLinkOneFileToManyEpisodesMutation,
 } from '@/core/react-query/file/mutations';
+import { useManagedFoldersQuery } from '@/core/react-query/managed-folder/queries';
 import {
   useDeleteSeriesMutation,
   useGetSeriesAniDBMutation,
@@ -36,7 +38,7 @@ import {
 } from '@/core/react-query/series/mutations';
 import { useSeriesAniDBEpisodesQuery, useSeriesEpisodesInfiniteQuery } from '@/core/react-query/series/queries';
 import toast from '@/core/toast';
-import { extractFileNameFromPath, getAnidbAnimeLink } from '@/core/util';
+import { extractFileNameFromPath, getAnidbAnimeLink, getManagedFolderName } from '@/core/util';
 import { detectShow, findMostCommonShowName } from '@/core/utilities/auto-match-logic';
 import useNavigateVoid from '@/hooks/useNavigateVoid';
 
@@ -139,6 +141,7 @@ const LinkFilesTab = () => {
     },
     false,
   );
+  const managedFoldersQuery = useManagedFoldersQuery();
   const anidbEpisodesQuery = useSeriesAniDBEpisodesQuery(
     selectedSeries.ID,
     {
@@ -500,6 +503,7 @@ const LinkFilesTab = () => {
       const file = find(selectedRows, ['ID', link.FileID]);
       const path = file?.Locations?.[0]?.RelativePath ?? '<missing file path>';
       const { fileName, relativePath } = extractFileNameFromPath(path);
+      const folderName = getManagedFolderName(managedFoldersQuery.data ?? [], file?.Locations?.[0]?.ManagedFolderID);
 
       return (
         <div
@@ -513,7 +517,7 @@ const LinkFilesTab = () => {
           data-tooltip-content={path}
         >
           <span className="line-clamp-1 text-sm font-semibold opacity-65">
-            {relativePath}
+            {formatFolderPath(folderName, relativePath)}
           </span>
           <span className="line-clamp-1">
             {fileName}
@@ -527,6 +531,7 @@ const LinkFilesTab = () => {
       const file = find(selectedRows, ['ID', link.FileID]);
       const path = file?.Locations?.[0]?.RelativePath ?? '<missing file path>';
       const { fileName, relativePath } = extractFileNameFromPath(path);
+      const folderName = getManagedFolderName(managedFoldersQuery.data ?? [], file?.Locations?.[0]?.ManagedFolderID);
       const isSameFile = idx > 0 && orderedLinks[idx - 1].FileID === link.FileID;
       result.push(
         <div
@@ -542,7 +547,7 @@ const LinkFilesTab = () => {
           data-tooltip-content={path}
         >
           <span className="line-clamp-1 text-sm font-semibold opacity-65">
-            {relativePath}
+            {formatFolderPath(folderName, relativePath)}
           </span>
           <span className="line-clamp-1">
             {fileName}


### PR DESCRIPTION
## fix: normalize relative path display and add managed folder context

Strip leading separators in `extractFileNameFromPath`, normalize backslashes, and return `'Root Level'` for root-level files. Detect unchanged relocation results via `IsRelocated` in the renamer. Centralize managed folder name lookup (`getManagedFolderName` + `useManagedFolderName` hook, query disabled without an ID) and the folder/path display label (`formatFolderPath`). Show `'Folder - relativePath'` in Link Files views, Video Metadata, and the File Search filename column.

## refactor: use staleTime Infinity where initialData semantics allow

Managed-folder and plugin queries have no `initialData`, so native `staleTime: Infinity` replaces the ~100-day `INFINITE_STALE_TIME` constant there. The constant stays for `useSettingsQuery`, whose `initialData` placeholder trick requires a finite `staleTime`; its doc comment now explains why.

---

### Docs

- **AGENTS.md:** fixed stale claims (toast import target, oxlint plugin list, id-length exceptions, react-query layout); added missing facts (SignalR middleware details, 401→AUTH_LOGOUT, tscheck, pnpm pinning, min server version gate, `@/core/util` file note); simplified import-order guidance to defer to `oxlint --fix`.
- **README.md:** corrected dev-server URL from `http://localhost:3000` to `http://localhost:3000/webui/`.