### PR TITLE
feat(edit-release-info): add Uncensored checkbox

### DIFF
--- a/src/components/Utilities/LinkFilesWithProvider/EditReleaseInfoModal.tsx
+++ b/src/components/Utilities/LinkFilesWithProvider/EditReleaseInfoModal.tsx
@@ -314,6 +314,16 @@ const EditReleaseInfoModal = (props: Props) => {
     });
   };
 
+  const handleCensoredChange = (event: ChangeEvent<HTMLInputElement>) => {
+    markTouched('IsCensored');
+    setHasDifferent((draft) => {
+      draft.censored = false;
+    });
+    setFormState((draft) => {
+      draft.isCensored = !event.target.checked;
+    });
+  };
+
   const handleSourceChange = (event: ChangeEvent<HTMLSelectElement>) => {
     markTouched('Source');
     setFormState((draft) => {
@@ -377,6 +387,7 @@ const EditReleaseInfoModal = (props: Props) => {
 
     setIfTouched('Version', formState.version === '' ? undefined : formState.version);
     setIfTouched('IsChaptered', formState.isChaptered);
+    setIfTouched('IsCensored', formState.isCensored);
     setIfTouched('IsCreditless', formState.isCreditless);
     setIfTouched('Source', formState.source === '' ? undefined : formState.source);
     // Comment and Group can be cleared: write undefined through so it is
@@ -447,7 +458,7 @@ const EditReleaseInfoModal = (props: Props) => {
         </div>
       }
       noPadding
-      className="h-172"
+      className="h-188"
     >
       <div className="flex grow flex-col gap-y-4 p-6">
         {!formState.selectedSeriesId && !hasDifferent.series && (
@@ -577,6 +588,15 @@ const EditReleaseInfoModal = (props: Props) => {
                 isChecked={!hasDifferent.creditless && !!formState.isCreditless}
                 indeterminate={hasDifferent.creditless}
                 onChange={handleCreditlessChange}
+                justify
+              />
+
+              <Checkbox
+                id="release-censored"
+                label="Uncensored"
+                isChecked={!hasDifferent.censored && formState.isCensored === false}
+                indeterminate={hasDifferent.censored}
+                onChange={handleCensoredChange}
                 justify
               />
 

--- a/src/core/types/utilities/link-files-with-providers.ts
+++ b/src/core/types/utilities/link-files-with-providers.ts
@@ -38,6 +38,7 @@ export type TouchableField =
   | 'CrossReferences'
   | 'Group'
   | 'IsChaptered'
+  | 'IsCensored'
   | 'IsCreditless'
   | 'Source'
   | 'Version';

--- a/src/hooks/utilities/useReleaseInfoForm.ts
+++ b/src/hooks/utilities/useReleaseInfoForm.ts
@@ -13,6 +13,7 @@ type FormState = {
   rangeFill?: RangeFillType;
   version: ReleaseInfoType['Version'] | '';
   isChaptered?: ReleaseInfoType['IsChaptered'];
+  isCensored?: ReleaseInfoType['IsCensored'];
   isCreditless?: ReleaseInfoType['IsCreditless'];
   source: ReleaseInfoType['Source'] | '';
   comment: ReleaseInfoType['Comment'];
@@ -31,6 +32,7 @@ const useReleaseInfoForm = (selectedLinks: ManualLinkType[], show: boolean) => {
   const [touchedFields, setTouchedFields] = useImmer<Set<TouchableField>>(new Set());
   const [hasDifferent, setHasDifferent] = useImmer({
     chaptered: false,
+    censored: false,
     creditless: false,
     episodes: false,
     group: false,
@@ -75,6 +77,7 @@ const useReleaseInfoForm = (selectedLinks: ManualLinkType[], show: boolean) => {
 
     setHasDifferent({
       chaptered: isBulk && !allSame(link => link.IsChaptered),
+      censored: isBulk && !allSame(link => link.IsCensored),
       creditless: isBulk && !allSame(link => link.IsCreditless),
       episodes: hasDifferentEpisodes,
       group: hasDifferentGroup,
@@ -86,6 +89,7 @@ const useReleaseInfoForm = (selectedLinks: ManualLinkType[], show: boolean) => {
       selectedEpisodeIds: initialEpisodeIds,
       version: hasDifferentVersion ? '' : first.Version,
       isChaptered: first.IsChaptered,
+      isCensored: first.IsCensored,
       isCreditless: first.IsCreditless,
       source: hasDifferentSource ? '' : first.Source,
       comment: hasDifferentComment ? '' : (first.Comment ?? ''),


### PR DESCRIPTION
Adds an **Uncensored** checkbox to the Edit Release Info modal, implemented as the inverse of the existing `IsCensored` field (no new server field).

### Changes
- `EditReleaseInfoModal.tsx`: new `handleCensoredChange` handler, `Uncensored` checkbox, `setIfTouched('IsCensored', ...)` in save, and a taller modal (`h-188`) to fit the extra row.
- `useReleaseInfoForm.ts`: add `isCensored` to form state and `censored` to the `hasDifferent` diff tracking.
- `link-files-with-providers.ts`: add `IsCensored` to `TouchableField`.

The checkbox only reads as checked when `IsCensored === false` (undefined/null renders unchecked), matching the sibling Chaptered/Creditless checkboxes.