### PR TITLE
chore: add PR and issue templates [no ci]

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,83 @@
+name: 🐛 Bug Report
+description: Something in the Web UI is broken or misbehaving.
+labels: []
+title: '[Bug] '
+body:
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before submitting
+      description: Issues that fail these checks may be closed without review.
+      options:
+        - label: I'm using the latest Stable or Daily version of Shoko Server.
+          required: true
+        - label: I'm using the correct Web UI version for my server (Stable Server → Stable WebUI, Daily Server → Daily WebUI).
+          required: true
+        - label: I've searched this repository for a similar issue.
+          required: true
+
+  - type: input
+    id: server-version
+    attributes:
+      label: Shoko Server Version
+      description: Shown in Settings → General (e.g. `5.3.3.0`). If the Web UI crashes before you can reach Settings, the versions are also shown on the crash page.
+      placeholder: '5.3.3.0'
+    validations:
+      required: true
+
+  - type: dropdown
+    id: server-channel
+    attributes:
+      label: Server Channel
+      options:
+        - Stable
+        - Daily
+    validations:
+      required: true
+
+  - type: input
+    id: webui-version
+    attributes:
+      label: Web UI Version
+      description: Shown in Settings → General, next to the server version (e.g. `2.5.11`); also visible on the crash page.
+      placeholder: '2.5.11'
+    validations:
+      required: true
+
+  - type: dropdown
+    id: webui-channel
+    attributes:
+      label: Web UI Channel
+      options:
+        - Stable
+        - Daily
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What happened, and what did you expect to happen instead?
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to Reproduce
+      description: |
+        Numbered steps starting from a fresh page load. Example:
+        1. Open `WebUI → Collection`
+        2. Click `...`
+        3. See error
+    validations:
+      required: true
+
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Screenshots
+      description: Screenshots of the error, including the browser toast if one appears.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Shoko Discord
+    url: https://discord.gg/vpeHDsg
+    about: For support questions and general discussion, please use Discord instead of opening an issue.
+  - name: Shoko Server Issues
+    url: https://github.com/ShokoAnime/ShokoServer/issues
+    about: If the problem only appears server-side (importing, AniDB, renaming), report it on ShokoServer instead.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,30 @@
+name: ✨ Feature Request
+description: Suggest a new feature or an improvement to an existing one.
+labels: []
+title: '[Feature Request] '
+body:
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before submitting
+      options:
+        - label: I've searched this repository for a similar feature request.
+          required: true
+        - label: This request is not related to allowing Shoko to download anime episodes or rip them from streaming sites.
+          required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Feature Description
+      description: What do you want to see, and what problem does it solve? Include the relevant page/section of the Web UI (e.g. `Collection`, `Settings → Import`).
+    validations:
+      required: true
+
+  - type: textarea
+    id: examples
+    attributes:
+      label: Examples / Mockups
+      description: Mockups, screenshots from other apps, or a concrete example of the behavior you'd expect. Delete this section if not applicable.
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,13 @@
+## Summary
+
+<!-- 1-3 sentences: what this PR does and why. -->
+<!-- Link related work: `Fixes #123`, `Relates to #123` (discussion/RFC), or `Depends on #123` for stacked PRs. -->
+
+## Changes
+
+<!-- Bulleted list of notable changes; bold the affected files/modules, e.g. **`EditReleaseInfoModal.tsx`**. -->
+<!-- Group under ### Added / ### Fixed / ### Removed headings for larger PRs. -->
+
+## Screenshots
+
+<!-- For UI changes: before/after screenshots or short clips. Delete this section otherwise. -->


### PR DESCRIPTION
## Summary

Adds repository templates for PRs and issues: `.github/PULL_REQUEST_TEMPLATE.md` plus YAML issue forms (bug report, feature request) and `config.yml`.

- **PR template** consolidates the de-facto format from the last ~13 PRs (Summary → Changes with bolded file paths → optional Screenshots), per the per-PR conventions of #1446, #1454, #1459 etc.
- **Bug report form** restores the version/channel fields the repo previously used (see #1290, #1400), making server + WebUI versions and channels required — mismatched versions are the most common back-and-forth in triage comments. Findings from recent issue history: version info lives in Settings (or the crash page), and server logs are not collectible from WebUI users, so the form asks for screenshots only.
- **Feature request form** mirrors the old feature template from #1219 (search + anti-piracy checks, description, examples).
- **`config.yml`** disables blank issues and routes support questions to Discord and server-side problems to ShokoServer.

## Changes

- **`.github/PULL_REQUEST_TEMPLATE.md`** — new; Summary / Changes / Screenshots sections with guidance comments.
- **`.github/ISSUE_TEMPLATE/bug_report.yml`** — new; required verify-checklist, required version/channel fields, description, steps to reproduce, optional screenshots.
- **`.github/ISSUE_TEMPLATE/feature_request.yml`** — new; verify-checklist, description, optional examples/mockups.
- **`.github/ISSUE_TEMPLATE/config.yml`** — new; blanks disabled, Discord + ShokoServer contact links.

Docs-only change, `[no ci]`.
