### PR TITLE
fix: numeric input clamping and Range Fill hotkey keystroke leak

### DIFF
--- a/src/components/Input/InputSmall.tsx
+++ b/src/components/Input/InputSmall.tsx
@@ -35,16 +35,40 @@ const InputSmall = (props: Props) => {
     value,
   } = props;
 
+  const defineOwn = (target: object, name: string, ownValue: unknown) => {
+    Object.defineProperty(target, name, { value: ownValue, writable: true, enumerable: true, configurable: true });
+  };
+
+  const withValue = (event: ChangeEvent<HTMLInputElement>, nextValue: string) => {
+    // Prototype-preserving clone of the DOM target; own properties are defined (not
+    // assigned) so the accessors on the prototype chain (React's value tracker,
+    // native valueAsNumber) are shadowed instead of invoked ("Illegal invocation").
+    const target = Object.create(event.target) as HTMLInputElement;
+    defineOwn(target, 'value', nextValue);
+    defineOwn(target, 'valueAsNumber', nextValue === '' ? Number.NaN : Number(nextValue));
+
+    return { ...event, target } as ChangeEvent<HTMLInputElement>;
+  };
+
   const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
-    if (type === 'number' && max && event.target.valueAsNumber > max) {
-      toast.info(`Value cannot be greater than ${max}!`);
-
-      const newEvent = { ...event };
-      newEvent.target.value = max.toString();
-      newEvent.target.valueAsNumber = max;
-
-      onChange(newEvent);
+    if (type !== 'number') {
+      onChange(event);
       return;
+    }
+
+    const { valueAsNumber } = event.target;
+    if (Number.isFinite(valueAsNumber)) {
+      if (max !== undefined && valueAsNumber > max) {
+        toast.info(`Value cannot be greater than ${max}!`);
+        onChange(withValue(event, max.toString()));
+        return;
+      }
+
+      if (min !== undefined && valueAsNumber < min) {
+        toast.info(`Value cannot be less than ${min}!`);
+        onChange(withValue(event, min.toString()));
+        return;
+      }
     }
 
     onChange(event);

--- a/src/components/Utilities/LinkFilesWithProvider/EditReleaseInfoModal.tsx
+++ b/src/components/Utilities/LinkFilesWithProvider/EditReleaseInfoModal.tsx
@@ -431,7 +431,7 @@ const EditReleaseInfoModal = (props: Props) => {
     },
     { scopes: 'modal' },
   );
-  useHotkeys('r', () => handleEpisodeSelect(RANGE_FILL_EPISODE_ID), { scopes: 'modal' });
+  useHotkeys('r', () => handleEpisodeSelect(RANGE_FILL_EPISODE_ID), { scopes: 'modal', preventDefault: true });
   useHotkeys('enter', handleSave, { scopes: 'modal' });
 
   return (


### PR DESCRIPTION
## Summary

Fixes two interaction bugs: `InputSmall` now clamps numeric input to both `min` and `max` (previously only `max`, and not for `max={0}`), and pressing the `r` hotkey no longer leaks an `r` into the Range Fill modal's autofocused number input. Relates to the Range Fill flow in **`EditReleaseInfoModal.tsx`**.

## Changes

### Fixed
- **`InputSmall.tsx`**: honor a `max` bound of `0` (the old truthiness check `max && ...` disabled clamping for `max={0}`)
- **`InputSmall.tsx`**: enforce `min` symmetrically — the prop was passed to the input but never checked in the handler
- **`InputSmall.tsx`**: deliver out-of-range values through a prototype-cloned event target instead of mutating the shared `event.target`, which previously wrote through to the real DOM input outside React's controlled-value flow
- **`EditReleaseInfoModal.tsx`**: `r` hotkey now sets `preventDefault: true` (react-hotkeys-hook v5 only prevents default when explicitly asked), so the keystroke is no longer typed into the autofocused "Range Starting Number" input

### Verification
- `pnpm lint`, `pnpm tscheck`, `pnpm test` (186/186) pass